### PR TITLE
Fix/272 Strict phpunit10 feature for php 81

### DIFF
--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
@@ -16,7 +16,7 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
-use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -82,7 +82,13 @@ CODE_SAMPLE
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::ATTRIBUTES;
+        /**
+         * This rule just work for phpunit 10,
+         * And as php 8.1 is the min version supported by phpunit 10, then we decided to let this version as minimum.
+         *
+         * You can see more detail in this issue: https://github.com/rectorphp/rector-phpunit/issues/272
+         */
+        return PhpVersion::PHP_81;
     }
 
     /**

--- a/src/Rector/StmtsAwareInterface/WithConsecutiveRector.php
+++ b/src/Rector/StmtsAwareInterface/WithConsecutiveRector.php
@@ -22,7 +22,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -125,7 +125,13 @@ CODE_SAMPLE
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::MATCH_EXPRESSION;
+        /**
+         * This rule just work for phpunit 10,
+         * And as php 8.1 is the min version supported by phpunit 10, then we decided to let this version as minimum.
+         *
+         * You can see more detail in this issue: https://github.com/rectorphp/rector-phpunit/issues/272
+         */
+        return PhpVersion::PHP_81;
     }
 
     /**


### PR DESCRIPTION
`DataProviderAnnotationToAttributeRector.php` and `WithConsecutiveRector.php` just work for phpunit10, But as there isn't the possibility to strict rules by `phpunit version`, then I am changing for the minimum version supported for phpunit10 (php 8.1)

Close #272