### PR TITLE
[PHPUnit] Skip AssertIssetToSpecificMethodRector when parent class not detected by PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,9 +23,6 @@ parameters:
         # not sure
         - '#Parameter \#1 \$expr of class PhpParser\\Node\\Stmt\\Expression constructor expects PhpParser\\Node\\Expr, PhpParser\\Node\\Expr\|PhpParser\\Node\\Stmt given#'
 
-        # non on PHP 8 yet
-        - '#This property type might be inlined to PHP\. Do you have confidence it is correct\? Put it here#'
-
         # phpstan false positive
         - '#Parameter \#1 \$className of method Rector\\Core\\PhpParser\\AstResolver\:\:resolveClassMethod\(\) expects class\-string, string given#'
 

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -126,11 +126,6 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
             return true;
         }
 
-        $parents = $reflection->getParents();
-        if ($parents !== []) {
-            return false;
-        }
-
         $className = $reflection->getName();
         $class = $this->astResolver->resolveClassFromName($className);
 

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -114,13 +114,9 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
     {
         $resolved = $this->nodeTypeResolver->getType($node);
 
-        // object not found, skip
-        if ($resolved instanceof ObjectWithoutClassType) {
-            return true;
-        }
-
         if (! $resolved instanceof TypeWithClassName) {
-            return false;
+            // object not found, skip
+            return $resolved instanceof ObjectWithoutClassType;
         }
 
         $reflection = $resolved->getClassReflection();

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -126,6 +126,8 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
             return true;
         }
 
+        // reflection->getParents() got empty array when
+        // extends class not found by PHPStan
         $className = $reflection->getName();
         $class = $this->astResolver->resolveClassFromName($className);
 

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\TypeWithClassName;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
@@ -112,6 +113,11 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
     private function hasMagicIsset(Node $node): bool
     {
         $resolved = $this->nodeTypeResolver->getType($node);
+
+        // object not found, skip
+        if ($resolved instanceof ObjectWithoutClassType) {
+            return true;
+        }
 
         if (! $resolved instanceof TypeWithClassName) {
             return false;

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -14,14 +14,14 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\TypeWithClassName;
+use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use PHPStan\Reflection\ReflectionProvider;
-use Rector\Core\PhpParser\AstResolver;
 
 /**
  * @see \Rector\PHPUnit\Tests\Rector\MethodCall\AssertIssetToSpecificMethodRector\AssertIssetToSpecificMethodRectorTest

--- a/src/ValueObject/ExpectationMockCollection.php
+++ b/src/ValueObject/ExpectationMockCollection.php
@@ -11,7 +11,7 @@ final class ExpectationMockCollection
     /**
      * @var ExpectationMock[]
      */
-    private $expectationMocks = [];
+    private array $expectationMocks = [];
 
     /**
      * @return ExpectationMock[]

--- a/tests/Rector/MethodCall/AssertIssetToSpecificMethodRector/Fixture/skip_if_magic_method_isset_exists_in_parent.php.inc
+++ b/tests/Rector/MethodCall/AssertIssetToSpecificMethodRector/Fixture/skip_if_magic_method_isset_exists_in_parent.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertIssetToSpecificMethodRector\Fixture;
+
+// parent class not loaded
+final class CustomIsset2 extends SomeAbstractClass {
+}
+
+final class SkipCustomIsset2 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $foo = new CustomIsset2();
+        $this->assertTrue(isset($foo->bar));
+    }
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
// parent class not loaded
final class CustomIsset2 extends SomeAbstractClass {
}

final class SkipCustomIsset2 extends \PHPUnit\Framework\TestCase
{
    public function test()
    {
        $foo = new CustomIsset2();
        $this->assertTrue(isset($foo->bar));
    }
}
```

It result:

```diff
-        $this->assertTrue(isset($foo->bar));
+        $this->assertObjectHasAttribute('bar', $foo);
```

which may be invalid as `SomeAbstractClass` not found by PHPStan, which may actually exists, but not loaded early. 

This PR handle it.