### PR TITLE
[PhpUnit] Skip Already attributed DoesNotPerformAssertions on AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -110,7 +110,10 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions')) {
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute(
+            $classMethod,
+            'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'
+        )) {
             return true;
         }
 

--- a/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\AssertCallAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\MockedVariableAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -27,6 +28,7 @@ final class AddDoesNotPerformAssertionToNonAssertingTestRector extends AbstractR
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly AssertCallAnalyzer $assertCallAnalyzer,
         private readonly MockedVariableAnalyzer $mockedVariableAnalyzer,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -105,6 +107,10 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if ($phpDocInfo->hasByNames(['doesNotPerformAssertions', 'expectedException'])) {
+            return true;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions')) {
             return true;
         }
 

--- a/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_already_attributed_doesnot_perform_assertion.php.inc
+++ b/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_already_attributed_doesnot_perform_assertion.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class SkipAlreadyAttributedDoesnotPerformAssertion extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test()
+    {
+        $nothing = 5;
+    }
+}


### PR DESCRIPTION
When already in phpunit 10 with attribute `DoesNotPerformAssertions`, the addition `@doesNotPerformAssertions` is not needed.