### PR TITLE
[PHPUnit] Using NodeTypeResolver->getType() instead of deprecated getObjectType()

### DIFF
--- a/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -221,10 +221,10 @@ CODE_SAMPLE
     private function resolveClassMethodFromCall(StaticCall | MethodCall $call): ?ClassMethod
     {
         if ($call instanceof MethodCall) {
-            $objectType = $this->getObjectType($call->var);
+            $objectType = $this->nodeTypeResolver->getType($call->var);
         } else {
             // StaticCall
-            $objectType = $this->getObjectType($call->class);
+            $objectType = $this->nodeTypeResolver->getType($call->class);
         }
 
         if (! $objectType instanceof TypeWithClassName) {


### PR DESCRIPTION
The `getObjectType()` is deprecated at rector-src's AbstractRector

https://github.com/rectorphp/rector-src/blob/c6473c6a0b4ecaab710353e83f0c740e2e998d26/src/Rector/AbstractRector.php#L335-L338

This PR update to use NodeTypeResolver->getType()