### PR TITLE
[DX] Remove appendArgs() usage on rector-phpunit rules

### DIFF
--- a/rules/CodeQuality/Rector/MethodCall/AssertComparisonToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertComparisonToSpecificMethodRector.php
@@ -147,7 +147,7 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
 
         unset($oldArguments[0]);
         $newArgs = [$firstArgument, $secondArgument];
-        $node->args = $this->appendArgs($newArgs, $oldArguments);
+        $node->args = array_merge($newArgs, $oldArguments);
     }
 
     private function isConstantValue(Expr $expr): bool

--- a/rules/CodeQuality/Rector/MethodCall/AssertFalseStrposToContainsRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertFalseStrposToContainsRector.php
@@ -101,7 +101,7 @@ final class AssertFalseStrposToContainsRector extends AbstractRector
         unset($oldArguments[0]);
 
         $newArgs = [$firstArgument, $secondArgument];
-        $node->args = $this->appendArgs($newArgs, $oldArguments);
+        $node->args = array_merge($newArgs, $oldArguments);
 
         return $node;
     }

--- a/rules/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -169,7 +169,7 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
         unset($oldArgs[0]);
 
         $newArgs = $this->nodeFactory->createArgs([new String_($name), $propertyFetch->var]);
-        $node->args = $this->appendArgs($newArgs, $oldArgs);
+        $node->args = array_merge($newArgs, $oldArgs);
         return $node;
     }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertPropertyExistsRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE
         unset($node->args[0]);
 
         $newArgs = $this->nodeFactory->createArgs([$secondArgument->value->value, $secondArg]);
-        $node->args = $this->appendArgs($newArgs, $node->getArgs());
+        $node->args = array_merge($newArgs, $node->getArgs());
 
         $this->identifierManipulator->renameNodeWithMap($node, $map);
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -203,15 +203,15 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
             && count($funcCallOrEmptyNodeArgs) === 3) {
             unset($funcCallOrEmptyNodeArgs[2]);
 
-            return $this->appendArgs($funcCallOrEmptyNodeArgs, $oldArguments);
+            return array_merge($funcCallOrEmptyNodeArgs, $oldArguments);
         }
 
         if ($funcCallOrEmptyNodeName === 'is_a') {
             $newArgs = [$funcCallOrEmptyNodeArgs[1], $funcCallOrEmptyNodeArgs[0]];
 
-            return $this->appendArgs($newArgs, $oldArguments);
+            return array_merge($newArgs, $oldArguments);
         }
 
-        return $this->appendArgs($funcCallOrEmptyNodeArgs, $oldArguments);
+        return array_merge($funcCallOrEmptyNodeArgs, $oldArguments);
     }
 }

--- a/rules/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
+++ b/rules/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
@@ -126,7 +126,7 @@ CODE_SAMPLE
 
         $newArgs = $this->nodeFactory->createArgs([$propertyExistsFuncCall]);
 
-        $node->args = $this->appendArgs($newArgs, $node->getArgs());
+        $node->args = array_merge($newArgs, $node->getArgs());
         $this->identifierManipulator->renameNodeWithMap($node, $map);
 
         return $node;


### PR DESCRIPTION
Use native `array_merge()` instead, after all removed, we can remove the `appendArgs()` method from `AbstractRector`.