### PR TITLE
[PreferPHPUnitThisCallRector] Skip current and child funct fixes #8008

### DIFF
--- a/src/Rector/Class_/PreferPHPUnitThisCallRector.php
+++ b/src/Rector/Class_/PreferPHPUnitThisCallRector.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Type\ObjectType;
+use PhpParser\NodeTraverser;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -75,10 +75,13 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
-        $isStatic = false;
-        $this->traverseNodesWithCallable($node, function (Node $node) use (&$hasChanged, &$isStatic): ?MethodCall {
-            $isStatic = ($isStatic) || ($node instanceof ClassMethod && $node->isStatic()) || ($node instanceof Closure && $node->static);
-            if (! $node instanceof StaticCall || $isStatic) {
+        $this->traverseNodesWithCallable($node, function (Node $node) use (&$hasChanged): int|null|MethodCall {
+            $isStatic = ($node instanceof ClassMethod && $node->isStatic()) || ($node instanceof Closure && $node->static);
+            if ($isStatic) {
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if (! $node instanceof StaticCall) {
                 return null;
             }
 
@@ -88,10 +91,6 @@ CODE_SAMPLE
             }
 
             if (! $this->isNames($node->class, ['static', 'self'])) {
-                return null;
-            }
-
-            if (! $this->isObjectType($node->class, new ObjectType('PHPUnit\Framework\TestCase'))) {
                 return null;
             }
 

--- a/tests/Rector/Class_/PreferPHPUnitThisCallRector/Fixture/replace_none_static_skip_static_function.php.inc
+++ b/tests/Rector/Class_/PreferPHPUnitThisCallRector/Fixture/replace_none_static_skip_static_function.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\PreferPHPUnitThisCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ReplaceNoneStaticSkipStaticFunction extends TestCase
+{
+    public function testMe()
+    {
+        self::assertSame(1, 1);
+    }
+
+    public static function testMe2()
+    {
+        self::assertSame(1, 1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\PreferPHPUnitThisCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ReplaceNoneStaticSkipStaticFunction extends TestCase
+{
+    public function testMe()
+    {
+        $this->assertSame(1, 1);
+    }
+
+    public static function testMe2()
+    {
+        self::assertSame(1, 1);
+    }
+}
+
+?>


### PR DESCRIPTION
This should fix: https://github.com/rectorphp/rector-phpunit/pull/194#discussion_r1234849677

I removed:
```php
if (! $this->isObjectType($node->class, new ObjectType('PHPUnit\Framework\TestCase'))) {
    return null;
}
```
Because we already check if we are in test case on line 73 `if (! $this->testsNodeAnalyzer->isInTestClass($node)) {` and i thought it was unnecessary to do this extra check.
And i got
 ``` 
src/Rector/Class_/PreferPHPUnitThisCallRector.php:72
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Cognitive complexity for "Rector\\PHPUnit\\Rector\\Class_\\PreferPHPUnitThisCallRector\:\:refactor\(\)" is 11, keep it under 10#'
``` 
from PHPStan