### PR TITLE
[PhpUnit60] Handle before stmt execute to test on DelegateExceptionArgumentsRector

### DIFF
--- a/rules-tests/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector/Fixture/before_test_stmt.php.inc
+++ b/rules-tests/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector/Fixture/before_test_stmt.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector\Fixture;
+
+final class BeforeTestStmt extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->setExpectedException('SecondException', $message);
+        $this->execute();
+    }
+
+    private function execute()
+    {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector\Fixture;
+
+final class BeforeTestStmt extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->expectException('SecondException');
+        $this->expectExceptionMessage($message);
+        $this->execute();
+    }
+
+    private function execute()
+    {}
+}
+
+?>

--- a/rules-tests/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector/Fixture/before_test_stmt_with_code.php.inc
+++ b/rules-tests/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector/Fixture/before_test_stmt_with_code.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector\Fixture;
+
+final class BeforeTestStmtWithCode extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->setExpectedException('SecondException', $message, 101);
+        $this->execute();
+    }
+
+    private function execute()
+    {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector\Fixture;
+
+final class BeforeTestStmtWithCode extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->expectException('SecondException');
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(101);
+        $this->execute();
+    }
+
+    private function execute()
+    {}
+}
+
+?>

--- a/rules/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
         $hasChanged = false;
         $oldMethodNames = array_keys(self::OLD_TO_NEW_METHOD);
 
-        foreach ($node->stmts as $stmt) {
+        foreach ($node->stmts as $key => $stmt) {
             if (! $stmt instanceof Expression) {
                 continue;
             }
@@ -109,21 +109,20 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (isset($call->args[1])) {
-                $extraCall = $this->createFirstArgExtraMethodCall($call);
-                $node->stmts[] = new Expression($extraCall);
-
-                unset($call->args[1]);
-            }
-
             // add exception code method call
             if (isset($call->args[2])) {
                 $extraCall = $this->assertCallFactory->createCallWithName($call, 'expectExceptionCode');
                 $extraCall->args[] = $call->args[2];
-
-                $node->stmts[] = new Expression($extraCall);
+                array_splice($node->stmts, $key + 1, 0, [new Expression($extraCall)]);
 
                 unset($call->args[2]);
+            }
+
+            if (isset($call->args[1])) {
+                $extraCall = $this->createFirstArgExtraMethodCall($call);
+                array_splice($node->stmts, $key + 1, 0, [new Expression($extraCall)]);
+
+                unset($call->args[1]);
             }
 
             $hasChanged = true;


### PR DESCRIPTION
It currently add `expectExceptionMessage()` after test part, it should be immediate after `expectException()`

```diff
There was 1 failure:

1) Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector\DelegateExceptionArgumentsRectorTest::test with data set #1
Failed on fixture file "before_test_stmt.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
     public function test()
     {
         $this->expectException('SecondException');
+        $this->execute();
         $this->expectExceptionMessage($message);
-        $this->execute();
     }
 
     private function execute()
```

Ref https://getrector.com/demo/d1033af1-10a9-4406-ab5e-775bef099e4f