### PR TITLE
[PostRector] Using NodesToAddCollector on rector rules

### DIFF
--- a/src/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
+++ b/src/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
                 $newMethodCall->args[0] = $node->args[0];
                 $newMethodCall->args[1] = $node->args[1];
                 $newMethodCall->args[2] = $node->args[2];
-                $this->addNodeAfterNode($newMethodCall, $node);
+                $this->nodesToAddCollector->addNodeAfterNode($newMethodCall, $node);
             }
 
             unset($node->args[6]);
@@ -132,7 +132,7 @@ CODE_SAMPLE
                 $newMethodCall->args[0] = $node->args[0];
                 $newMethodCall->args[1] = $node->args[1];
                 $newMethodCall->args[2] = $node->args[2];
-                $this->addNodeAfterNode($newMethodCall, $node);
+                $this->nodesToAddCollector->addNodeAfterNode($newMethodCall, $node);
             }
 
             unset($node->args[5]);
@@ -152,7 +152,7 @@ CODE_SAMPLE
                 $newMethodCall->args[1] = $node->args[1];
                 $newMethodCall->args[2] = $node->args[3];
                 $newMethodCall->args[3] = $node->args[2];
-                $this->addNodeAfterNode($newMethodCall, $node);
+                $this->nodesToAddCollector->addNodeAfterNode($newMethodCall, $node);
             }
 
             unset($node->args[3]);

--- a/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
 
             $call = $this->assertCallFactory->createCallWithName($node, self::OLD_TO_NEW_METHOD[$oldMethodName]);
             $call->args[] = $node->args[1];
-            $this->addNodeAfterNode($call, $node);
+            $this->nodesToAddCollector->addNodeAfterNode($call, $node);
 
             unset($node->args[1]);
 
@@ -83,7 +83,7 @@ CODE_SAMPLE
             if (isset($node->args[2])) {
                 $call = $this->assertCallFactory->createCallWithName($node, 'expectExceptionCode');
                 $call->args[] = $node->args[2];
-                $this->addNodeAfterNode($call, $node);
+                $this->nodesToAddCollector->addNodeAfterNode($call, $node);
 
                 unset($node->args[2]);
             }


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector-src/pull/812 as this direct call is deprecated.