### PR TITLE
[PHPUnit] Apply MinPhpVersionInterface on CoversAnnotationWithValueToAttributeRector and DependsAnnotationWithValueToAttributeRector

### DIFF
--- a/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -12,16 +12,18 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\DependsAnnotationWithValueToAttributeRectorTest
  */
-final class DependsAnnotationWithValueToAttributeRector extends AbstractRector
+final class DependsAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -76,6 +78,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [ClassMethod::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
     }
 
     /**

--- a/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -12,15 +12,17 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\CoversAnnotationWithValueToAttributeRectorTest
  */
-final class CoversAnnotationWithValueToAttributeRector extends AbstractRector
+final class CoversAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly PhpDocTagRemover $phpDocTagRemover,
@@ -75,6 +77,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class, ClassMethod::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
     }
 
     /**


### PR DESCRIPTION
Attributes only exists in php 8+, so MinPhpVersionInterface is needed for it.
