### PR TITLE
StaticDataProviderClassMethodRector should only run if `$this` is not used in dataProvider

### DIFF
--- a/src/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/src/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -96,15 +96,8 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($dataProviderClassMethods as $dataProviderClassMethod) {
-            if ($dataProviderClassMethod->isStatic()) {
+            if ($this->skipMethod($dataProviderClassMethod)) {
                 continue;
-            }
-
-            $variables = $this->betterNodeFinder->findInstanceOf($dataProviderClassMethod, Variable::class);
-            foreach ($variables as $variable) {
-                if ($this->nodeNameResolver->isName($variable, 'this')) {
-                    continue 2;
-                }
             }
 
             $this->visibilityManipulator->makeStatic($dataProviderClassMethod);
@@ -116,5 +109,20 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function skipMethod(Node\Stmt\ClassMethod $method): bool {
+        if ($method->isStatic()) {
+            return true;
+        }
+
+        $variables = $this->betterNodeFinder->findInstanceOf($method, Variable::class);
+        foreach ($variables as $variable) {
+            if ($this->nodeNameResolver->isName($variable, 'this')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/src/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\Rector\Class_;
 
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;

--- a/src/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/src/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
@@ -111,7 +110,8 @@ CODE_SAMPLE
         return null;
     }
 
-    private function skipMethod(Node\Stmt\ClassMethod $method): bool {
+    private function skipMethod(Node\Stmt\ClassMethod $method): bool
+    {
         if ($method->isStatic()) {
             return true;
         }

--- a/src/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/src/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -117,13 +117,13 @@ CODE_SAMPLE
             return true;
         }
 
-        $variables = $this->betterNodeFinder->findInstanceOf($classMethod, Variable::class);
-        foreach ($variables as $variable) {
-            if ($this->nodeNameResolver->isName($variable, 'this')) {
-                return true;
-            }
+        if ($classMethod->stmts === null) {
+            return false;
         }
 
-        return false;
+        return (bool) $this->betterNodeFinder->findFirst(
+            $classMethod->stmts,
+            fn (Node $node): bool => $node instanceof Variable && $this->nodeNameResolver->isName($node, 'this')
+        );
     }
 }

--- a/src/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/src/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\Rector\Class_;
 
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
@@ -110,13 +111,13 @@ CODE_SAMPLE
         return null;
     }
 
-    private function skipMethod(Node\Stmt\ClassMethod $method): bool
+    private function skipMethod(ClassMethod $classMethod): bool
     {
-        if ($method->isStatic()) {
+        if ($classMethod->isStatic()) {
             return true;
         }
 
-        $variables = $this->betterNodeFinder->findInstanceOf($method, Variable::class);
+        $variables = $this->betterNodeFinder->findInstanceOf($classMethod, Variable::class);
         foreach ($variables as $variable) {
             if ($this->nodeNameResolver->isName($variable, 'this')) {
                 return true;

--- a/tests/Rector/Class_/StaticDataProviderClassMethodRector/Fixture/skip_containing_this.php.inc
+++ b/tests/Rector/Class_/StaticDataProviderClassMethodRector/Fixture/skip_containing_this.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\StaticDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\Rector\Class_\StaticDataProviderClassMethodRector\Source\SomeClassToMock;
+
+final class SkipContainingThis extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public function provideData()
+    {
+        $mock = $this->createMock(SomeClassToMock::class);
+
+        yield 'thing generated' => [$mock];
+    }
+}

--- a/tests/Rector/Class_/StaticDataProviderClassMethodRector/Source/SomeClassToMock.php
+++ b/tests/Rector/Class_/StaticDataProviderClassMethodRector/Source/SomeClassToMock.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\StaticDataProviderClassMethodRector\Source;
+
+class SomeClassToMock {}


### PR DESCRIPTION
closes https://github.com/rectorphp/rector/issues/7872