### PR TITLE
Add failing test fixture for `StaticDataProviderClassMethodRector` with ignored abstract parent test case

### DIFF
--- a/tests/Rector/Class_/StaticDataProviderClassMethodRector/Fixture/test_case.php.inc
+++ b/tests/Rector/Class_/StaticDataProviderClassMethodRector/Fixture/test_case.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace PHPUnit\Framework;
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+class TestCase
+{
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+abstract class AbstractFooTestCase extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testWithDataProvider($value1, $value2): void
+    {
+        
+    }
+    
+    abstract public function dataProvider(): array;
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+class MyTest extends AbstractFooTestCase
+{
+    public function dataProvider(): array
+    {
+        return [
+        	[1, 2],
+        ];
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for StaticDataProviderClassMethodRector

Based on https://getrector.com/demo/9372e294-4277-4bb9-abeb-34764c0b053c

# Explanation

Because the parent abstract class is skipped in rector config, their child classes should be ignored for this rector as well. Check the demo link please, thanks.

This test should be failing ❗ 

Spotted in
* https://github.com/symfony/symfony/pull/48668