### PR TITLE
setMethods call has been removed in PHPUnit 10

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -27,7 +27,6 @@ use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameBoolNullToSpecificMet
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameTrueFalseToAssertTrueFalseRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveExpectAnyFromMockRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWithMethodRector;
 
@@ -71,7 +70,6 @@ return static function (RectorConfig $rectorConfig): void {
          * @see https://steemit.com/php/@crell/don-t-use-mocking-libraries
          * @see https://davegebler.com/post/php/better-php-unit-testing-avoiding-mocks
          */
-        RemoveSetMethodsMethodCallRector::class,
         RemoveExpectAnyFromMockRector::class,
     ]);
 };

--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\AddProphecyTraitRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;
@@ -19,6 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
         PropertyExistsWithoutAssertRector::class,
         AddProphecyTraitRector::class,
         WithConsecutiveRector::class,
+        RemoveSetMethodsMethodCallRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [


### PR DESCRIPTION
Deprecated in PPHPUnit 8.3 see: https://github.com/sebastianbergmann/phpunit/commit/d618fa3fda437421264dcfa1413a474f306f79c4

Fixes #292