### PR TITLE
Move PHPUnitLevelSetList constants to PHPUnitSetList

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        PHPUnitSetList::PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_90, // to run also previous phpunit version ruleSets use: PHPUnitSetList::UP_TO_PHPUNIT_90
     ]);
 };
 ```

--- a/config/sets/level/up-to-phpunit-100.php
+++ b/config/sets/level/up-to-phpunit-100.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_91);
-    $rectorConfig->import(PHPUnitLevelSetList::UP_TO_PHPUNIT_90);
+    $rectorConfig->import(PHPUnitSetList::UP_TO_PHPUNIT_90);
 };

--- a/config/sets/level/up-to-phpunit-60.php
+++ b/config/sets/level/up-to-phpunit-60.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_60);
-    $rectorConfig->import(PHPUnitLevelSetList::UP_TO_PHPUNIT_50);
+    $rectorConfig->import(PHPUnitSetList::UP_TO_PHPUNIT_50);
 };

--- a/config/sets/level/up-to-phpunit-70.php
+++ b/config/sets/level/up-to-phpunit-70.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_70);
-    $rectorConfig->import(PHPUnitLevelSetList::UP_TO_PHPUNIT_60);
+    $rectorConfig->import(PHPUnitSetList::UP_TO_PHPUNIT_60);
 };

--- a/config/sets/level/up-to-phpunit-80.php
+++ b/config/sets/level/up-to-phpunit-80.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_80);
-    $rectorConfig->import(PHPUnitLevelSetList::UP_TO_PHPUNIT_70);
+    $rectorConfig->import(PHPUnitSetList::UP_TO_PHPUNIT_70);
 };

--- a/config/sets/level/up-to-phpunit-90.php
+++ b/config/sets/level/up-to-phpunit-90.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_90);
-    $rectorConfig->import(PHPUnitLevelSetList::UP_TO_PHPUNIT_80);
+    $rectorConfig->import(PHPUnitSetList::UP_TO_PHPUNIT_80);
 };

--- a/src/Set/PHPUnitLevelSetList.php
+++ b/src/Set/PHPUnitLevelSetList.php
@@ -6,6 +6,9 @@ namespace Rector\PHPUnit\Set;
 
 use Rector\Set\Contract\SetListInterface;
 
+/**
+ * @deprecated use PHPUnitSetList constants instead.
+ */
 final class PHPUnitLevelSetList implements SetListInterface
 {
     /**

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -72,4 +72,34 @@ final class PHPUnitSetList implements SetListInterface
      * @var string
      */
     public const PHPUNIT_YIELD_DATA_PROVIDER = __DIR__ . '/../../config/sets/phpunit-yield-data-provider.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHPUNIT_50 = __DIR__ . '/../../config/sets/level/up-to-phpunit-50.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHPUNIT_60 = __DIR__ . '/../../config/sets/level/up-to-phpunit-60.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHPUNIT_70 = __DIR__ . '/../../config/sets/level/up-to-phpunit-70.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHPUNIT_80 = __DIR__ . '/../../config/sets/level/up-to-phpunit-80.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHPUNIT_90 = __DIR__ . '/../../config/sets/level/up-to-phpunit-90.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHPUNIT_100 = __DIR__ . '/../../config/sets/level/up-to-phpunit-100.php';
 }


### PR DESCRIPTION
Similar to: https://github.com/rectorphp/rector-symfony/pull/217, https://github.com/rectorphp/rector-symfony/issues/216

Think the CI errors are unrelated to the PR.