### PR TITLE
[CodeQuality] Skip inline comment on DataProviderArrayItemsNewLinedRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/Fixture/skip_comment_inline.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector/Fixture/skip_comment_inline.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\DataProviderArrayItemsNewlinedRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipCommentInline extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @dataProvider provideData2()
+     * @dataProvider provideData3()
+     * @dataProvider provideData4()
+     */
+    public function testGetBytesSize(string $content, int $number): void
+    {
+        // ...
+    }
+
+    public function provideData(): array
+    {
+        return [
+            ['content123', 11], // a comment inline
+        ];
+    }
+
+    public function provideData2(): array
+    {
+        return [
+            ['content123', 11], // a comment inline
+            ['content123', 12],
+        ];
+    }
+
+    public function provideData3(): array
+    {
+        return [
+            ['content123', 11],
+            ['content123', 12], // a comment inline
+        ];
+    }
+
+    public function provideData4(): array
+    {
+        return [
+            ['content123', 11], // a comment inline
+            ['content123', 12], // a comment inline
+        ];
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
@@ -6,6 +6,7 @@ namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -117,6 +118,21 @@ CODE_SAMPLE
 
             $array = $return->expr;
             if ($array->items === []) {
+                continue;
+            }
+
+            $shouldReprint = false;
+            foreach ($array->items as $key => $item) {
+                if (
+                    isset($array->items[$key+1])
+                    && $array->items[$key+1] instanceof ArrayItem
+                    && $array->items[$key+1]->getStartLine() === $item->getEndLine()) {
+                    $shouldReprint = true;
+                    break;
+                }
+            }
+
+            if (! $shouldReprint) {
                 continue;
             }
 

--- a/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
@@ -124,9 +124,9 @@ CODE_SAMPLE
             $shouldReprint = false;
             foreach ($array->items as $key => $item) {
                 if (
-                    isset($array->items[$key+1])
-                    && $array->items[$key+1] instanceof ArrayItem
-                    && $array->items[$key+1]->getStartLine() === $item->getEndLine()) {
+                    isset($array->items[$key + 1])
+                    && $array->items[$key + 1] instanceof ArrayItem
+                    && $array->items[$key + 1]->getStartLine() === $item->getEndLine()) {
                     $shouldReprint = true;
                     break;
                 }

--- a/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
@@ -121,18 +121,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $shouldReprint = false;
-            foreach ($array->items as $key => $item) {
-                if (
-                    isset($array->items[$key + 1])
-                    && $array->items[$key + 1] instanceof ArrayItem
-                    && $array->items[$key + 1]->getStartLine() === $item->getEndLine()) {
-                    $shouldReprint = true;
-                    break;
-                }
-            }
-
-            if (! $shouldReprint) {
+            if (! $this->shouldRePrint($array)) {
                 continue;
             }
 
@@ -148,5 +137,20 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function shouldRePrint(Array_ $array): bool
+    {
+        foreach ($array->items as $key => $item) {
+            if (! $item instanceof ArrayItem) {
+                continue;
+            }
+
+            if (isset($array->items[$key + 1]) && $array->items[$key + 1]->getStartLine() === $item->getEndLine()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
@@ -145,12 +145,15 @@ CODE_SAMPLE
             if (! $item instanceof ArrayItem) {
                 continue;
             }
+
             if (! isset($array->items[$key + 1])) {
                 continue;
             }
+
             if ($array->items[$key + 1]->getStartLine() !== $item->getEndLine()) {
                 continue;
             }
+
             return true;
         }
 

--- a/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DataProviderArrayItemsNewLinedRector.php
@@ -145,10 +145,13 @@ CODE_SAMPLE
             if (! $item instanceof ArrayItem) {
                 continue;
             }
-
-            if (isset($array->items[$key + 1]) && $array->items[$key + 1]->getStartLine() === $item->getEndLine()) {
-                return true;
+            if (! isset($array->items[$key + 1])) {
+                continue;
             }
+            if ($array->items[$key + 1]->getStartLine() !== $item->getEndLine()) {
+                continue;
+            }
+            return true;
         }
 
         return false;


### PR DESCRIPTION
array with inline comment should be skipped instead of re-printed, it currently produce invalid change:

```diff
     public function provideData(): array
     {
         return [
-            ['content123', 11], // a comment inline
+            ['content123', 11],
```