### PR TITLE
Fix MigrateAtToConsecutiveExpectationsRector for other types

### DIFF
--- a/src/NodeAnalyzer/ExpectationAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectationAnalyzer.php
@@ -58,14 +58,15 @@ final class ExpectationAnalyzer
                 continue;
             }
 
-            $expectsArg = $expects->args[0];
-            /** @var MethodCall $expectsValue */
+            $expectsArg = $expects->getArgs()[0];
+
             $expectsValue = $expectsArg->value;
             if (! $this->isValidAtCall($expectsValue)) {
                 continue;
             }
 
-            $atArg = $expectsValue->args[0];
+            /** @var MethodCall|StaticCall $expectsValue */
+            $atArg = $expectsValue->getArgs()[0];
             $atValue = $atArg->value;
             if (! $atValue instanceof LNumber) {
                 continue;
@@ -99,13 +100,17 @@ final class ExpectationAnalyzer
         return count($call->getArgs()) === 1;
     }
 
-    public function isValidAtCall(MethodCall|StaticCall $call): bool
+    public function isValidAtCall(Expr $expr): bool
     {
-        if (! $this->testsNodeAnalyzer->isInPHPUnitMethodCallName($call, 'at')) {
+        if (! $expr instanceof StaticCall && ! $expr instanceof MethodCall) {
             return false;
         }
 
-        return count($call->getArgs()) === 1;
+        if (! $this->testsNodeAnalyzer->isInPHPUnitMethodCallName($expr, 'at')) {
+            return false;
+        }
+
+        return count($expr->getArgs()) === 1;
     }
 
     private function getMethod(MethodCall $methodCall): MethodCall

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_dynamic_variable.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_dynamic_variable.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectationsRector\Source\SomeObject;
+
+final class SkipDynamicVariable extends TestCase
+{
+    public function test(): void
+    {
+        $one = 1;
+        $two = 2;
+
+        $mock = $this->createMock(SomeObject::class);
+
+        $mock
+            ->expects($this->at($one))
+            ->with(0)
+            ->method('someMethod')
+            ->willReturn('0');
+        $mock
+            ->expects($this->at($two))
+            ->with(1)
+            ->method('someMethod')
+            ->willReturn('1');
+    }
+}

--- a/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_other_class_types.php.inc
+++ b/tests/Rector/ClassMethod/MigrateAtToConsecutiveExpectationsRector/Fixture/skip_other_class_types.php.inc
@@ -4,11 +4,11 @@ namespace Rector\PHPUnit\Tests\Rector\ClassMethod\MigrateAtToConsecutiveExpectat
 
 use PHPUnit\Framework\TestCase;
 
-final class SkipStaticCallSelf extends TestCase
+final class SkipOtherClassTypes extends TestCase
 {
-    public function testSuccessfulBuildFoundEntity(): void
+    public function testSuccessfulBuildFoundEntity($expecataiton): void
     {
         $entity = $this->createMock(TestCase::class);
-        $entity->expects(self::once())->method('getId')->willReturn(1);
+        $entity->expects($expecataiton)->method('getId');
     }
 }


### PR DESCRIPTION
Ref rectorphp/rector#6976

Follow up to https://github.com/rectorphp/rector-phpunit/pull/41