### PR TITLE
Remove codeCoverageIgnore from annotations to attributes set

### DIFF
--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -88,7 +88,6 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('afterClass', 'PHPUnit\Framework\Attributes\AfterClass'),
         new AnnotationToAttribute('before', 'PHPUnit\Framework\Attributes\Before'),
         new AnnotationToAttribute('beforeClass', 'PHPUnit\Framework\Attributes\BeforeClass'),
-        new AnnotationToAttribute('codeCoverageIgnore', 'PHPUnit\Framework\Attributes\CodeCoverageIgnore'),
         new AnnotationToAttribute('coversNothing', 'PHPUnit\Framework\Attributes\CoversNothing'),
         new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
         new AnnotationToAttribute('large', 'PHPUnit\Framework\Attributes\Large'),


### PR DESCRIPTION
This is no longer deprecated as of 10.4 https://github.com/sebastianbergmann/phpunit/blob/10.4/ChangeLog-10.4.md#changed.