### PR TITLE
Ignore non existent data provider methods

### DIFF
--- a/src/NodeFinder/DataProviderClassMethodFinder.php
+++ b/src/NodeFinder/DataProviderClassMethodFinder.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\Core\Exception\ShouldNotHappenException;
 
 final class DataProviderClassMethodFinder
 {
@@ -28,7 +27,7 @@ final class DataProviderClassMethodFinder
         foreach ($dataProviderMethodNames as $dataProviderMethodName) {
             $dataProviderClassMethod = $class->getMethod($dataProviderMethodName);
             if (! $dataProviderClassMethod instanceof ClassMethod) {
-                throw new ShouldNotHappenException();
+                continue;
             }
 
             $dataProviderClassMethods[] = $dataProviderClassMethod;


### PR DESCRIPTION
This PR, when merged, would unblock the ~failures~ failure described in #142.

Handling non-final classes that define data provider methods and not use them themself could be handled as a feature, I guess.