### PR TITLE
[PHPUnit] Apply MinPhpVersionInterface on AnnotationWithValueToAttributeRector

### DIFF
--- a/src/Rector/Class_/AnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/AnnotationWithValueToAttributeRector.php
@@ -13,8 +13,10 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -22,7 +24,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\PHPUnit\Tests\Rector\Class_\AnnotationWithValueToAttributeRector\AnnotationWithValueToAttributeRectorTest
  */
-final class AnnotationWithValueToAttributeRector extends AbstractRector implements ConfigurableRectorInterface
+final class AnnotationWithValueToAttributeRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
 {
     /**
      * @var AnnotationWithValueToAttribute[]
@@ -77,6 +79,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class, ClassMethod::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
     }
 
     /**


### PR DESCRIPTION
Attributes only exists in php 8+, so `MinPhpVersionInterface` is needed for it.