### PR TITLE
Fix MigrateAtToConsecutiveExpectationsRector for static calls

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+    $parameters->set(Option::PARALLEL, true);
+
     $parameters->set(Option::PATHS, [
         __DIR__ . '/src',
         __DIR__ . '/tests',

--- a/rector.php
+++ b/rector.php
@@ -40,5 +40,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(LevelSetList::UP_TO_PHP_81);
     $containerConfigurator->import(SetList::DEAD_CODE);
     $containerConfigurator->import(SetList::CODE_QUALITY);
+    $containerConfigurator->import(SetList::CODING_STYLE);
+    $containerConfigurator->import(SetList::EARLY_RETURN);
 };
 

--- a/src/NodeManipulator/ParamAndArgFromArrayResolver.php
+++ b/src/NodeManipulator/ParamAndArgFromArrayResolver.php
@@ -79,6 +79,7 @@ final class ParamAndArgFromArrayResolver
                 ++$i;
             }
         }
+
         return $paramAndArgs;
     }
 

--- a/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -178,6 +178,7 @@ CODE_SAMPLE
                     'setExpectedException*',
                 ]);
             }
+
             if ($node instanceof StaticCall) {
                 return $this->isNames($node->name, [
                     // phpunit
@@ -187,6 +188,7 @@ CODE_SAMPLE
                     'setExpectedException*',
                 ]);
             }
+
             return false;
         });
     }

--- a/src/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector.php
+++ b/src/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector.php
@@ -135,6 +135,7 @@ CODE_SAMPLE
             if (! $originalExpression instanceof Expression) {
                 continue;
             }
+
             if ($max > $originalExpression->getEndLine()) {
                 $this->removeNode($originalExpression);
             } else {
@@ -156,6 +157,7 @@ CODE_SAMPLE
         if ($expectationMockCollection->hasMissingAtIndexes()) {
             return true;
         }
+
         return $expectationMockCollection->hasMissingReturnValues();
     }
 
@@ -178,9 +180,11 @@ CODE_SAMPLE
             if (! is_string($variable->name)) {
                 continue;
             }
+
             if (! isset($groupedByVariable[$variable->name])) {
                 $groupedByVariable[$variable->name] = new ExpectationMockCollection();
             }
+
             $groupedByVariable[$variable->name]->add($expectationMock);
         }
 

--- a/src/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/src/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -172,9 +172,9 @@ CODE_SAMPLE
 
     private function removeNonExistingClassSeeAnnotation(PhpDocInfo $phpDocInfo): void
     {
+        /** @var PhpDocTagNode[] $seePhpDocTagNodes */
         $seePhpDocTagNodes = $phpDocInfo->getTagsByName(self::SEE);
 
-        /** @var PhpDocTagNode[] $seePhpDocTagNodes */
         foreach ($seePhpDocTagNodes as $seePhpDocTagNode) {
             if (! $seePhpDocTagNode->value instanceof GenericTagValueNode) {
                 continue;

--- a/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
+++ b/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
@@ -44,7 +44,7 @@ final class ArrayArgumentToDataProviderRector extends AbstractRector implements 
      * @api
      * @var string
      */
-    final public const ARRAY_ARGUMENTS_TO_DATA_PROVIDERS = 'array_arguments_to_data_providers';
+    public const ARRAY_ARGUMENTS_TO_DATA_PROVIDERS = 'array_arguments_to_data_providers';
 
     /**
      * @var ArrayArgumentToDataProvider[]

--- a/src/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
+++ b/src/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
@@ -97,6 +97,7 @@ CODE_SAMPLE
             // add new node only in case of non-default value
             unset($node->args[4]);
         }
+
         $this->processAssertEqualsWithDelta($node);
 
         return $node;

--- a/src/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/src/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -74,6 +74,7 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
         if (! $firstArgumentValue instanceof Instanceof_) {
             return null;
         }
+
         $this->identifierManipulator->renameNodeWithMap($node, self::RENAME_METHODS_MAP);
         $this->changeArgumentsOrder($node);
 

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -86,10 +86,12 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
         if (! $firstArgumentValue instanceof Isset_) {
             return null;
         }
+
         $variableNodeClass = $firstArgumentValue->vars[0]::class;
         if (! in_array($variableNodeClass, [ArrayDimFetch::class, PropertyFetch::class], true)) {
             return null;
         }
+
         /** @var Isset_ $issetNode */
         $issetNode = $node->args[0]->value;
 

--- a/src/Rector/MethodCall/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertSameBoolNullToSpecificMethodRector.php
@@ -65,6 +65,7 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
         if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, ['assertSame', 'assertNotSame'])) {
             return null;
         }
+
         $firstArgumentValue = $node->args[0]->value;
         if (! $firstArgumentValue instanceof ConstFetch) {
             return null;

--- a/src/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -118,12 +118,15 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
         if (in_array($oldMethodName, ['assertTrue', 'assertNotFalse'], true)) {
             $node->name = new Identifier($functionNameWithAssertMethods->getAssetMethodName());
         }
+
         if ($functionNameWithAssertMethods->getNotAssertMethodName() === '') {
             return;
         }
+
         if (! in_array($oldMethodName, ['assertFalse', 'assertNotTrue'], true)) {
             return;
         }
+
         $node->name = new Identifier($functionNameWithAssertMethods->getNotAssertMethodName());
     }
 

--- a/src/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
+++ b/src/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
@@ -91,10 +91,12 @@ CODE_SAMPLE
         if ($secondArgType instanceof StringType) {
             return null;
         }
+
         //when less then 5 arguments given: do nothing
         if (! isset($node->args[4])) {
             return null;
         }
+
         if ($node->args[4]->value === null) {
             return null;
         }

--- a/src/Set/PHPUnitLevelSetList.php
+++ b/src/Set/PHPUnitLevelSetList.php
@@ -11,30 +11,30 @@ final class PHPUnitLevelSetList implements SetListInterface
     /**
      * @var string
      */
-    final public const UP_TO_PHPUNIT_50 = __DIR__ . '/../../config/sets/level/up-to-phpunit-50.php';
+    public const UP_TO_PHPUNIT_50 = __DIR__ . '/../../config/sets/level/up-to-phpunit-50.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_PHPUNIT_60 = __DIR__ . '/../../config/sets/level/up-to-phpunit-60.php';
+    public const UP_TO_PHPUNIT_60 = __DIR__ . '/../../config/sets/level/up-to-phpunit-60.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_PHPUNIT_70 = __DIR__ . '/../../config/sets/level/up-to-phpunit-70.php';
+    public const UP_TO_PHPUNIT_70 = __DIR__ . '/../../config/sets/level/up-to-phpunit-70.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_PHPUNIT_80 = __DIR__ . '/../../config/sets/level/up-to-phpunit-80.php';
+    public const UP_TO_PHPUNIT_80 = __DIR__ . '/../../config/sets/level/up-to-phpunit-80.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_PHPUNIT_90 = __DIR__ . '/../../config/sets/level/up-to-phpunit-90.php';
+    public const UP_TO_PHPUNIT_90 = __DIR__ . '/../../config/sets/level/up-to-phpunit-90.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_PHPUNIT_100 = __DIR__ . '/../../config/sets/level/up-to-phpunit-100.php';
+    public const UP_TO_PHPUNIT_100 = __DIR__ . '/../../config/sets/level/up-to-phpunit-100.php';
 }

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -11,70 +11,70 @@ final class PHPUnitSetList implements SetListInterface
     /**
      * @var string
      */
-    final public const PHPUNIT80_DMS = __DIR__ . '/../../config/sets/phpunit80-dms.php';
+    public const PHPUNIT80_DMS = __DIR__ . '/../../config/sets/phpunit80-dms.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_40 = __DIR__ . '/../../config/sets/phpunit40.php';
+    public const PHPUNIT_40 = __DIR__ . '/../../config/sets/phpunit40.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_50 = __DIR__ . '/../../config/sets/phpunit50.php';
+    public const PHPUNIT_50 = __DIR__ . '/../../config/sets/phpunit50.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_60 = __DIR__ . '/../../config/sets/phpunit60.php';
+    public const PHPUNIT_60 = __DIR__ . '/../../config/sets/phpunit60.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_70 = __DIR__ . '/../../config/sets/phpunit70.php';
+    public const PHPUNIT_70 = __DIR__ . '/../../config/sets/phpunit70.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_75 = __DIR__ . '/../../config/sets/phpunit75.php';
+    public const PHPUNIT_75 = __DIR__ . '/../../config/sets/phpunit75.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_80 = __DIR__ . '/../../config/sets/phpunit80.php';
+    public const PHPUNIT_80 = __DIR__ . '/../../config/sets/phpunit80.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_90 = __DIR__ . '/../../config/sets/phpunit90.php';
+    public const PHPUNIT_90 = __DIR__ . '/../../config/sets/phpunit90.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_91 = __DIR__ . '/../../config/sets/phpunit91.php';
+    public const PHPUNIT_91 = __DIR__ . '/../../config/sets/phpunit91.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_CODE_QUALITY = __DIR__ . '/../../config/sets/phpunit-code-quality.php';
+    public const PHPUNIT_CODE_QUALITY = __DIR__ . '/../../config/sets/phpunit-code-quality.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_EXCEPTION = __DIR__ . '/../../config/sets/phpunit-exception.php';
+    public const PHPUNIT_EXCEPTION = __DIR__ . '/../../config/sets/phpunit-exception.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_MOCK = __DIR__ . '/../../config/sets/phpunit-mock.php';
+    public const PHPUNIT_MOCK = __DIR__ . '/../../config/sets/phpunit-mock.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_SPECIFIC_METHOD = __DIR__ . '/../../config/sets/phpunit-specific-method.php';
+    public const PHPUNIT_SPECIFIC_METHOD = __DIR__ . '/../../config/sets/phpunit-specific-method.php';
 
     /**
      * @var string
      */
-    final public const PHPUNIT_YIELD_DATA_PROVIDER = __DIR__ . '/../../config/sets/phpunit-yield-data-provider.php';
+    public const PHPUNIT_YIELD_DATA_PROVIDER = __DIR__ . '/../../config/sets/phpunit-yield-data-provider.php';
 }

--- a/src/ValueObject/ExpectationMockCollection.php
+++ b/src/ValueObject/ExpectationMockCollection.php
@@ -70,6 +70,7 @@ final class ExpectationMockCollection
         if ($this->getLowestAtIndex() !== 0) {
             return true;
         }
+
         return $this->isMissingAtIndexBetweenHighestAndLowest();
     }
 
@@ -126,11 +127,13 @@ final class ExpectationMockCollection
                 if ($previousMethod === '') {
                     $previousMethod = $methodArgument->value->value;
                 }
+
                 if ($previousMethod !== $methodArgument->value->value) {
                     return false;
                 }
             }
         }
+
         return true;
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/different_return_values.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/different_return_values.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class DifferentReturnValues extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->method('someMethod')
@@ -53,17 +49,13 @@ final class DifferentReturnValues extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class DifferentReturnValues extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $reference = '2';
         $mock->method('someMethod')->willReturnOnConsecutiveCalls('1', new \PHPUnit\Framework\MockObject\Stub\ReturnReference($reference), $this->returnValueMap(['foo' => 'bar']), $this->returnArgument(1), $this->returnCallback(static function () {
             return null;

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/expects_non_at_is_skipped.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/expects_non_at_is_skipped.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class ExpectsNonAtIsSkipped extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->exactly(1))
             ->method('someMethod');

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/handle_multiple_variables.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/handle_multiple_variables.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class HandleMultipleVariables extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->with('0')
@@ -24,7 +20,7 @@ final class HandleMultipleVariables extends \PHPUnit\Framework\TestCase
             ->method('someMethod')
             ->willReturn('2');
 
-        $mock2 = $this->createMock(Foo::class);
+        $mock2 = $this->createMock(SomeObject::class);
         $mock2
             ->expects($this->at(0))
             ->with('0')
@@ -44,20 +40,16 @@ final class HandleMultipleVariables extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class HandleMultipleVariables extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->withConsecutive(['0'], ['1'])->willReturnOnConsecutiveCalls('1', '2');
 
-        $mock2 = $this->createMock(Foo::class);
+        $mock2 = $this->createMock(SomeObject::class);
         $mock2->method('someMethod')->withConsecutive(['0'], ['1'])->willReturnOnConsecutiveCalls('1', '2');
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/handle_property_fetch.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/handle_property_fetch.php.inc
@@ -2,12 +2,8 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
 {
     protected $mock;
@@ -16,7 +12,7 @@ final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->mock = $this->createMock(Foo::class);
+        $this->mock = $this->createMock(SomeObject::class);
     }
 
     public function test(): void
@@ -39,12 +35,8 @@ final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
 {
     protected $mock;
@@ -53,7 +45,7 @@ final class HandlePropertyFetch extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->mock = $this->createMock(Foo::class);
+        $this->mock = $this->createMock(SomeObject::class);
     }
 
     public function test(): void

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/missing_with_is_replaced_by_empty_array_if_no_return_expectation.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/missing_with_is_replaced_by_empty_array_if_no_return_expectation.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class MissingWithIsReplacedByEmptyArrayIfNoReturnExpectation extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->with('0')
@@ -30,17 +26,13 @@ final class MissingWithIsReplacedByEmptyArrayIfNoReturnExpectation extends \PHPU
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class MissingWithIsReplacedByEmptyArrayIfNoReturnExpectation extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->withConsecutive(['0'], [], ['2']);
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/missing_with_is_replaced_by_empty_array_if_no_return_expectation2.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/missing_with_is_replaced_by_empty_array_if_no_return_expectation2.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class MissingWithIsReplacedByEmptyArrayIfNoReturnExpectation2 extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(1))
             ->with('1')
@@ -30,17 +26,13 @@ final class MissingWithIsReplacedByEmptyArrayIfNoReturnExpectation2 extends \PHP
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class MissingWithIsReplacedByEmptyArrayIfNoReturnExpectation2 extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->withConsecutive([], ['1'], ['2']);
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/mixed.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/mixed.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class Mixed extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->with(0)
@@ -32,17 +28,13 @@ final class Mixed extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class Mixed extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->withConsecutive([0], [1])->willReturnOnConsecutiveCalls('0', '1');
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/mixed2.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/mixed2.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class Mixed2 extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->exactly(2))
             ->method('someMethod');
@@ -35,17 +31,13 @@ final class Mixed2 extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class Mixed2 extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->exactly(2))
             ->method('someMethod');

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_different_method_expectations.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_different_method_expectations.php.inc
@@ -3,6 +3,8 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 class Foo
 {
     public function someMethod()
@@ -16,7 +18,7 @@ final class SkipDifferentMethodExpectations extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->method('someMethod')

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_expects.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class SkipMissingExpects extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
 
         $mock
             ->method('someMethod')

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_return_expectation.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_return_expectation.php.inc
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
 class Foo

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_return_expectation.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_return_expectation.php.inc
@@ -2,20 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-    public function someOtherMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class SkipMissingReturnExpectation extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->method('someMethod')
@@ -33,4 +26,3 @@ final class SkipMissingReturnExpectation extends \PHPUnit\Framework\TestCase
 }
 
 ?>
-

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_with_if_return_expectations_exist.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_missing_with_if_return_expectations_exist.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class SkipMissingWithIfReturnExpectationsExist extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->with('0')

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_static_call_self.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_static_call_self.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipStaticCallSelf extends TestCase
+{
+
+    public function testSuccessfulBuildFoundEntity(): void
+    {
+        $entity = $this->createMock(TestCase::class);
+        $entity->expects(self::once())->method('getId')->willReturn(1);
+    }
+}

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/will_callbacks_are_kept.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/will_callbacks_are_kept.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WillCallbacksAreKept extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->method('someMethod')
@@ -30,17 +26,13 @@ final class WillCallbacksAreKept extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WillCallbacksAreKept extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->willReturnOnConsecutiveCalls($this->throwException(new \Exception()), $this->returnValue('1'));
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/will_return_only.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/will_return_only.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WillReturnOnly extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->method('someMethod')
@@ -38,17 +34,13 @@ final class WillReturnOnly extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WillReturnOnly extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->willReturnOnConsecutiveCalls('0', '1', '2', null);
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/with_multiple_arguments.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/with_multiple_arguments.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WithMultipleArguments extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->with('0', '1')
@@ -26,17 +22,13 @@ final class WithMultipleArguments extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WithMultipleArguments extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->withConsecutive(['0', '1']);
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/with_only.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/with_only.php.inc
@@ -2,17 +2,13 @@
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WithOnly extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock
             ->expects($this->at(0))
             ->with('0')
@@ -38,17 +34,13 @@ final class WithOnly extends \PHPUnit\Framework\TestCase
 
 namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
 
-class Foo
-{
-    public function someMethod()
-    {
-    }
-}
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
 final class WithOnly extends \PHPUnit\Framework\TestCase
 {
     public function test(): void
     {
-        $mock = $this->createMock(Foo::class);
+        $mock = $this->createMock(SomeObject::class);
         $mock->method('someMethod')->withConsecutive(['0'], ['1'], ['2'], [null]);
     }
 }

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Source/SomeObject.php
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Source/SomeObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source;
+
+class SomeObject
+{
+
+    public static function someMethod()
+    {
+    }
+
+    public function someOtherMethod()
+    {
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/6976

- add failing fixture for https://github.com/rectorphp/rector/issues/6976
- move Foo class outside test fixtures to Source
- enable parallel Rector
- fix MigrateAtToConsecutiveExpectationsRector for static calls
- apply Rector on codebase
