### PR TITLE
Add PropertyExistsWithoutAssertRector

### DIFF
--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\PHPUnit\Rector\MethodCall\PropertyExistsWithoutAssertRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/annotations-to-attributes.php');
 
-    $rectorConfig->rules([StaticDataProviderClassMethodRector::class]);
+    $rectorConfig->rules([StaticDataProviderClassMethodRector::class, PropertyExistsWithoutAssertRector::class]);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 49 Rules Overview
+# 50 Rules Overview
 
 ## AddDoesNotPerformAssertionToNonAssertingTestRector
 
@@ -730,6 +730,21 @@ Changes PHPUnit calls from self::assert*() to `$this->assert*()`
 +        $this->assertEquals('expected', $result);
      }
  }
+```
+
+<br>
+
+## PropertyExistsWithoutAssertRector
+
+Turns PHPUnit TestCase assertObjectHasAttribute into `property_exists` comparisons
+
+- class: [`Rector\PHPUnit\Rector\MethodCall\PropertyExistsWithoutAssertRector`](../src/Rector/MethodCall/PropertyExistsWithoutAssertRector.php)
+
+```diff
+-$this->assertClassHasAttribute("property", "Class");
+-$this->assertClassNotHasAttribute("property", "Class");
++$this->assertFalse(property_exists(new Class, "property"));
++$this->assertTrue(property_exists(new Class, "property"));
 ```
 
 <br>

--- a/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
+++ b/src/Rector/Class_/ArrayArgumentToDataProviderRector.php
@@ -288,7 +288,6 @@ CODE_SAMPLE
             /** @var string $paramName */
             $paramName = $this->getName($paramAndArg->getVariable());
 
-            /** @var TypeNode $staticTypeNode */
             $staticTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($staticType);
 
             $paramTagValueNode = $this->createParamTagNode($paramName, $staticTypeNode);

--- a/src/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
+++ b/src/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\Rector\MethodCall\PropertyExistsWithoutAssertRector\PropertyExistsWithoutAssertRectorTest
+ */
+final class PropertyExistsWithoutAssertRector extends AbstractRector
+{
+    /**
+     * @var array<string, string>
+     */
+    private const RENAME_METHODS_WITH_OBJECT_MAP = [
+        'assertObjectHasAttribute' => 'assertTrue',
+        'assertObjectNotHasAttribute' => 'assertFalse',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const RENAME_METHODS_WITH_CLASS_MAP = [
+        'assertClassHasAttribute' => 'assertTrue',
+        'assertClassNotHasAttribute' => 'assertFalse',
+    ];
+
+    public function __construct(
+        private readonly IdentifierManipulator $identifierManipulator,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Turns PHPUnit TestCase assertObjectHasAttribute into `property_exists` comparisons',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$this->assertClassHasAttribute("property", "Class");
+$this->assertClassNotHasAttribute("property", "Class");
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$this->assertFalse(property_exists(new Class, "property"));
+$this->assertTrue(property_exists(new Class, "property"));
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, [
+            'assertClassHasAttribute',
+            'assertClassNotHasAttribute',
+            'assertObjectNotHasAttribute',
+            'assertObjectHasAttribute',
+        ])) {
+            return null;
+        }
+
+        $arguments = array_column($node->args, 'value');
+        if (
+            $arguments[0] instanceof String_ ||
+            $arguments[0] instanceof Variable ||
+            $arguments[0] instanceof ArrayDimFetch ||
+            $arguments[0] instanceof PropertyFetch
+        ) {
+            $secondArg = $arguments[0];
+        } else {
+            return null;
+        }
+
+        if ($arguments[1] instanceof Variable) {
+            $firstArg = new Variable($arguments[1]->name);
+            $map = self::RENAME_METHODS_WITH_OBJECT_MAP;
+        } elseif ($arguments[1] instanceof String_) {
+            $firstArg = new New_(new FullyQualified($arguments[1]->value));
+            $map = self::RENAME_METHODS_WITH_CLASS_MAP;
+        } elseif ($arguments[1] instanceof PropertyFetch || $arguments[1] instanceof ArrayDimFetch) {
+            $firstArg = $arguments[1];
+            $map = self::RENAME_METHODS_WITH_OBJECT_MAP;
+        } else {
+            return null;
+        }
+
+        unset($node->args[0]);
+        unset($node->args[1]);
+
+        $propertyExistsFuncCall = new FuncCall(new Name('property_exists'), [
+            new Arg($firstArg),
+            new Arg($secondArg),
+        ]);
+
+        $newArgs = $this->nodeFactory->createArgs([$propertyExistsFuncCall]);
+
+        $node->args = $this->appendArgs($newArgs, $node->getArgs());
+        $this->identifierManipulator->renameNodeWithMap($node, $map);
+
+        return $node;
+    }
+}

--- a/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyTest1 extends TestCase
+{
+    public function test()
+    {
+        $this->assertClassHasAttribute('property', 'stdClass');
+        $this->assertClassNotHasAttribute('property', 'Namespaced\stdClass', 'message');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyTest1 extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(property_exists(new \stdClass(), 'property'));
+        $this->assertFalse(property_exists(new \Namespaced\stdClass(), 'property'), 'message');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture2.php.inc
+++ b/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture2.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+final class MyTest2 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $response = new \Namespaced\Response();
+        $this->assertObjectNotHasAttribute('property', $response);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+final class MyTest2 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $response = new \Namespaced\Response();
+        $this->assertFalse(property_exists($response, 'property'));
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture3.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+final class MyTest3 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertObjectHasAttribute('property', $object->data);
+        $this->assertObjectNotHasAttribute('property', $object->data);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+final class MyTest3 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(property_exists($object->data, 'property'));
+        $this->assertFalse(property_exists($object->data, 'property'));
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture4.php.inc
+++ b/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture4.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+final class MyTest4 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertObjectHasAttribute($property, $object);
+        $this->assertObjectNotHasAttribute($property, $object);
+        $this->assertObjectHasAttribute($property[0], $object);
+        $this->assertObjectNotHasAttribute($property[1], $object);
+        $this->assertObjectHasAttribute($property->name, $object);
+        $this->assertObjectNotHasAttribute($property[1]->name, $object);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertPropertyExistsRector\Fixture;
+
+final class MyTest4 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(property_exists($object, $property));
+        $this->assertFalse(property_exists($object, $property));
+        $this->assertTrue(property_exists($object, $property[0]));
+        $this->assertFalse(property_exists($object, $property[1]));
+        $this->assertTrue(property_exists($object, $property->name));
+        $this->assertFalse(property_exists($object, $property[1]->name));
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/PropertyExistsWithoutAssertRectorTest.php
+++ b/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/PropertyExistsWithoutAssertRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\PropertyExistsWithoutAssertRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PropertyExistsWithoutAssertRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/PropertyExistsWithoutAssertRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Rector\MethodCall\PropertyExistsWithoutAssertRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(PropertyExistsWithoutAssertRector::class);
+};


### PR DESCRIPTION
Removes the now deprecated property/method exists PHPUnit assertions and
replaces them with plain PHP equivalents.
