### PR TITLE
[NodeAnalyzer] Fix crash on set returnType on setUp() method on ConstructClassMethodToSetUpTestCaseRector

### DIFF
--- a/src/NodeAnalyzer/SetUpMethodDecorator.php
+++ b/src/NodeAnalyzer/SetUpMethodDecorator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\NodeAnalyzer;
 
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\ValueObject\MethodName;
@@ -31,6 +32,11 @@ final class SetUpMethodDecorator
             return;
         }
 
-        $classMethod->returnType = $setUpClassMethod->returnType;
+        if ($setUpClassMethod->returnType instanceof Identifier) {
+            $classMethod->returnType = new Identifier($setUpClassMethod->returnType->toString());
+            return;
+        }
+
+        $classMethod->returnType = null;
     }
 }


### PR DESCRIPTION
@Knallcharge this should fix https://github.com/rectorphp/rector/issues/8188

The `Identifier` must be rebuild for bring Node assign from `AstResolver`.