### PR TITLE
Handle mocks stored as properties in MigrateAtToConsecutiveExpectation

### DIFF
--- a/src/NodeAnalyzer/ExpectationAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectationAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\NodeAnalyzer;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Expression;
@@ -80,7 +81,7 @@ final class ExpectationAnalyzer
             if (! $atValue instanceof LNumber) {
                 continue;
             }
-            if (! $expects->var instanceof Variable) {
+            if (! ($expects->var instanceof Variable || $expects->var instanceof PropertyFetch) ) {
                 continue;
             }
 

--- a/src/NodeAnalyzer/ExpectationAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectationAnalyzer.php
@@ -81,7 +81,7 @@ final class ExpectationAnalyzer
             if (! $atValue instanceof LNumber) {
                 continue;
             }
-            if (! ($expects->var instanceof Variable || $expects->var instanceof PropertyFetch) ) {
+            if (! ($expects->var instanceof Variable || $expects->var instanceof PropertyFetch)) {
                 continue;
             }
 

--- a/src/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector.php
+++ b/src/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector.php
@@ -6,6 +6,7 @@ namespace Rector\PHPUnit\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -179,6 +180,13 @@ CODE_SAMPLE
         $groupedByVariable = [];
         foreach ($expectationMockCollection->getExpectationMocks() as $expectationMock) {
             $variable = $expectationMock->getExpectationVariable();
+
+            // The $variable->name will be a string if the mock object is stored as a local variable (Expr\Variable)
+            // The $variable->name will be Identifier object when the mock object is stored as a class property (Expr\PropertyFetch).
+            if ($variable->name instanceof Identifier) {
+                $variable = $variable->name;
+            }
+
             if (! is_string($variable->name)) {
                 continue;
             }

--- a/src/ValueObject/ExpectationMock.php
+++ b/src/ValueObject/ExpectationMock.php
@@ -7,12 +7,13 @@ namespace Rector\PHPUnit\ValueObject;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Stmt\Expression;
 
 final class ExpectationMock
 {
     /**
-     * @var Variable
+     * @var Variable|PropertyFetch
      */
     private $expectationVariable;
 
@@ -42,11 +43,12 @@ final class ExpectationMock
     private $originalExpression;
 
     /**
+     * @param Variable|PropertyFetch $expectationVariable
      * @param Arg[] $methodArguments
      * @param array<int, null|Expr> $withArguments
      */
     public function __construct(
-        Variable $expectationVariable,
+        Expr $expectationVariable,
         array $methodArguments,
         int $index,
         ?Expr $expr,
@@ -61,7 +63,10 @@ final class ExpectationMock
         $this->originalExpression = $originalExpression;
     }
 
-    public function getExpectationVariable(): Variable
+    /**
+     * @return Variable|PropertyFetch
+     */
+    public function getExpectationVariable(): Expr
     {
         return $this->expectationVariable;
     }

--- a/src/ValueObject/ExpectationMock.php
+++ b/src/ValueObject/ExpectationMock.php
@@ -6,8 +6,8 @@ namespace Rector\PHPUnit\ValueObject;
 
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 
 final class ExpectationMock

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/handle_property_fetch.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/handle_property_fetch.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
+
+class Foo
+{
+    public function someMethod()
+    {
+    }
+}
+final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
+{
+    protected $mock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mock = $this->createMock(Foo::class);
+    }
+
+    public function test(): void
+    {
+        $this->mock
+            ->expects($this->at(0))
+            ->method('someMethod')
+            ->willReturn(1);
+
+        $this->mock
+            ->expects($this->at(1))
+            ->method('someMethod')
+            ->willReturn(2);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
+
+class Foo
+{
+    public function someMethod()
+    {
+    }
+}
+final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
+{
+    protected $mock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mock = $this->createMock(Foo::class);
+    }
+
+    public function test(): void
+    {
+        $this->mock->method('someMethod')->willReturnOnConsecutiveCalls(1, 2);
+    }
+}
+
+?>


### PR DESCRIPTION
Closes #9.  