### PR TITLE
[PHPUnit] Skip expectOutput prefix on AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -157,6 +157,7 @@ final class AssertCallAnalyzer
             'assert*',
             'expectException*',
             'setExpectedException*',
+            'expectOutput*',
         ]);
     }
 }

--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_expect_output.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_expect_output.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class SkipExpectOutputTest extends \PHPUnit\Framework\TestCase
+{
+    public function testExpectOutputString()
+    {
+        $this->expectOutputString('Hello world!');
+
+        print 'Hello world!';
+    }
+
+    public function testExpectOutputRegex()
+    {
+        $this->expectOutputString('#^Hello world!$#');
+
+        print 'Hello world!';
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7101