### PR TITLE
Add failing test fixture for AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
@@ -2,15 +2,13 @@
 
 declare(strict_types=1);
 
-namespace AppTest\Client\Adapter;
+namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 interface CacheInterface {}
 interface AdapterInterface {}
-
-namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
 
 final class CacheAdapter implements AdapterInterface
 {
@@ -27,7 +25,6 @@ final class CacheAdapter implements AdapterInterface
     }
 }    
 
-namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
 
 final class CachedAdapterTest extends TestCase
 {

--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Client\Adapter;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+interface CacheInterface {}
+interface AdapterInterface {}
+
+namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+final class CacheAdapter implements AdapterInterface
+{
+    public static function create(AdapterInterface $adapter, CacheInterface $listCache, CacheInterface $getCache): self
+    {
+        return new self($adapter, $listCache, $getCache);
+    }
+    
+    private function __construct(
+        private readonly AdapterInterface $adapter,
+        private readonly CacheInterface $listCache,
+        private readonly CacheInterface $getCache,
+    ) {
+    }
+}    
+
+namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+final class CachedAdapterTest extends TestCase
+{
+    /** @var CacheInterface&MockObject */
+    private MockObject $listCache;
+
+    /** @var CacheInterface&MockObject */
+    private MockObject $getCache;
+
+    /** @var AdapterInterface&MockObject */
+    private MockObject $wrappedAdapter;
+
+    /** @var CachedAdapter */
+    private CachedAdapter $cachedAdapter;
+
+    protected function setUp(): void
+    {
+        $this->listCache      = $this->createMock(CacheInterface::class);
+        $this->getCache       = $this->createMock(CacheInterface::class);
+        $this->wrappedAdapter = $this->createMock(AdapterInterface::class);
+        $this->cachedAdapter  = CachedAdapter::create($this->wrappedAdapter, $this->listCache, $this->getCache);
+    }
+
+    public function testDeleteRequestsCallTheAdapterThenClearTheListCacheAndRemoveFromGetCache(): void
+    {
+        $endpoint = 'test';
+
+        $this->getCache
+            ->expects(self::never())
+            ->method('has');
+
+        $this->wrappedAdapter
+            ->expects(self::once())
+            ->method('delete')
+            ->with($endpoint);
+
+        $this->listCache
+            ->expects(self::once())
+            ->method('clear');
+
+        $this->getCache
+            ->expects(self::once())
+            ->method('unset')
+            ->with($endpoint);
+
+        $this->cachedAdapter->delete($endpoint);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+// what is expected code?
+// should remain the same? delete part bellow ----- (included)
+
+?>

--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
@@ -79,11 +79,3 @@ final class CachedAdapterTest extends TestCase
 
 ?>
 -----
-<?php
-
-namespace Rector\Tests\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
-
-// what is expected code?
-// should remain the same? delete part bellow ----- (included)
-
-?>

--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_mock_expectations.php.inc
@@ -16,15 +16,14 @@ final class CacheAdapter implements AdapterInterface
     {
         return new self($adapter, $listCache, $getCache);
     }
-    
+
     private function __construct(
         private readonly AdapterInterface $adapter,
         private readonly CacheInterface $listCache,
         private readonly CacheInterface $getCache,
     ) {
     }
-}    
-
+}
 
 final class CachedAdapterTest extends TestCase
 {


### PR DESCRIPTION
# Failing Test for AddDoesNotPerformAssertionToNonAssertingTestRector

Based on https://getrector.org/demo/17e60282-2c25-4daa-bf6f-e39aa35428b1
As requested:
- https://github.com/rectorphp/rector/issues/7448#issuecomment-1235743890