### PR TITLE
Support missing expects method in MigrateAtToConsecutiveExpectations

### DIFF
--- a/src/NodeAnalyzer/ExpectationAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectationAnalyzer.php
@@ -148,10 +148,11 @@ final class ExpectationAnalyzer
 
     private function getExpects(Expr $expr, MethodCall $methodCall): Expr
     {
-        if (! $this->testsNodeAnalyzer->isInPHPUnitMethodCallName($expr, 'with')) {
-            return $methodCall->var;
-        }
         if (! $expr instanceof MethodCall) {
+            return $methodCall;
+        }
+
+        if (! $this->testsNodeAnalyzer->isInPHPUnitMethodCallName($expr, 'with')) {
             return $methodCall->var;
         }
         return $expr->var;

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
@@ -10,58 +10,8 @@ class Foo
 }
 final class SkipMissingExpects extends \PHPUnit\Framework\TestCase
 {
-    protected $mock;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->mock = $this->createMock(Foo::class);
-    }
-
     public function test(): void
     {
-        $this->mock
-            ->method('someMethod')
-            ->willReturn(1);
-
-        $mock = $this->createMock(Foo::class);
-
-        $mock
-            ->method('someOtherMethod')
-            ->willReturn(1);
-    }
-}
-
-?>
------
-<?php
-
-namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
-
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
-final class SkipMissingExpects extends \PHPUnit\Framework\TestCase
-{
-    protected $mock;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->mock = $this->createMock(Foo::class);
-    }
-
-    public function test(): void
-    {
-        $this->mock
-            ->method('someMethod')
-            ->willReturn(1);
-
         $mock = $this->createMock(Foo::class);
 
         $mock

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
+
+class Foo
+{
+    public function someMethod()
+    {
+    }
+}
+final class SkipMissingExpects extends \PHPUnit\Framework\TestCase
+{
+    protected $mock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mock = $this->createMock(Foo::class);
+    }
+
+    public function test(): void
+    {
+        $this->mock
+            ->method('someMethod')
+            ->willReturn(1);
+
+        $mock = $this->createMock(Foo::class);
+
+        $mock
+            ->method('someOtherMethod')
+            ->willReturn(1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
+
+class Foo
+{
+    public function someMethod()
+    {
+    }
+}
+final class SkipMissingExpects extends \PHPUnit\Framework\TestCase
+{
+    protected $mock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mock = $this->createMock(Foo::class);
+    }
+
+    public function test(): void
+    {
+        $this->mock
+            ->method('someMethod')
+            ->willReturn(1);
+
+        $mock = $this->createMock(Foo::class);
+
+        $mock
+            ->method('someOtherMethod')
+            ->willReturn(1);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
@@ -15,7 +15,7 @@ final class SkipMissingExpects extends \PHPUnit\Framework\TestCase
         $mock = $this->createMock(Foo::class);
 
         $mock
-            ->method('someOtherMethod')
+            ->method('someMethod')
             ->willReturn(1);
     }
 }


### PR DESCRIPTION
Closes #7.

Wasn't 100% sure of the best way to handle this - Happy to make changes to the fix based on feedback.