### PR TITLE
Feature/287 Move DataProviderArrayItemsNewLinedRector to rector-phpunit repository

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -8,6 +8,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCase
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\TestWithToDataProviderRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\RemoveEmptyTestMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector;
 use Rector\PHPUnit\CodeQuality\Rector\Foreach_\SimplifyForeachInstanceOfRector;
@@ -42,6 +43,7 @@ return static function (RectorConfig $rectorConfig): void {
         ReplaceTestAnnotationWithPrefixedFunctionRector::class,
         TestWithToDataProviderRector::class,
         AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector::class,
+        DataProviderArrayItemsNewlinedRector::class,
 
         // specific asserts
         AssertCompareToSpecificMethodRector::class,

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 49 Rules Overview
+# 51 Rules Overview
 
 ## AddDoesNotPerformAssertionToNonAssertingTestRector
 
@@ -159,7 +159,7 @@ Change `assertNotEmpty()` on an object to more clear `assertInstanceof()`
 
 Change `assertEquals()/assertSame()` method using float on expected argument to new specific alternatives.
 
-- class: [`Rector\PHPUnit\Transform\AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector`](../rules/CodeQuality/Rector/MethodCall/AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector.php)
+- class: [`Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector`](../rules/CodeQuality/Rector/MethodCall/AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector.php)
 
 ```diff
 -$this->assertSame(10.20, $value);
@@ -479,6 +479,38 @@ Change dataProvider annotations to attribute
 +    #[\PHPUnit\Framework\Attributes\DataProvider('test')]
      public function test(): void
      {
+     }
+ }
+```
+
+<br>
+
+## DataProviderArrayItemsNewLinedRector
+
+Change data provider in PHPUnit test case to newline per item
+
+- class: [`Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector`](../rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php)
+
+```diff
+ use PHPUnit\Framework\TestCase;
+
+ final class ImageBinaryTest extends TestCase
+ {
+     /**
+      * @dataProvider provideData()
+      */
+     public function testGetBytesSize(string $content, int $number): void
+     {
+         // ...
+     }
+
+     public static function provideData(): array
+     {
+-        return [['content', 8], ['content123', 11]];
++        return [
++            ['content', 8],
++            ['content123', 11]
++        ];
      }
  }
 ```
@@ -990,6 +1022,39 @@ Change `@testWith()` annotation to #[TestWith] attribute
      public function test(): void
      {
      }
+ }
+```
+
+<br>
+
+## TestWithToDataProviderRector
+
+Replace testWith annotation to data provider.
+
+- class: [`Rector\PHPUnit\CodeQuality\Rector\Class_\TestWithToDataProviderRector`](../rules/CodeQuality/Rector/Class_/TestWithToDataProviderRector.php)
+
+```diff
++public function dataProviderSum()
++{
++    return [
++        [0, 0, 0],
++        [0, 1, 1],
++        [1, 0, 1],
++        [1, 1, 3]
++    ];
++}
++
+ /**
+- * @testWith    [0, 0, 0]
+- * @testWith    [0, 1, 1]
+- * @testWith    [1, 0, 1]
+- * @testWith    [1, 1, 3]
++ * @dataProvider dataProviderSum
+  */
+-public function testSum(int $a, int $b, int $expected)
++public function test(int $a, int $b, int $expected)
+ {
+     $this->assertSame($expected, $a + $b);
  }
 ```
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/DataProviderArrayItemsNewLinedRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/DataProviderArrayItemsNewLinedRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DataProviderArrayItemsNewLinedRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/Fixture/fixture.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function dataProviderFoo()
+    {
+        return [[1], [2], [3]];
+    }
+
+    /**
+     * @dataProvider dataProviderFoo
+     */
+    public function testFoo(int $value)
+    {
+        $this->assertGreaterThan(0, $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function dataProviderFoo()
+    {
+        return [
+            [1],
+            [2],
+            [3],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderFoo
+     */
+    public function testFoo(int $value)
+    {
+        $this->assertGreaterThan(0, $value);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([DataProviderArrayItemsNewLinedRector::class]);
+};

--- a/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector\DataProviderArrayItemsNewLinedRectorTest
+ */
+final class DataProviderArrayItemsNewLinedRector extends AbstractRector
+{
+    public function __construct(
+        /**
+         * @readonly
+         */
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        /**
+         * @readonly
+         */
+        private readonly BetterNodeFinder $betterNodeFinder
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change data provider in PHPUnit test case to newline per item', [new CodeSample(
+            <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class ImageBinaryTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function testGetBytesSize(string $content, int $number): void
+    {
+        // ...
+    }
+
+    public static function provideData(): array
+    {
+        return [['content', 8], ['content123', 11]];
+    }
+}
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class ImageBinaryTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function testGetBytesSize(string $content, int $number): void
+    {
+        // ...
+    }
+
+    public static function provideData(): array
+    {
+        return [
+            ['content', 8],
+            ['content123', 11]
+        ];
+    }
+}
+CODE_SAMPLE
+        )]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->isPublic()) {
+            return null;
+        }
+
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        // skip test methods
+        if (str_starts_with($node->name->toString(), 'test')) {
+            return null;
+        }
+
+        // find array in data provider - must contain a return node
+        /** @var Return_[] $returns */
+        $returns = $this->betterNodeFinder->findInstanceOf((array) $node->stmts, Return_::class);
+        $hasChanged = \false;
+        foreach ($returns as $return) {
+            if (! $return->expr instanceof Array_) {
+                continue;
+            }
+
+            $array = $return->expr;
+            if ($array->items === []) {
+                continue;
+            }
+
+            // ensure newlined printed
+            $array->setAttribute(AttributeKey::NEWLINED_ARRAY_PRINT, \true);
+            // invoke reprint
+            $array->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $hasChanged = \true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
- Move `DataProviderArrayItemsNewLinedRector` from rector repository.
- Add test for DataProviderArrayItemsNewLinedRector
- Add group rule set for coding style

after this PR pass I will remove the rule from rector repository.

Issue #287