### PR TITLE
[PHPUnit 10] Handle DataProvider attribute not included on use PHPUnitSetList::PHPUNIT_100

### DIFF
--- a/tests/Issues/PHPUnit10DataProvider/Fixture/some_test.php.inc
+++ b/tests/Issues/PHPUnit10DataProvider/Fixture/some_test.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\PHPUnit\Tests\Issues\PHPUnit10DataProvider\Fixture;
 
-final class SomeTest
+final class SomeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
@@ -24,10 +24,10 @@ final class SomeTest
 
 namespace Rector\PHPUnit\Tests\Issues\PHPUnit10DataProvider\Fixture;
 
-final class SomeTest
+final class SomeTest extends \PHPUnit\Framework\TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
     #[\PHPUnit\Framework\Attributes\DataProvider('fooProvider')]
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_should_do_stuff(string $foo): void
     {
     }

--- a/tests/Issues/PHPUnit10DataProvider/Fixture/some_test.php.inc
+++ b/tests/Issues/PHPUnit10DataProvider/Fixture/some_test.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Issues\PHPUnit10DataProvider\Fixture;
+
+final class SomeTest
+{
+    /**
+     * @test
+     * @dataProvider fooProvider
+     */
+    public function it_should_do_stuff(string $foo): void
+    {
+    }
+
+    public static function fooProvider(): array
+    {
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Issues\PHPUnit10DataProvider\Fixture;
+
+final class SomeTest
+{
+    #[\PHPUnit\Framework\Attributes\Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('fooProvider')]
+    public function it_should_do_stuff(string $foo): void
+    {
+    }
+
+    public static function fooProvider(): array
+    {
+        return [];
+    }
+}
+
+?>

--- a/tests/Issues/PHPUnit10DataProvider/PHPUnit10DataProviderTest.php
+++ b/tests/Issues/PHPUnit10DataProvider/PHPUnit10DataProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Issues\PHPUnit10DataProvider;
+
+use Iterator;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PHPUnit10DataProviderTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/PHPUnit10DataProvider/config/configured_rule.php
+++ b/tests/Issues/PHPUnit10DataProvider/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        PHPUnitSetList::PHPUNIT_100,
+    ]);
+};

--- a/tests/Issues/PHPUnit10DataProvider/config/configured_rule.php
+++ b/tests/Issues/PHPUnit10DataProvider/config/configured_rule.php
@@ -1,10 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([
-        PHPUnitSetList::PHPUNIT_100,
-    ]);
+    $rectorConfig->sets([PHPUnitSetList::PHPUNIT_100]);
 };


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8360