### PR TITLE
[PHPUnit] Add DependsAnnotationWithValueToAttributeRector

### DIFF
--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -20,6 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
          *
          * Todo:
          *      - @depends Class::MethodName
+         *      - @depends clone, !clone, shallowClone, !shallowClone
          */
         DependsAnnotationWithValueToAttributeRector::class,
     ]);

--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -7,10 +7,22 @@ use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\PHPUnit\Rector\Class_\AnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
+use Rector\PHPUnit\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([CoversAnnotationWithValueToAttributeRector::class]);
+    $rectorConfig->rules([
+        CoversAnnotationWithValueToAttributeRector::class,
+
+        /**
+         * Currently handle:
+         *      - @depends Methodname
+         *
+         * Todo:
+         *      - @depends Class::MethodName
+         */
+        DependsAnnotationWithValueToAttributeRector::class,
+    ]);
 
     $rectorConfig->ruleWithConfiguration(AnnotationWithValueToAttributeRector::class, [
         new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [

--- a/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -11,6 +11,9 @@ use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see \Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\DependsAnnotationWithValueToAttributeRectorTest
+ */
 final class DependsAnnotationWithValueToAttributeRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition

--- a/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -115,9 +115,8 @@ CODE_SAMPLE
                 continue;
             }
 
-            $attributeClass = 'PHPUnit\Framework\Attributes\Depends';
             $attributeGroup = $this->phpAttributeGroupFactory->createFromClassWithItems(
-                $attributeClass,
+                'PHPUnit\Framework\Attributes\Depends',
                 [$attributeValue]
             );
             $node->attrGroups[] = $attributeGroup;

--- a/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DependsAnnotationWithValueToAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change depends annotations with value to attribute', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function testOne() {}
+    public function testTwo() {}
+
+    /**
+     * @depends testOne
+     * @depends testTwo
+     */
+    public function testThree(): void
+    {
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function testOne() {}
+    public function testTwo() {}
+
+    /**
+     * @depends testOne
+     * @depends testTwo
+     */
+    public function testThree(): void
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -27,7 +27,6 @@ final class SomeTest extends TestCase
 {
     public function testOne() {}
     public function testTwo() {}
-
     /**
      * @depends testOne
      * @depends testTwo
@@ -46,11 +45,8 @@ final class SomeTest extends TestCase
 {
     public function testOne() {}
     public function testTwo() {}
-
-    /**
-     * @depends testOne
-     * @depends testTwo
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testOne')]
+    #[\PHPUnit\Framework\Attributes\Depends('testTwo')]
     public function testThree(): void
     {
     }

--- a/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/DependsAnnotationWithValueToAttributeRectorTest.php
+++ b/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/DependsAnnotationWithValueToAttributeRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DependsAnnotationWithValueToAttributeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function testOne() {}
+    public function testTwo() {}
+    /**
+     * @depends testOne
+     * @depends testTwo
+     */
+    public function testThree(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function testOne() {}
+    public function testTwo() {}
+    #[\PHPUnit\Framework\Attributes\Depends('testOne')]
+    #[\PHPUnit\Framework\Attributes\Depends('testTwo')]
+    public function testThree(): void
+    {
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/Fixture/skip_no_annotation.php.inc
+++ b/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/Fixture/skip_no_annotation.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\Fixture;
+
+class SkipNoAnnotation extends \PHPUnit\Framework\TestCase
+{
+    public function testOne(): void
+    {
+    }
+}

--- a/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/Fixture/skip_not_test_class.php.inc
+++ b/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/Fixture/skip_not_test_class.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\Fixture;
+
+/**
+ * Just random class, not a test class, skip it
+ */
+class SkipNotTestClass
+{
+    public function testOne() {}
+    /**
+     * @depends testOne
+     */
+    public function testThree(): void
+    {
+    }
+}

--- a/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(DependsAnnotationWithValueToAttributeRector::class);
+};


### PR DESCRIPTION
Add `DependsAnnotationWithValueToAttributeRector`, current functionality will only cover current class method, for external, it needs another PR iteration.