### PR TITLE
Add failing test fixture for `StaticDataProviderClassMethodRector`

### DIFF
--- a/tests/Rector/Class_/StaticDataProviderClassMethodRector/Fixture/test_case.php.inc
+++ b/tests/Rector/Class_/StaticDataProviderClassMethodRector/Fixture/test_case.php.inc
@@ -1,0 +1,77 @@
+<?php
+
+namespace PHPUnit\Framework;
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+class TestCase
+{
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+abstract class AbstractFooTestCase extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testWithDataProvider($value1, $value2): void
+    {
+        
+    }
+    
+    abstract public function dataProvider(): array;
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+class MyTest extends AbstractFooTestCase
+{
+    public function dataProvider(): array
+    {
+        return [
+        	[1, 2],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace PHPUnit\Framework;
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+class TestCase
+{
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+abstract class AbstractFooTestCase extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testWithDataProvider($value1, $value2): void
+    {
+        
+    }
+    
+    abstract public static function dataProvider(): array;
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+class MyTest extends AbstractFooTestCase
+{
+    public static function dataProvider(): array
+    {
+        return [
+        	[1, 2],
+        ];
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for StaticDataProviderClassMethodRector

Based on https://getrector.com/demo/3074e792-c0f4-4db7-bdd4-fb2c4b55bee3