### PR TITLE
Replace deprecated methods from phpunit issue 5062

### DIFF
--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -65,5 +65,31 @@ return static function (RectorConfig $rectorConfig): void {
 
         // https://github.com/sebastianbergmann/phpunit/pull/3687
         new MethodCallRename('PHPUnit\Framework\MockObject\MockBuilder', 'setMethods', 'onlyMethods'),
+
+        //https://github.com/sebastianbergmann/phpunit/issues/5062
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectDeprecationMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectDeprecationMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectNoticeMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectNoticeMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectWarningMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectWarningMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectErrorMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectErrorMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
     ]);
 };


### PR DESCRIPTION
On issue https://github.com/sebastianbergmann/phpunit/issues/5062 was deprecated few methods.

then I am applying the replacement for methods that has other method to substitute.


you can check here in this file: https://github.com/sebastianbergmann/phpunit/blob/9.6/src/Framework/TestCase.php