### PR TITLE
Update PHPUnit 9 config set

### DIFF
--- a/config/sets/phpunit90.php
+++ b/config/sets/phpunit90.php
@@ -28,7 +28,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'expectExceptionMessageRegExp',
                     'expectExceptionMessageMatches'
                 ),
-                new MethodCallRename('PHPUnit\Framework\TestCase', 'assertRegExp', 'assertMatchesRegularExpression'),
             ]),
         ]]);
 };

--- a/config/sets/phpunit91.php
+++ b/config/sets/phpunit91.php
@@ -16,7 +16,24 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RenameMethodRector::class)
         ->call('configure', [[
             RenameMethodRector::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
-                new MethodCallRename('PHPUnit\Framework\TestCase', 'assertFileNotExists', 'assertFileDoesNotExist'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4087
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertRegExp', 'assertMatchesRegularExpression'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4090
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotRegExp', 'assertDoesNotMatchRegularExpression'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4078
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotExists', 'assertFileDoesNotExist'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4081
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotIsReadable', 'assertFileIsNotReadable'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4072
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertDirectoryNotIsReadable', 'assertDirectoryIsNotReadable'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4075
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertDirectoryNotIsWritable', 'assertDirectoryIsNotWritable'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4069
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertDirectoryNotExists', 'assertDirectoryDoesNotExist'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4066
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsWritable', 'assertIsNotWritable'),
+                // https://github.com/sebastianbergmann/phpunit/issues/4063
+                new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsReadable', 'assertIsNotReadable'),
             ]),
         ]]);
 };


### PR DESCRIPTION
Includes more of the deprecated function renames in `phpunit91.php`.

Move a single rename rule (`assertRegExp`) from `phpunit90.php` to `phpunit91.php`, but `assertRegExp` was not deprecated until PHPUnit 9.1. 

Fixed the rule's parent class: `PHPUnit\Framework\Assert` instead of `PHPUnit\Framework\TestCase`.