### PR TITLE
Move betterNodeFinder,valueResolver,phpDocInfoFactory dependencies from AbstractRector into rules

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -54,4 +54,5 @@ return static function (RectorConfig $rectorConfig): void {
         'PHPUnit\Framework\*',
         'Prophecy\Prophet',
     ]);
+    $rectorConfig->rule(\Rector\Utils\Rector\MoveAbstractRectorToChildrenRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -54,5 +54,4 @@ return static function (RectorConfig $rectorConfig): void {
         'PHPUnit\Framework\*',
         'Prophecy\Prophet',
     ]);
-    $rectorConfig->rule(\Rector\Utils\Rector\MoveAbstractRectorToChildrenRector::class);
 };

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
@@ -11,6 +11,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -33,6 +34,7 @@ final class DataProviderAnnotationToAttributeRector extends AbstractRector imple
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -30,6 +31,7 @@ final class DependsAnnotationWithValueToAttributeRector extends AbstractRector i
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -32,7 +33,8 @@ final class TestWithAnnotationToAttributeRector extends AbstractRector implement
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly PhpDocTagRemover $phpDocTagRemover,
-        private readonly DocBlockUpdater $docBlockUpdater
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
@@ -156,7 +156,7 @@ CODE_SAMPLE
             return $genericTagValueNode->value;
         }
 
-        $originalValue = strtolower((string) $genericTagValueNode->value);
+        $originalValue = strtolower($genericTagValueNode->value);
         return $valueMap[$originalValue];
     }
 }

--- a/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
@@ -36,6 +37,7 @@ final class AnnotationWithValueToAttributeRector extends AbstractRector implemen
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 
@@ -154,7 +156,7 @@ CODE_SAMPLE
             return $genericTagValueNode->value;
         }
 
-        $originalValue = strtolower($genericTagValueNode->value);
+        $originalValue = strtolower((string) $genericTagValueNode->value);
         return $valueMap[$originalValue];
     }
 }

--- a/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -30,7 +31,8 @@ final class CoversAnnotationWithValueToAttributeRector extends AbstractRector im
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
-        private readonly DocBlockUpdater $docBlockUpdater
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/AnnotationsToAttributes/Rector/Class_/TicketAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/TicketAnnotationToAttributeRector.php
@@ -16,6 +16,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPUnit\Framework\Attributes\Ticket;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -34,6 +35,7 @@ final class TicketAnnotationToAttributeRector extends AbstractRector implements 
     public function __construct(
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -23,6 +24,7 @@ final class ReplaceTestAnnotationWithPrefixedFunctionRector extends AbstractRect
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 
@@ -90,7 +92,7 @@ CODE_SAMPLE
         $this->phpDocTagRemover->removeByName($phpDocInfo, 'test');
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
-        $node->name->name = 'test' . ucfirst($node->name->name);
+        $node->name->name = 'test' . ucfirst((string) $node->name->name);
 
         return $node;
     }

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
         $this->phpDocTagRemover->removeByName($phpDocInfo, 'test');
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
-        $node->name->name = 'test' . ucfirst((string) $node->name->name);
+        $node->name->name = 'test' . ucfirst($node->name->name);
 
         return $node;
     }

--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -11,6 +11,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -33,6 +34,7 @@ final class AddSeeTestAnnotationRector extends AbstractRector
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly TestClassNameResolver $testClassNameResolver,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/CodeQuality/Rector/Class_/YieldDataProviderRector.php
+++ b/rules/CodeQuality/Rector/Class_/YieldDataProviderRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\NodeTransformer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -31,6 +32,7 @@ final class YieldDataProviderRector extends AbstractRector
         private readonly NodeTransformer $nodeTransformer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertRegExpRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertRegExpRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\LNumber;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -44,7 +45,8 @@ final class AssertRegExpRector extends AbstractRector
     private const ASSERT_NOT_EQUALS = 'assertNotEquals';
 
     public function __construct(
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertSameTrueFalseToAssertTrueFalseRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertSameTrueFalseToAssertTrueFalseRector.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\ArgumentMover;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -20,7 +21,8 @@ final class AssertSameTrueFalseToAssertTrueFalseRector extends AbstractRector
 {
     public function __construct(
         private readonly ArgumentMover $argumentMover,
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/PHPUnit100/Rector/Class_/AddProphecyTraitRector.php
+++ b/rules/PHPUnit100/Rector/Class_/AddProphecyTraitRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\TraitUse;
 use PHPStan\Reflection\ClassReflection;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -32,6 +33,7 @@ final class AddProphecyTraitRector extends AbstractRector
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/rules/PHPUnit100/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/rules/PHPUnit100/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
@@ -24,6 +25,7 @@ final class StaticDataProviderClassMethodRector extends AbstractRector
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,
         private readonly VisibilityManipulator $visibilityManipulator,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
@@ -31,6 +32,7 @@ final class AddDoesNotPerformAssertionToNonAssertingTestRector extends AbstractR
         private readonly MockedVariableAnalyzer $mockedVariableAnalyzer,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/PHPUnit60/Rector/ClassMethod/ExceptionAnnotationRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/ExceptionAnnotationRector.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\PHPUnit60\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -40,6 +41,7 @@ final class ExceptionAnnotationRector extends AbstractRector
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/PHPUnit80/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
+++ b/rules/PHPUnit80/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\PHPUnit80\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFactory\AssertCallFactory;
@@ -24,7 +25,8 @@ final class AssertEqualsParameterToSpecificMethodsTypeRector extends AbstractRec
 {
     public function __construct(
         private readonly AssertCallFactory $assertCallFactory,
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Type\StringType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -31,7 +32,8 @@ final class SpecificAssertContainsWithoutIdentityRector extends AbstractRector
     ];
 
     public function __construct(
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/src/Rector/StmtsAwareInterface/WithConsecutiveRector.php
+++ b/src/Rector/StmtsAwareInterface/WithConsecutiveRector.php
@@ -17,6 +17,7 @@ use PhpParser\Node\MatchArm;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -30,7 +31,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class WithConsecutiveRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder
     ) {
     }
 


### PR DESCRIPTION
Ref
 
- https://github.com/rectorphp/rector-src/pull/5051
- https://github.com/rectorphp/rector-src/pull/5052
- https://github.com/rectorphp/rector-src/pull/5053