### PR TITLE
[BetterReflection 6.x] Fix assert($startLine > 0) on CreateMockToAnonymousClassRector

### DIFF
--- a/src/Rector/ClassMethod/CreateMockToAnonymousClassRector.php
+++ b/src/Rector/ClassMethod/CreateMockToAnonymousClassRector.php
@@ -193,6 +193,9 @@ CODE_SAMPLE
         // must respect PHPStan anonymous internal naming \Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver::ANONYMOUS_CLASS_START_REGEX
         return new Class_('AnonymousClass1234', [
             'extends' => $className,
+        ], [
+            'startLine' => $firstArg->getStartLine(),
+            'endLine' => $firstArg->getEndLine(),
         ]);
     }
 


### PR DESCRIPTION
@staabm this should fix https://github.com/rectorphp/rector-phpunit/issues/169