### PR TITLE
[PhpUnit90] Return null on no change on ExplicitPhpErrorApiRector

### DIFF
--- a/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
     /**
      * @param MethodCall|StaticCall $node
      */
-    public function refactor(Node $node): ?Node
+    public function refactor(Node $node): null|MethodCall|StaticCall
     {
         if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, ['expectException'])) {
             return null;
@@ -106,7 +106,7 @@ CODE_SAMPLE
         MethodCall|StaticCall $node,
         string $exceptionClass,
         string $explicitMethod
-    ): ?Node {
+    ): null|MethodCall|StaticCall {
         if ($node->isFirstClassCallable()) {
             return null;
         }

--- a/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
             }
         }
 
-        return $node;
+        return null;
     }
 
     private function replaceExceptionWith(


### PR DESCRIPTION
The applied change return null already in line 98 under loop

https://github.com/rectorphp/rector-phpunit/blob/3b48901693f0d960790af65f73b36b36436badd0/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php#L95-L98