### PR TITLE
 [CodeQualitiy] Use str_ends_with instead of isName(, '*Test') 

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/some_test.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/some_test.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/some_test.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/some_test.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Fixture;
-
-class SomeTest extends \PHPUnit\Framework\TestCase
-{
-}

--- a/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/some_test.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/some_test.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+}

--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -16,7 +16,6 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\Naming\TestClassNameResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\AddSeeTestAnnotationRectorTest

--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -116,7 +116,7 @@ CODE_SAMPLE
     private function shouldSkipClass(Class_ $class): bool
     {
         // we are in the test case
-        if ($this->isName($class, '*Test')) {
+        if (str_ends_with($class->name->toString(), 'Test')) {
             return true;
         }
 

--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
@@ -15,6 +16,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\Naming\TestClassNameResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\AddSeeTestAnnotationRectorTest
@@ -115,8 +117,12 @@ CODE_SAMPLE
 
     private function shouldSkipClass(Class_ $class): bool
     {
+        if ($class->isAnonymous()) {
+            return true;
+        }
+
         // we are in the test case
-        if (str_ends_with($class->name->toString(), 'Test')) {
+        if ($class->name instanceof Identifier && str_ends_with($class->name->toString(), 'Test')) {
             return true;
         }
 


### PR DESCRIPTION
@TomasVotruba @staabm here based on https://github.com/rectorphp/rector-src/pull/4980#issuecomment-1713784117