### PR TITLE
Fix typo

### DIFF
--- a/src/Rector/Class_/PreferPHPUnitSelfCallRector.php
+++ b/src/Rector/Class_/PreferPHPUnitSelfCallRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if (! $this->nodeNameResolver->matchesStringName($node->name->toString(), 'assert*')) {
+            if (! $this->nodeNameResolver->matchesStringName($methodName, 'assert*')) {
                 return null;
             }
 

--- a/src/Rector/Class_/PreferPHPUnitSelfCallRector.php
+++ b/src/Rector/Class_/PreferPHPUnitSelfCallRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if (! $this->nodeNameResolver->matchesStringName($node->name, 'assert*')) {
+            if (! $this->nodeNameResolver->matchesStringName($node->name->toString(), 'assert*')) {
                 return null;
             }
 


### PR DESCRIPTION
should fix 
```
TypeError: Rector\NodeNameResolver\NodeNameResolver::matchesStringName(): Argument #1 ($resolvedName) must be of type string, PhpParser\Node\Identifier given, called in /home/runner/work/rector-src/rector-src/src/Rector/Class_/PreferPHPUnitSelfCallRector.php on line 94

```

followup to https://github.com/rectorphp/rector-phpunit/pull/248