### PR TITLE
[WIP][Set] Annotation to attribute

### DIFF
--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        // @see https://github.com/sebastianbergmann/phpunit/issues/4502
+        new AnnotationToAttribute('after', 'PHPUnit\Framework\Attributes\After'),
+        new AnnotationToAttribute('afterClass', 'PHPUnit\Framework\Attributes\AfterClass'),
+        // new AnnotationToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals'),
+        // new AnnotationToAttribute('backupStaticAttributes', 'PHPUnit\Framework\Attributes\BackupStaticProperties'),
+        new AnnotationToAttribute('before', 'PHPUnit\Framework\Attributes\Before'),
+        new AnnotationToAttribute('beforeClass', 'PHPUnit\Framework\Attributes\BeforeClass'),
+        new AnnotationToAttribute('codeCoverageIgnore', 'PHPUnit\Framework\Attributes\CodeCoverageIgnore'),
+        // new AnnotationToAttribute('covers', 'PHPUnit\Framework\Attributes\CoversClass'),
+        // new AnnotationToAttribute('covers', 'PHPUnit\Framework\Attributes\CoversFunction'),
+        new AnnotationToAttribute('coversNothing', 'PHPUnit\Framework\Attributes\CoversNothing'),
+        // new AnnotationToAttribute('dataProvider', 'PHPUnit\Framework\Attributes\DataProvider'),
+        // new AnnotationToAttribute('dataProvider', 'PHPUnit\Framework\Attributes\DataProviderExternal'),
+        // new AnnotationToAttribute('depends', 'PHPUnit\Framework\Attributes\Depends'),
+        // new AnnotationToAttribute('depends', 'PHPUnit\Framework\Attributes\DependsExternal'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsExternalUsingDeepClone'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsExternalUsingShallowClone'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsOnClass'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsOnClassUsingDeepClone'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsOnClassUsingShallowClone'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsUsingDeepClone'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\DependsUsingShallowClone'),
+        new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\ExcludeGlobalVariableFromBackup'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\ExcludeStaticPropertyFromBackup'),
+        // new AnnotationToAttribute('group', 'PHPUnit\Framework\Attributes\Group'),
+        new AnnotationToAttribute('large', 'PHPUnit\Framework\Attributes\Large'),
+        new AnnotationToAttribute('medium', 'PHPUnit\Framework\Attributes\Medium'),
+        new AnnotationToAttribute('preCondition', 'PHPUnit\Framework\Attributes\PostCondition'),
+        new AnnotationToAttribute('postCondition', 'PHPUnit\Framework\Attributes\PreCondition'),
+        new AnnotationToAttribute('preserveGlobalState', 'PHPUnit\Framework\Attributes\PreserveGlobalState'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresFunction'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresMethod'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresOperatingSystem'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresPhp'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresPhpExtension'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresPhpunit'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RequiresSetting'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\RunClassInSeparateProcess'),
+        new AnnotationToAttribute('runInSeparateProcess', 'PHPUnit\Framework\Attributes\RunInSeparateProcess'),
+        new AnnotationToAttribute('runTestsInSeparateProcesses', 'PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses'),
+        new AnnotationToAttribute('small', 'PHPUnit\Framework\Attributes\Small'),
+        new AnnotationToAttribute('test', 'PHPUnit\Framework\Attributes\Test'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\TestDox'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\TestWith'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\TestWithJson'),
+        // new AnnotationToAttribute('ticket', 'PHPUnit\Framework\Attributes\Ticket'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\UsesClass'),
+        // new AnnotationToAttribute('PHPUnit\Framework\Attributes\UsesFunction'),
+    ]);
+};

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -72,4 +72,9 @@ final class PHPUnitSetList implements SetListInterface
      * @var string
      */
     public const PHPUNIT_YIELD_DATA_PROVIDER = __DIR__ . '/../../config/sets/phpunit-yield-data-provider.php';
+
+    /**
+     * @var string
+     */
+    public const ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/annotations-to-attributes.php';
 }

--- a/tests/AnnotationsToAttributes/AnnotationsToAttributesTest.php
+++ b/tests/AnnotationsToAttributes/AnnotationsToAttributesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AnnotationsToAttributesTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/annotationsToAttributes.php';
+    }
+}

--- a/tests/AnnotationsToAttributes/Fixture/small_fixture.php.inc
+++ b/tests/AnnotationsToAttributes/Fixture/small_fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @small
+ */
+class BarController extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldDoStuff()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\Small]
+class BarController extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function shouldDoStuff()
+    {
+    }
+}
+
+?>

--- a/tests/AnnotationsToAttributes/config/annotationsToAttributes.php
+++ b/tests/AnnotationsToAttributes/config/annotationsToAttributes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../config/config.php');
+    $rectorConfig->sets([PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES]);
+};


### PR DESCRIPTION
PHPUnit will support [attributes](https://github.com/sebastianbergmann/phpunit/issues/4502) in version 10.  
It would be cool to have day 1 support.
ref issue: https://github.com/rectorphp/rector-phpunit/issues/69

This is work in progress because currently `AnnotationToAttribute`:
1. do not support syntax like: `@dataProvider  data`  or `@group api` (those are probably most common)
2. are not aware if the annotation is attached to method or class

Probably some new class like `PHPUnitAnnotationToAttribute` is needed.
@TomasVotruba Any feedback is welcome.
