### PR TITLE
Fix phpstan notice on update to phpstan 1.10.11

### DIFF
--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -120,7 +120,7 @@ final class AssertCallAnalyzer
                 return false;
             }
 
-            if ($classMethod !== null) {
+            if ($classMethod instanceof ClassMethod) {
                 return $this->containsAssertCall($classMethod);
             }
 

--- a/src/NodeFinder/DataProviderClassMethodFinder.php
+++ b/src/NodeFinder/DataProviderClassMethodFinder.php
@@ -118,7 +118,9 @@ final class DataProviderClassMethodFinder
                 break;
             }
 
-            $parentClasses[] = $this->astResolver->resolveClassFromClassReflection($parentClassReflection);
+            /** @var Class_ $parentClass */
+            $parentClass = $this->astResolver->resolveClassFromClassReflection($parentClassReflection);
+            $parentClasses[] = $parentClass;
         }
 
         return $parentClasses;

--- a/src/Rector/MethodCall/ExplicitPhpErrorApiRector.php
+++ b/src/Rector/MethodCall/ExplicitPhpErrorApiRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
 
         foreach (self::REPLACEMENTS as $class => $method) {
             $newNode = $this->replaceExceptionWith($node, $class, $method);
-            if ($newNode !== null) {
+            if ($newNode instanceof Node) {
                 return $newNode;
             }
         }


### PR DESCRIPTION
After update to phpstan 1.10.11, there is notice:

```
➜  rector-phpunit git:(main) composer phpstan
> vendor/bin/phpstan analyse --ansi --error-format symplify
Note: Using configuration file /Users/samsonasik/www/rector-phpunit/phpstan.neon.
 198/198 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  src/NodeFinder/DataProviderClassMethodFinder.php:124
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\PHPUnit\\NodeFinder\\DataProviderClassMethodFinder\:\:resolveParentAbstractClasses\(\) should return array<PhpParser\\Node\\Stmt\\Class_> but returns array<int<0, max>, PhpParser\\Node\\Stmt\\Class_\|PhpParser\\Node\\Stmt\\Enum_\|PhpParser\\Node\\Stmt\\Interface_\|PhpParser\\Node\\Stmt\\Trait_\|null>#'
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


                                                                                                                        
 [ERROR] Found 1 errors                                                                                                 
                                                                                                                        

Script vendor/bin/phpstan analyse --ansi --error-format symplify handling the phpstan event returned with error code 1
```

This PR resolve it. Ref https://github.com/rectorphp/rector-src/pull/3562#issuecomment-1496713887