### PR TITLE
PHPUnit10 Attributes

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -378,12 +378,12 @@ Change covers annotations with value to attribute
 - * @covers SomeClass
 - */
 +#[CoversClass(SomeClass::class)]
++#[CoversFunction('someFunction')]
  final class SomeTest extends TestCase
  {
 -    /**
--     * @covers ::someFunction
+-     * @covers ::someFunction()
 -     */
-+    #[CoversFunction('someFunction')]
      public function test()
      {
      }
@@ -479,13 +479,11 @@ Change depends annotations with value to attribute
  final class SomeTest extends TestCase
  {
      public function testOne() {}
-     public function testTwo() {}
+
 -    /**
 -     * @depends testOne
--     * @depends testTwo
 -     */
 +    #[\PHPUnit\Framework\Attributes\Depends('testOne')]
-+    #[\PHPUnit\Framework\Attributes\Depends('testTwo')]
      public function testThree(): void
      {
      }

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class_default.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class_default.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass
+ * @covers ::__construct
+ */
+final class CoversClassDefault extends TestCase
+{
+    /**
+     * @covers ::foo
+     * @covers \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\HelperClass
+     */
+    public function testFoo()
+    {
+    }
+
+    /**
+     * @covers ::bar
+     * @covers \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\HelperClass
+     */
+    public function testBar()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
+#[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\HelperClass::class)]
+final class CoversClassDefault extends TestCase
+{
+    public function testFoo()
+    {
+    }
+
+    public function testBar()
+    {
+    }
+}
+
+?>

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
@@ -4,19 +4,16 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers ::someFunction()
+ */
 final class CoversFunction extends TestCase
 {
-    /**
-     * @covers ::someFunction()
-     */
-    public function testOne()
+    public function testOne(): void
     {
     }
 
-    /**
-     * @covers ::someFunction()
-     */
-    public function testTwo()
+    public function testTwo(): void
     {
     }
 }
@@ -32,11 +29,11 @@ use PHPUnit\Framework\TestCase;
 #[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
 final class CoversFunction extends TestCase
 {
-    public function testOne()
+    public function testOne(): void
     {
     }
 
-    public function testTwo()
+    public function testTwo(): void
     {
     }
 }

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
@@ -22,9 +22,9 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
 final class CoversFunction extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
     public function test()
     {
     }

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function.php.inc
@@ -9,7 +9,14 @@ final class CoversFunction extends TestCase
     /**
      * @covers ::someFunction()
      */
-    public function test()
+    public function testOne()
+    {
+    }
+
+    /**
+     * @covers ::someFunction()
+     */
+    public function testTwo()
     {
     }
 }
@@ -25,7 +32,11 @@ use PHPUnit\Framework\TestCase;
 #[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
 final class CoversFunction extends TestCase
 {
-    public function test()
+    public function testOne()
+    {
+    }
+
+    public function testTwo()
     {
     }
 }

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function_method.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_function_method.php.inc
@@ -4,15 +4,18 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers ::someFunction()
- */
-final class CoversFunction extends TestCase
+final class CoversFunctionMethod extends TestCase
 {
+    /**
+     * @covers ::someFunction()
+     */
     public function testOne(): void
     {
     }
 
+    /**
+     * @covers ::someFunction()
+     */
     public function testTwo(): void
     {
     }
@@ -27,7 +30,7 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 use PHPUnit\Framework\TestCase;
 
 #[\PHPUnit\Framework\Attributes\CoversFunction('someFunction')]
-final class CoversFunction extends TestCase
+final class CoversFunctionMethod extends TestCase
 {
     public function testOne(): void
     {

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_method.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_method.php.inc
@@ -22,9 +22,9 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
 final class CoversMethod extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
     public function test()
     {
     }

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Source/ExistingClass.php
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Source/ExistingClass.php
@@ -5,5 +5,15 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 
 final class ExistingClass
 {
+    public function __construct()
+    {
+    }
 
+    public function foo(): void
+    {
+    }
+
+    public function bar(): void
+    {
+    }
 }

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Source/HelperClass.php
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Source/HelperClass.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source;
+
+final class HelperClass
+{
+}

--- a/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -48,7 +48,7 @@ use PHPUnit\Framework\TestCase;
 final class SomeTest extends TestCase
 {
     /**
-     * @covers ::someFunction
+     * @covers ::someFunction()
      */
     public function test()
     {
@@ -63,9 +63,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 
 #[CoversClass(SomeClass::class)]
+#[CoversFunction('someFunction')]
 final class SomeTest extends TestCase
 {
-    #[CoversFunction('someFunction')]
     public function test()
     {
     }
@@ -137,8 +137,9 @@ CODE_SAMPLE
         $phpDocInfo          = $this->phpDocInfoFactory->createFromNode($node);
         if ($phpDocInfo instanceof PhpDocInfo) {
             $coversDefaultGroups = $this->handleCoversDefaultClass($phpDocInfo);
-            $hasCoversDefault    = count($coversDefaultGroups) > 0;
-            $coversGroups        = $this->handleCovers($phpDocInfo, $hasCoversDefault);
+            // If there is a ::coversDefaultClass, @covers ::function will refer to class methods, otherwise it will refer to global functions.
+            $hasCoversDefault = count($coversDefaultGroups) > 0;
+            $coversGroups     = $this->handleCovers($phpDocInfo, $hasCoversDefault);
         }
 
         foreach ($node->getMethods() as $methodNode) {

--- a/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -208,8 +208,6 @@ CODE_SAMPLE
             } elseif (!$hasCoversDefault && str_starts_with($covers, '::')) {
                 $attributeGroups[$covers] = $this->createAttributeGroup($covers);
             }
-
-            $attributeGroups[$covers] = $this->createAttributeGroup($covers);
         }
 
         return $attributeGroups;

--- a/tests/Issues/DoubleAnnotation/Fixture/some_test.php.inc
+++ b/tests/Issues/DoubleAnnotation/Fixture/some_test.php.inc
@@ -8,7 +8,7 @@ use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRect
 final class SomeTest extends TestCase
 {
     /**
-     * @covers SomeClass::method
+     * @covers \SomeClass::method
      * @dataProvider generatorInput
      */
     public function testSomething(mixed $expected)
@@ -29,10 +29,10 @@ namespace Rector\PHPUnit\Tests\Issues\DoubleAnnotation\Fixture;
 use PHPUnit\Framework\TestCase;
 use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector\Fixture\SomeClass;
 
+#[\PHPUnit\Framework\Attributes\CoversClass(\SomeClass::class)]
 final class SomeTest extends TestCase
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('generatorInput')]
-    #[\PHPUnit\Framework\Attributes\CoversClass(SomeClass::method)]
     public function testSomething(mixed $expected)
     {
         $this->assertSame($expected, 'actual');


### PR DESCRIPTION
Changed refactors done in `CoversAnnotationWithValueToAttributeRector.php` so that
- [CoversClass](https://github.com/sebastianbergmann/phpunit/blob/main/src/Framework/Attributes/CoversClass.php), [CoversFunction](https://github.com/sebastianbergmann/phpunit/blob/main/src/Framework/Attributes/CoversFunction.php)  attributes are added on class level (in accordance with their respective `#[Attribute ... ]` values). 
- `@covers` annotations are removed from method level
- Duplicate covers attributes are unified
- `@coversDefault` is converted to a `CoversClass` attribute
