### PR TITLE
[PHPUnit 10] Add CoversAnnotationWithValueToAttributeRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require-dev": {
         "rector/rector-src": "dev-main",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^1.9.2",
         "symplify/phpstan-rules": "^11.1",
         "symplify/phpstan-extensions": "^11.1",
         "symplify/easy-coding-standard": "^11.1",

--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -6,9 +6,12 @@ use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\PHPUnit\Rector\Class_\AnnotationWithValueToAttributeRector;
+use Rector\PHPUnit\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([CoversAnnotationWithValueToAttributeRector::class]);
+
     $rectorConfig->ruleWithConfiguration(AnnotationWithValueToAttributeRector::class, [
         new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [
             'enabled' => true,
@@ -31,8 +34,6 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationWithValueToAttribute('testWith', 'PHPUnit\Framework\Attributes\TestWith'),
         new AnnotationWithValueToAttribute('testDox', 'PHPUnit\Framework\Attributes\TestDox'),
 
-        // new AnnotationToAttribute('covers', 'PHPUnit\Framework\Attributes\CoversClass'),
-        // new AnnotationToAttribute('covers', 'PHPUnit\Framework\Attributes\CoversFunction'),
         // new AnnotationToAttribute('dataProvider', 'PHPUnit\Framework\Attributes\DataProviderExternal'),
 
         // depends

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 43 Rules Overview
+# 45 Rules Overview
 
 ## AddDoesNotPerformAssertionToNonAssertingTestRector
 
@@ -63,6 +63,47 @@ Add `@see` annotation test of the class for faster jump to test. Make it FQN, so
  use PHPUnit\Framework\TestCase;
 
  class SomeServiceTest extends TestCase
+ {
+ }
+```
+
+<br>
+
+## AnnotationWithValueToAttributeRector
+
+Change annotations with value to attribute
+
+:wrench: **configure it!**
+
+- class: [`Rector\PHPUnit\Rector\Class_\AnnotationWithValueToAttributeRector`](../src/Rector/Class_/AnnotationWithValueToAttributeRector.php)
+
+```php
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Rector\Class_\AnnotationWithValueToAttributeRector;
+use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(
+        AnnotationWithValueToAttributeRector::class,
+        [new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [
+            true,
+            false,
+        ])]
+    );
+};
+```
+
+↓
+
+```diff
+ use PHPUnit\Framework\TestCase;
++use PHPUnit\Framework\Attributes\BackupGlobals;
+
+-/**
+- * @backupGlobals enabled
+- */
++#[BackupGlobals(true)]
+ final class SomeTest extends TestCase
  {
  }
 ```
@@ -417,6 +458,35 @@ Change `__construct()` method in tests of `PHPUnit\Framework\TestCase` to `setUp
 +
          $this->someValue = 1000;
 -        parent::__construct($name, $data, $dataName);
+     }
+ }
+```
+
+<br>
+
+## CoversAnnotationWithValueToAttributeRector
+
+Change covers annotations with value to attribute
+
+- class: [`Rector\PHPUnit\Rector\Class_\CoversAnnotationWithValueToAttributeRector`](../src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php)
+
+```diff
+ use PHPUnit\Framework\TestCase;
++use PHPUnit\Framework\Attributes\CoversClass;
++use PHPUnit\Framework\Attributes\CoversFunction;
+
+-/**
+- * @covers SomeClass
+- */
++#[CoversClass(SomeClass::class)]
+ final class SomeTest extends TestCase
+ {
+-    /**
+-     * @covers ::someFunction
+-     */
++    #[CoversFunction('someFunction')]
+     public function test()
+     {
      }
  }
 ```

--- a/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\CoversAnnotationWithValueToAttributeRectorTest
+ */
+final class CoversAnnotationWithValueToAttributeRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change covers annotations with value to attribute', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers SomeClass
+ */
+final class SomeTest extends TestCase
+{
+    /**
+     * @covers ::someFunction
+     */
+    public function test()
+    {
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+#[CoversClass(SomeClass::class)]
+final class SomeTest extends TestCase
+{
+    #[CoversFunction('someFunction')]
+    public function test()
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class, ClassMethod::class];
+    }
+
+    /**
+     * @param Class_|ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        /** @var PhpDocTagNode[] $desiredTagValueNodes */
+        $desiredTagValueNodes = $phpDocInfo->getTagsByName('covers');
+
+        foreach ($desiredTagValueNodes as $desiredTagValueNode) {
+            if (! $desiredTagValueNode->value instanceof GenericTagValueNode) {
+                continue;
+            }
+
+            $annotationValue = $desiredTagValueNode->value->value;
+
+            if (str_starts_with($annotationValue, '::')) {
+                $attributeClass = 'PHPUnit\Framework\Attributes\CoversFunction';
+                $attributeValue = trim($annotationValue, ':()');
+            } else {
+                $attributeClass = 'PHPUnit\Framework\Attributes\CoversClass';
+                $attributeValue = trim($annotationValue) . '::class';
+            }
+
+            $hasChanged = true;
+
+            $attributeGroup = $this->phpAttributeGroupFactory->createFromClassWithItems(
+                $attributeClass,
+                [$attributeValue]
+            );
+            $node->attrGroups[] = $attributeGroup;
+
+            // cleanup
+            $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $desiredTagValueNode);
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/CoversAnnotationWithValueToAttributeRectorTest.php
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/CoversAnnotationWithValueToAttributeRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CoversAnnotationWithValueToAttributeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<string>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class.php.inc
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CoversClass extends TestCase
+{
+    /**
+     * @covers \Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass
+     */
+    public function test()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CoversClass extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
+    public function test()
+    {
+    }
+}
+
+?>

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\AnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CoversFunction extends TestCase
+{
+    /**
+     * @covers ::someFunction()
+     */
+    public function test()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\AnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CoversFunction extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
+    public function test()
+    {
+    }
+}
+
+?>

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Source/ExistingClass.php
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Source/ExistingClass.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source;
+
+final class ExistingClass
+{
+
+}

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->rule(CoversAnnotationWithValueToAttributeRector::class);
+};


### PR DESCRIPTION
* Ref https://github.com/rectorphp/rector-phpunit/issues/69
* Ref https://github.com/sebastianbergmann/phpunit/issues/4502

```diff
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;

-/**
- * @covers SomeClass
- */
+#[CoversClass(SomeClass::class)]
 final class SomeTest extends TestCase
 {
-    /**
-     * @covers ::someFunction
-     */
+    #[CoversFunction('someFunction')]
     public function test()
     {
     }
 }
```