### PR TITLE
Keep `#[CoversClass]` attribute on method, and don't move it to class scope

### DIFF
--- a/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
      *
      * @return AttributeGroup[]
      */
-    private function resolveCoversClassAttributeGroups(Node\Stmt $node): array
+    private function resolveCoversClassAttributeGroups(Class_|ClassMethod $node): array
     {
         // resolve covers class first
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
@@ -157,7 +157,7 @@ CODE_SAMPLE
      *
      * @return AttributeGroup[]
      */
-    private function resolveCoversFunctionAttributeGroups(Node\Stmt $node): array
+    private function resolveCoversFunctionAttributeGroups(Class_|ClassMethod $node): array
     {
         // resolve covers function
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);

--- a/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -94,15 +94,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $coversClassAttributeGroups = $this->resolveCoversClassAttributeGroups($node);
-        $coversFunctionsAttributeGroups = $this->resolveCoversFunctionAttributeGroups($node);
-
-        $attributeGroups = array_merge($coversClassAttributeGroups, $coversFunctionsAttributeGroups);
-        if ($attributeGroups === []) {
+        $coversAttributeGroups = $this->resolveCoversAttributeGroups($node);
+        if ($coversAttributeGroups === []) {
             return null;
         }
 
-        $node->attrGroups = array_merge($node->attrGroups, $attributeGroups);
+        $node->attrGroups = $coversAttributeGroups;
 
         return $node;
     }
@@ -123,7 +120,7 @@ CODE_SAMPLE
     /**
      * @return AttributeGroup[]
      */
-    private function resolveCoversClassAttributeGroups(Class_|ClassMethod $node): array
+    private function resolveCoversAttributeGroups(Class_|ClassMethod $node): array
     {
         // resolve covers class first
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
@@ -150,32 +147,4 @@ CODE_SAMPLE
         return $attributeGroups;
     }
 
-    /**
-     * @return AttributeGroup[]
-     */
-    private function resolveCoversFunctionAttributeGroups(Class_|ClassMethod $node): array
-    {
-        // resolve covers function
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return [];
-        }
-
-        /** @var PhpDocTagNode[] $desiredTagValueNodes */
-        $desiredTagValueNodes = $phpDocInfo->getTagsByName('covers');
-
-        $attributeGroups = [];
-        foreach ($desiredTagValueNodes as $desiredTagValueNode) {
-            if (! $desiredTagValueNode->value instanceof GenericTagValueNode) {
-                continue;
-            }
-
-            $attributeGroups[] = $this->createAttributeGroup($desiredTagValueNode->value->value);
-
-            // cleanup
-            $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $desiredTagValueNode);
-        }
-
-        return $attributeGroups;
-    }
 }

--- a/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -146,5 +146,4 @@ CODE_SAMPLE
 
         return $attributeGroups;
     }
-
 }

--- a/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/src/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -121,8 +121,6 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Class_|ClassMethod $node
-     *
      * @return AttributeGroup[]
      */
     private function resolveCoversClassAttributeGroups(Class_|ClassMethod $node): array
@@ -153,8 +151,6 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Class_|ClassMethod $node
-     *
      * @return AttributeGroup[]
      */
     private function resolveCoversFunctionAttributeGroups(Class_|ClassMethod $node): array

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class.php.inc
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class.php.inc
@@ -4,11 +4,11 @@ namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttribut
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass
+ */
 final class CoversClass extends TestCase
 {
-    /**
-     * @covers \Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass
-     */
     public function test()
     {
     }

--- a/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_method.php.inc
+++ b/tests/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_method.php.inc
@@ -4,10 +4,10 @@ namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttribut
 
 use PHPUnit\Framework\TestCase;
 
-final class CoversFunction extends TestCase
+final class CoversMethod extends TestCase
 {
     /**
-     * @covers ::someFunction()
+     * @covers \Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass
      */
     public function test()
     {
@@ -22,9 +22,9 @@ namespace Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttribut
 
 use PHPUnit\Framework\TestCase;
 
-final class CoversFunction extends TestCase
+final class CoversMethod extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
+    #[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
     public function test()
     {
     }


### PR DESCRIPTION
closes https://github.com/rectorphp/rector/issues/7873