### PR TITLE
Skip Inner class __construct on ConstructClassMethodToSetUpTestCaseRector

### DIFF
--- a/src/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector.php
+++ b/src/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Nette\NodeAnalyzer\StaticCallAnalyzer;
@@ -27,7 +28,8 @@ final class ConstructClassMethodToSetUpTestCaseRector extends AbstractRector
     public function __construct(
         private SetUpClassMethodNodeManipulator $setUpClassMethodNodeManipulator,
         private StaticCallAnalyzer $staticCallAnalyzer,
-        private TestsNodeAnalyzer $testsNodeAnalyzer
+        private TestsNodeAnalyzer $testsNodeAnalyzer,
+        private ClassAnalyzer $classAnalyzer
     ) {
     }
 
@@ -92,6 +94,10 @@ CODE_SAMPLE
 
         $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
         if (! $constructClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        if ($this->classAnalyzer->isAnonymousClass($node)) {
             return null;
         }
 

--- a/tests/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector/FixtureInnerClass/skip_inner_class.php.inc
+++ b/tests/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector/FixtureInnerClass/skip_inner_class.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector\FixtureInnerClass;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSomething(): void
+    {
+        new class() extends \stdClass {
+            public function __construct()
+            {
+            }
+        };
+    }
+}

--- a/tests/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector/InnerClassTest.php
+++ b/tests/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector/InnerClassTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class InnerClassTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureInnerClass');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/inner_class_configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector/config/inner_class_configured_rule.php
+++ b/tests/Rector/Class_/ConstructClassMethodToSetUpTestCaseRector/config/inner_class_configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
+use Rector\PHPUnit\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(RemoveParentCallWithoutParentRector::class);
+    $services->set(ConstructClassMethodToSetUpTestCaseRector::class);
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6893