### PR TITLE
Ensure isFirstClassCallable() before getArgs() on other rules

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,7 +28,7 @@ parameters:
         # rector co-variant
         - '#Parameter \#1 \$node (.*?) of method Rector\\(.*?)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\PhpRectorInterface\:\:refactor\(\)#'
 
-        - '#Cognitive complexity for "Rector\\PHPUnit\\Rector\\ClassMethod\\CreateMockToAnonymousClassRector\:\:refactor\(\)" is 23, keep it under 9#'
+        - '#Cognitive complexity for "Rector\\PHPUnit\\Rector\\ClassMethod\\CreateMockToAnonymousClassRector\:\:refactor\(\)" is 25, keep it under 9#'
 
         - '#Cognitive complexity for "Rector\\PHPUnit\\Rector\\MethodCall\\DelegateExceptionArgumentsRector\:\:refactor\(\)" is 12, keep it under 9#'
 

--- a/src/NodeFactory/ArgumentShiftingFactory.php
+++ b/src/NodeFactory/ArgumentShiftingFactory.php
@@ -11,6 +11,10 @@ final class ArgumentShiftingFactory
 {
     public function removeAllButFirstArgMethodCall(MethodCall $methodCall, string $methodName): void
     {
+        if ($methodCall->isFirstClassCallable()) {
+            return;
+        }
+
         $methodCall->name = new Identifier($methodName);
         foreach (array_keys($methodCall->getArgs()) as $i) {
             // keep first arg

--- a/src/NodeFactory/DataProviderClassMethodFactory.php
+++ b/src/NodeFactory/DataProviderClassMethodFactory.php
@@ -22,21 +22,19 @@ final class DataProviderClassMethodFactory
 
         $classMethod = $method->getNode();
 
-        if (! $dataProviderClassMethodRecipe->isFirstClassCallable()) {
-            foreach ($dataProviderClassMethodRecipe->getArgs() as $arg) {
-                $value = $arg->value;
-                if (! $value instanceof Array_) {
+        foreach ($dataProviderClassMethodRecipe->getArgs() as $arg) {
+            $value = $arg->value;
+            if (! $value instanceof Array_) {
+                continue;
+            }
+
+            foreach ($value->items as $arrayItem) {
+                if (! $arrayItem instanceof ArrayItem) {
                     continue;
                 }
 
-                foreach ($value->items as $arrayItem) {
-                    if (! $arrayItem instanceof ArrayItem) {
-                        continue;
-                    }
-
-                    $returnStatement = new Yield_(new Array_([new ArrayItem($arrayItem->value)]));
-                    $classMethod->stmts[] = new Expression($returnStatement);
-                }
+                $returnStatement = new Yield_(new Array_([new ArrayItem($arrayItem->value)]));
+                $classMethod->stmts[] = new Expression($returnStatement);
             }
         }
 

--- a/src/NodeFactory/DataProviderClassMethodFactory.php
+++ b/src/NodeFactory/DataProviderClassMethodFactory.php
@@ -22,19 +22,21 @@ final class DataProviderClassMethodFactory
 
         $classMethod = $method->getNode();
 
-        foreach ($dataProviderClassMethodRecipe->getArgs() as $arg) {
-            $value = $arg->value;
-            if (! $value instanceof Array_) {
-                continue;
-            }
-
-            foreach ($value->items as $arrayItem) {
-                if (! $arrayItem instanceof ArrayItem) {
+        if (! $dataProviderClassMethodRecipe->isFirstClassCallable()) {
+            foreach ($dataProviderClassMethodRecipe->getArgs() as $arg) {
+                $value = $arg->value;
+                if (! $value instanceof Array_) {
                     continue;
                 }
 
-                $returnStatement = new Yield_(new Array_([new ArrayItem($arrayItem->value)]));
-                $classMethod->stmts[] = new Expression($returnStatement);
+                foreach ($value->items as $arrayItem) {
+                    if (! $arrayItem instanceof ArrayItem) {
+                        continue;
+                    }
+
+                    $returnStatement = new Yield_(new Array_([new ArrayItem($arrayItem->value)]));
+                    $classMethod->stmts[] = new Expression($returnStatement);
+                }
             }
         }
 

--- a/src/NodeFactory/ExpectExceptionCodeFactory.php
+++ b/src/NodeFactory/ExpectExceptionCodeFactory.php
@@ -24,6 +24,10 @@ final class ExpectExceptionCodeFactory
             return null;
         }
 
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
         $secondArgument = $methodCall->getArgs()[1]
 ->value;
         if (! $secondArgument instanceof MethodCall) {

--- a/src/NodeFactory/ExpectExceptionFactory.php
+++ b/src/NodeFactory/ExpectExceptionFactory.php
@@ -23,6 +23,10 @@ final class ExpectExceptionFactory
             return null;
         }
 
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
         $argumentVariableName = $this->nodeNameResolver->getName($methodCall->getArgs()[1]->value);
         if ($argumentVariableName === null) {
             return null;

--- a/src/NodeFactory/ExpectExceptionMessageFactory.php
+++ b/src/NodeFactory/ExpectExceptionMessageFactory.php
@@ -26,6 +26,10 @@ final class ExpectExceptionMessageFactory
             return null;
         }
 
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
         $secondArgument = $methodCall->getArgs()[1]
 ->value;
         if (! $secondArgument instanceof MethodCall) {

--- a/src/NodeFactory/ExpectExceptionMessageRegExpFactory.php
+++ b/src/NodeFactory/ExpectExceptionMessageRegExpFactory.php
@@ -28,7 +28,7 @@ final class ExpectExceptionMessageRegExpFactory
         }
 
         if ($methodCall->isFirstClassCallable()) {
-            return;
+            return null;
         }
 
         $secondArgument = $methodCall->getArgs()[1]

--- a/src/NodeFactory/ExpectExceptionMessageRegExpFactory.php
+++ b/src/NodeFactory/ExpectExceptionMessageRegExpFactory.php
@@ -27,6 +27,10 @@ final class ExpectExceptionMessageRegExpFactory
             return null;
         }
 
+        if ($methodCall->isFirstClassCallable()) {
+            return;
+        }
+
         $secondArgument = $methodCall->getArgs()[1]
 ->value;
         if (! $secondArgument instanceof MethodCall) {

--- a/src/NodeManipulator/ArgumentMover.php
+++ b/src/NodeManipulator/ArgumentMover.php
@@ -11,6 +11,10 @@ final class ArgumentMover
 {
     public function removeFirst(MethodCall|StaticCall $node): void
     {
+        if ($node->isFirstClassCallable()) {
+            return;
+        }
+
         $methodArguments = $node->getArgs();
         array_shift($methodArguments);
 

--- a/src/Rector/ClassMethod/CreateMockToAnonymousClassRector.php
+++ b/src/Rector/ClassMethod/CreateMockToAnonymousClassRector.php
@@ -125,6 +125,10 @@ CODE_SAMPLE
                         continue;
                     }
 
+                    if ($methodCall->isFirstClassCallable()) {
+                        continue;
+                    }
+
                     // has dynamic return?
                     if ($hasDynamicReturnExprs === false) {
                         $returnedExpr = $methodCall->getArgs()[0]
@@ -146,6 +150,11 @@ CODE_SAMPLE
             // change to anonymous class
             /** @var MethodCall $methodCall */
             $methodCall = $createMockMethodCallAssign->expr;
+
+            if ($methodCall->isFirstClassCallable()) {
+                continue;
+            }
+
             $firstArg = $methodCall->getArgs()[0];
 
             $mockExpr = $createMockMethodCallAssign->var;

--- a/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
+++ b/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
@@ -180,7 +180,7 @@ CODE_SAMPLE
         }
 
         if ($methodCall->isFirstClassCallable()) {
-            return null;
+            return;
         }
 
         if (count($methodCall->getArgs()) !== 1) {

--- a/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
+++ b/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
@@ -179,6 +179,10 @@ CODE_SAMPLE
             return;
         }
 
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
         if (count($methodCall->getArgs()) !== 1) {
             throw new ShouldNotHappenException();
         }

--- a/src/Rector/Class_/ProphecyPHPDocRector.php
+++ b/src/Rector/Class_/ProphecyPHPDocRector.php
@@ -139,6 +139,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
         return $expr->getArgs()[0];
     }
 

--- a/src/Rector/Foreach_/SimplifyForeachInstanceOfRector.php
+++ b/src/Rector/Foreach_/SimplifyForeachInstanceOfRector.php
@@ -70,6 +70,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
         if (! $this->nodeComparator->areNodesEqual($node->valueVar, $expr->getArgs()[1]->value)) {
             return null;
         }

--- a/src/Rector/MethodCall/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertCompareToSpecificMethodRector.php
@@ -85,6 +85,10 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         // we need 2 args
         if (! isset($node->args[1])) {
             return null;

--- a/src/Rector/MethodCall/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertComparisonToSpecificMethodRector.php
@@ -95,6 +95,10 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof BinaryOp) {

--- a/src/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
+++ b/src/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
@@ -89,6 +89,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         // 1. refactor to "assertEqualsIgnoringCase()"
         $newMethodCall = $this->processAssertEqualsIgnoringCase($node);
         if ($newMethodCall !== null) {

--- a/src/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/src/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -78,6 +78,10 @@ final class AssertEqualsToSameRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $args = $node->getArgs();
         if (! isset($args[0])) {
             return null;

--- a/src/Rector/MethodCall/AssertFalseStrposToContainsRector.php
+++ b/src/Rector/MethodCall/AssertFalseStrposToContainsRector.php
@@ -63,6 +63,10 @@ final class AssertFalseStrposToContainsRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if ($firstArgumentValue instanceof StaticCall) {

--- a/src/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/src/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -70,6 +70,10 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof Instanceof_) {

--- a/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -81,6 +81,10 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         // is property access

--- a/src/Rector/MethodCall/AssertNotOperatorRector.php
+++ b/src/Rector/MethodCall/AssertNotOperatorRector.php
@@ -63,6 +63,10 @@ final class AssertNotOperatorRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof BooleanNot) {

--- a/src/Rector/MethodCall/AssertPropertyExistsRector.php
+++ b/src/Rector/MethodCall/AssertPropertyExistsRector.php
@@ -81,6 +81,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof FuncCall) {

--- a/src/Rector/MethodCall/AssertRegExpRector.php
+++ b/src/Rector/MethodCall/AssertRegExpRector.php
@@ -85,6 +85,10 @@ final class AssertRegExpRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         /** @var FuncCall|Node $secondArgumentValue */
         $secondArgumentValue = $node->getArgs()[1]
 ->value;

--- a/src/Rector/MethodCall/AssertResourceToClosedResourceRector.php
+++ b/src/Rector/MethodCall/AssertResourceToClosedResourceRector.php
@@ -68,6 +68,10 @@ final class AssertResourceToClosedResourceRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (! isset($node->getArgs()[0])) {
             return null;
         }

--- a/src/Rector/MethodCall/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertSameBoolNullToSpecificMethodRector.php
@@ -66,6 +66,10 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof ConstFetch) {

--- a/src/Rector/MethodCall/AssertSameTrueFalseToAssertTrueFalseRector.php
+++ b/src/Rector/MethodCall/AssertSameTrueFalseToAssertTrueFalseRector.php
@@ -81,6 +81,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArg = $node->getArgs()[0];
 
         if ($this->valueResolver->isTrue($firstArg->value)) {

--- a/src/Rector/MethodCall/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -90,6 +90,10 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractRe
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof FuncCall) {

--- a/src/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -79,6 +79,10 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (! isset($node->args[0])) {
             return null;
         }

--- a/src/Rector/MethodCall/ExplicitPhpErrorApiRector.php
+++ b/src/Rector/MethodCall/ExplicitPhpErrorApiRector.php
@@ -107,6 +107,10 @@ CODE_SAMPLE
         string $exceptionClass,
         string $explicitMethod
     ): ?Node {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (! isset($node->getArgs()[0])) {
             return null;
         }

--- a/src/Rector/MethodCall/RemoveExpectAnyFromMockRector.php
+++ b/src/Rector/MethodCall/RemoveExpectAnyFromMockRector.php
@@ -83,6 +83,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (count($node->args) !== 1) {
             return null;
         }

--- a/src/Rector/MethodCall/SpecificAssertContainsRector.php
+++ b/src/Rector/MethodCall/SpecificAssertContainsRector.php
@@ -85,6 +85,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (! $this->isPossiblyStringType($node->getArgs()[1]->value)) {
             return null;
         }

--- a/src/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
+++ b/src/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
@@ -86,6 +86,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         // when second argument is string: do nothing
         $secondArgType = $this->getType($node->getArgs()[1]->value);
         if ($secondArgType instanceof StringType) {

--- a/src/Rector/MethodCall/SpecificAssertInternalTypeRector.php
+++ b/src/Rector/MethodCall/SpecificAssertInternalTypeRector.php
@@ -100,6 +100,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $typeNode = $node->getArgs()[0]
 ->value;
         if (! $typeNode instanceof String_) {

--- a/src/Rector/MethodCall/UseSpecificWillMethodRector.php
+++ b/src/Rector/MethodCall/UseSpecificWillMethodRector.php
@@ -95,6 +95,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $callArgs = $node->getArgs();
         if (! $callArgs[0]->value instanceof MethodCall) {
             return null;

--- a/src/Rector/MethodCall/UseSpecificWithMethodRector.php
+++ b/src/Rector/MethodCall/UseSpecificWithMethodRector.php
@@ -83,6 +83,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         foreach ($node->getArgs() as $i => $argNode) {
             if (! $argNode->value instanceof MethodCall) {
                 continue;

--- a/src/Rector/StaticCall/GetMockRector.php
+++ b/src/Rector/StaticCall/GetMockRector.php
@@ -88,6 +88,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         // narrow args to one
         if (count($node->args) > 1) {
             $node->args = [$node->getArgs()[0]];


### PR DESCRIPTION
@TomasVotruba same with 

- https://github.com/rectorphp/rector-src/pull/4049

this is to ensure no crash on first class callable again.