### PR TITLE
RemoveSetMethodsMethodCallRector: move tests and classes to new location

### DIFF
--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\AddProphecyTraitRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;
+use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 use Rector\PHPUnit\Rector\StmtsAwareInterface\WithConsecutiveRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;

--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
+use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\AddProphecyTraitRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -790,7 +790,7 @@ Remove `expect($this->any())` from mocks as it has no added value
 
 Remove `"setMethods()"` method as never used
 
-- class: [`Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector`](../rules/CodeQuality/Rector/MethodCall/RemoveSetMethodsMethodCallRector.php)
+- class: [`Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector`](../rules/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector.php)
 
 ```diff
  use PHPUnit\Framework\TestCase;

--- a/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/Fixture/keep_unrelated_set_methods.php.inc
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/Fixture/keep_unrelated_set_methods.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture;
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture;
 
 use PHPUnit\Framework\TestCase;
 

--- a/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/Fixture/some_class.php.inc
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/Fixture/some_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture;
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture;
 
 use PHPUnit\Framework\TestCase;
 use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture\SomeClass;
@@ -19,7 +19,7 @@ final class SomeTest extends TestCase
 -----
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture;
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture;
 
 use PHPUnit\Framework\TestCase;
 use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector\Fixture\SomeClass;

--- a/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/RemoveSetMethodsMethodCallRectorTest.php
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/RemoveSetMethodsMethodCallRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
+use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(RemoveSetMethodsMethodCallRector::class);

--- a/rules/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector.php
+++ b/rules/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
+namespace Rector\PHPUnit\PHPUnit100\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
@@ -17,7 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://github.com/sebastianbergmann/phpunit/commit/d618fa3fda437421264dcfa1413a474f306f79c4
  * @changelog https://stackoverflow.com/questions/65075204/method-setmethods-is-deprecated-when-try-to-write-a-php-unit-test
  *
- * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector\RemoveSetMethodsMethodCallRectorTest
+ * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector\RemoveSetMethodsMethodCallRectorTest
  */
 final class RemoveSetMethodsMethodCallRector extends AbstractRector
 {


### PR DESCRIPTION
Move RemoveSetMethodsMethodCallRector and its tests to correct namespace.

As per: https://github.com/rectorphp/rector-phpunit/pull/293#issuecomment-1806286903