### PR TITLE
Remove check-markdown command from composer fix-cs and composer docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,7 @@
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
-        "docs": [
-            "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi",
-            "vendor/bin/ecs check-markdown docs/rector_rules_overview.md --ansi --fix"
-        ]
+        "docs": "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi"
     },
     "extra": {
         "enable-patching": true,

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 45 Rules Overview
+# 46 Rules Overview
 
 ## AddDoesNotPerformAssertionToNonAssertingTestRector
 
@@ -78,18 +78,16 @@ Change annotations with value to attribute
 - class: [`Rector\PHPUnit\Rector\Class_\AnnotationWithValueToAttributeRector`](../src/Rector/Class_/AnnotationWithValueToAttributeRector.php)
 
 ```php
+<?php
+
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Rector\Class_\AnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(
-        AnnotationWithValueToAttributeRector::class,
-        [new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [
-            true,
-            false,
-        ])]
-    );
+    $rectorConfig->ruleWithConfiguration(AnnotationWithValueToAttributeRector::class, [new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [true, false])]);
 };
 ```
 
@@ -119,16 +117,16 @@ Move array argument from tests into data provider [configurable]
 - class: [`Rector\PHPUnit\Rector\Class_\ArrayArgumentToDataProviderRector`](../src/Rector/Class_/ArrayArgumentToDataProviderRector.php)
 
 ```php
+<?php
+
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Rector\Class_\ArrayArgumentToDataProviderRector;
 use Rector\PHPUnit\ValueObject\ArrayArgumentToDataProvider;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(ArrayArgumentToDataProviderRector::class, [
-        ArrayArgumentToDataProviderRector::ARRAY_ARGUMENTS_TO_DATA_PROVIDERS => [
-            new ArrayArgumentToDataProvider('PHPUnit\Framework\TestCase', 'doTestMultiple', 'doTestSingle', 'number'),
-        ],
-    ]);
+    $rectorConfig->ruleWithConfiguration(ArrayArgumentToDataProviderRector::class, [ArrayArgumentToDataProviderRector::ARRAY_ARGUMENTS_TO_DATA_PROVIDERS => [new ArrayArgumentToDataProvider('PHPUnit\Framework\TestCase', 'doTestMultiple', 'doTestSingle', 'number')]]);
 };
 ```
 
@@ -564,6 +562,33 @@ Takes `setExpectedException()` 2nd and next arguments to own methods in PHPUnit.
 +$this->setExpectedException(SomeException::class);
 +$this->expectExceptionMessage('Message');
 +$this->expectExceptionCode('CODE');
+```
+
+<br>
+
+## DependsAnnotationWithValueToAttributeRector
+
+Change depends annotations with value to attribute
+
+- class: [`Rector\PHPUnit\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector`](../src/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php)
+
+```diff
+ use PHPUnit\Framework\TestCase;
+
+ final class SomeTest extends TestCase
+ {
+     public function testOne() {}
+     public function testTwo() {}
+-    /**
+-     * @depends testOne
+-     * @depends testTwo
+-     */
++    #[\PHPUnit\Framework\Attributes\Depends('testOne')]
++    #[\PHPUnit\Framework\Attributes\Depends('testTwo')]
+     public function testThree(): void
+     {
+     }
+ }
 ```
 
 <br>

--- a/easy-ci.php
+++ b/easy-ci.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Contract\Rector\RectorInterface;
-use Rector\Set\Contract\SetListInterface;
 use Symplify\EasyCI\Config\EasyCIConfig;
 
 return static function (EasyCIConfig $easyCIConfig): void {
+    $easyCIConfig->paths([__DIR__ . '/config', __DIR__ . '/src']);
+
     $easyCIConfig->typesToSkip([
-        RectorInterface::class,
-        SetListInterface::class,
     ]);
 };

--- a/easy-ci.php
+++ b/easy-ci.php
@@ -2,11 +2,29 @@
 
 declare(strict_types=1);
 
+use Rector\PHPUnit\Rector\Class_\ArrayArgumentToDataProviderRector;
+use Rector\PHPUnit\Rector\Class_\ProphecyPHPDocRector;
+use Rector\PHPUnit\Rector\ClassMethod\CreateMockToAnonymousClassRector;
+use Rector\PHPUnit\Rector\ClassMethod\RemoveEmptyTestMethodRector;
+use Rector\PHPUnit\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector;
+use Rector\PHPUnit\Rector\ClassMethod\TryCatchToExpectExceptionRector;
+use Rector\PHPUnit\Rector\MethodCall\AssertResourceToClosedResourceRector;
+use Rector\PHPUnit\Rector\MethodCall\CreateMockToCreateStubRector;
+use Rector\PHPUnit\Rector\MethodCall\UseSpecificWithMethodRector;
 use Symplify\EasyCI\Config\EasyCIConfig;
 
 return static function (EasyCIConfig $easyCIConfig): void {
     $easyCIConfig->paths([__DIR__ . '/config', __DIR__ . '/src']);
 
     $easyCIConfig->typesToSkip([
+        CreateMockToAnonymousClassRector::class,
+        RemoveEmptyTestMethodRector::class,
+        ReplaceTestAnnotationWithPrefixedFunctionRector::class,
+        TryCatchToExpectExceptionRector::class,
+        ArrayArgumentToDataProviderRector::class,
+        ProphecyPHPDocRector::class,
+        AssertResourceToClosedResourceRector::class,
+        CreateMockToCreateStubRector::class,
+        UseSpecificWithMethodRector::class,
     ]);
 };


### PR DESCRIPTION
Per discussion on https://github.com/rectorphp/rector/issues/7752#issuecomment-1413397028