### PR TITLE
Typo Fix copy paste

### DIFF
--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_expect_output.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_expect_output.php.inc
@@ -13,7 +13,7 @@ class SkipExpectOutputTest extends \PHPUnit\Framework\TestCase
 
     public function testExpectOutputRegex()
     {
-        $this->expectOutputString('#^Hello world!$#');
+        $this->expectOutputRegex('#^Hello world!$#');
 
         print 'Hello world!';
     }


### PR DESCRIPTION
`expectOutputString()` should be `expectOutputRegex()` in 2nd example.