### PR TITLE
[DX] Merge 9.1 set to PHPUnit 10, to keep it simple and major-only as all other sets

### DIFF
--- a/config/sets/level/up-to-phpunit-91.php
+++ b/config/sets/level/up-to-phpunit-91.php
@@ -3,10 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
-use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(PHPUnitSetList::PHPUNIT_91);
-    $rectorConfig->import(PHPUnitLevelSetList::UP_TO_PHPUNIT_90);
 };

--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -3,11 +3,45 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Rector\Class_\AddProphecyTraitRector;
 use Rector\PHPUnit\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\Rector\MethodCall\PropertyExistsWithoutAssertRector;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/annotations-to-attributes.php');
 
     $rectorConfig->rules([StaticDataProviderClassMethodRector::class, PropertyExistsWithoutAssertRector::class]);
+
+    $rectorConfig->rule(AddProphecyTraitRector::class);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        // https://github.com/sebastianbergmann/phpunit/issues/4087
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertRegExp', 'assertMatchesRegularExpression'),
+        // https://github.com/sebastianbergmann/phpunit/issues/4090
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotRegExp', 'assertDoesNotMatchRegularExpression'),
+        // https://github.com/sebastianbergmann/phpunit/issues/4078
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotExists', 'assertFileDoesNotExist'),
+        // https://github.com/sebastianbergmann/phpunit/issues/4081
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotIsReadable', 'assertFileIsNotReadable'),
+        // https://github.com/sebastianbergmann/phpunit/issues/4072
+        new MethodCallRename(
+            'PHPUnit\Framework\Assert',
+            'assertDirectoryNotIsReadable',
+            'assertDirectoryIsNotReadable'
+        ),
+        // https://github.com/sebastianbergmann/phpunit/issues/4075
+        new MethodCallRename(
+            'PHPUnit\Framework\Assert',
+            'assertDirectoryNotIsWritable',
+            'assertDirectoryIsNotWritable'
+        ),
+        // https://github.com/sebastianbergmann/phpunit/issues/4069
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertDirectoryNotExists', 'assertDirectoryDoesNotExist'),
+        // https://github.com/sebastianbergmann/phpunit/issues/4066
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsWritable', 'assertIsNotWritable'),
+        // https://github.com/sebastianbergmann/phpunit/issues/4063
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsReadable', 'assertIsNotReadable'),
+    ]);
 };

--- a/config/sets/phpunit91.php
+++ b/config/sets/phpunit91.php
@@ -3,39 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Rector\Class_\AddProphecyTraitRector;
-use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
-use Rector\Renaming\ValueObject\MethodCallRename;
 
+/** @deprecated Use PHPUnitSetList::PHPUNIT_10 directly */
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(AddProphecyTraitRector::class);
-
-    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
-        // https://github.com/sebastianbergmann/phpunit/issues/4087
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertRegExp', 'assertMatchesRegularExpression'),
-        // https://github.com/sebastianbergmann/phpunit/issues/4090
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotRegExp', 'assertDoesNotMatchRegularExpression'),
-        // https://github.com/sebastianbergmann/phpunit/issues/4078
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotExists', 'assertFileDoesNotExist'),
-        // https://github.com/sebastianbergmann/phpunit/issues/4081
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotIsReadable', 'assertFileIsNotReadable'),
-        // https://github.com/sebastianbergmann/phpunit/issues/4072
-        new MethodCallRename(
-            'PHPUnit\Framework\Assert',
-            'assertDirectoryNotIsReadable',
-            'assertDirectoryIsNotReadable'
-        ),
-        // https://github.com/sebastianbergmann/phpunit/issues/4075
-        new MethodCallRename(
-            'PHPUnit\Framework\Assert',
-            'assertDirectoryNotIsWritable',
-            'assertDirectoryIsNotWritable'
-        ),
-        // https://github.com/sebastianbergmann/phpunit/issues/4069
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertDirectoryNotExists', 'assertDirectoryDoesNotExist'),
-        // https://github.com/sebastianbergmann/phpunit/issues/4066
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsWritable', 'assertIsNotWritable'),
-        // https://github.com/sebastianbergmann/phpunit/issues/4063
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsReadable', 'assertIsNotReadable'),
-    ]);
 };

--- a/src/Set/PHPUnitLevelSetList.php
+++ b/src/Set/PHPUnitLevelSetList.php
@@ -38,6 +38,7 @@ final class PHPUnitLevelSetList implements SetListInterface
 
     /**
      * @var string
+     * @deprecated Use PHPUnitSetList::PHPUNIT_10 directly
      */
     public const UP_TO_PHPUNIT_91 = __DIR__ . '/../../config/sets/level/up-to-phpunit-91.php';
 

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -47,6 +47,7 @@ final class PHPUnitSetList implements SetListInterface
     public const PHPUNIT_90 = __DIR__ . '/../../config/sets/phpunit90.php';
 
     /**
+     * @deprecated Use PHPUnitSetList::PHPUNIT_10 directly
      * @var string
      */
     public const PHPUNIT_91 = __DIR__ . '/../../config/sets/phpunit91.php';


### PR DESCRIPTION
This address issue from https://github.com/rectorphp/rector-phpunit/pull/206

The sets should always target only the major version, as PHPUnit is quite a small package with well done BC compatibility. Splitting sets into minor version would create extreeme complexity. Let's make it simple instead :)