### PR TITLE
[Feature] Add TestClassNameResolverInterface to allow custom implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "symplify/vendor-patches": "^10.0",
-        "symplify/monorepo-builder": "^10.0"
+        "symplify/monorepo-builder": "^10.0",
+        "symplify/easy-ci": "^10.1"
     },
     "autoload": {
         "psr-4": {

--- a/easy-ci.php
+++ b/easy-ci.php
@@ -2,12 +2,17 @@
 
 declare(strict_types=1);
 
+use Rector\Core\Contract\Rector\RectorInterface;
+use Rector\PHPUnit\Naming\TestClassNameResolverInterface;
+use Rector\Set\Contract\SetListInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCI\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::TYPES_TO_SKIP, [
-        \Rector\PHPUnit\Naming\TestClassNameResolver::class,
+        TestClassNameResolverInterface::class,
+        RectorInterface::class,
+        SetListInterface::class,
     ]);
 };

--- a/easy-ci.php
+++ b/easy-ci.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCI\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::TYPES_TO_SKIP, [
+        \Rector\PHPUnit\Naming\TestClassNameResolver::class,
+    ]);
+};

--- a/src/Naming/TestClassNameResolver.php
+++ b/src/Naming/TestClassNameResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\Naming;
 
-final class TestClassNameResolver
+final class TestClassNameResolver implements TestClassNameResolverInterface
 {
     /**
      * @return string[]

--- a/src/Naming/TestClassNameResolverInterface.php
+++ b/src/Naming/TestClassNameResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Naming;
+
+interface TestClassNameResolverInterface
+{
+    /**
+     * @return string[]
+     */
+    public function resolve(string $className): array;
+}

--- a/src/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/src/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -12,7 +12,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Core\Rector\AbstractRector;
-use Rector\PHPUnit\Naming\TestClassNameResolver;
+use Rector\PHPUnit\Naming\TestClassNameResolverInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -29,7 +29,7 @@ final class AddSeeTestAnnotationRector extends AbstractRector
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
         private readonly PhpDocTagRemover $phpDocTagRemover,
-        private readonly TestClassNameResolver $testClassNameResolver
+        private readonly TestClassNameResolverInterface $testClassNameResolver
     ) {
     }
 


### PR DESCRIPTION
PR for https://github.com/rectorphp/rector-phpunit/issues/51

I have tested this locally by applying a patch to the rector's vendor directory, and then in `rector.php`

```php
    $services->set(
        \Rector\PHPUnit\Naming\TestClassNameResolverInterface::class,
        \Utils\Rector\Rector\PHPUnit\Naming\CustomTestClassNameResolver::class
    );
```