### PR TITLE
[PHPUnit100] Adds the PublicDataProviderClassMethodRector rule

### DIFF
--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\AddProphecyTraitRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;
 use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
@@ -17,6 +18,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rules([
         StaticDataProviderClassMethodRector::class,
+        PublicDataProviderClassMethodRector::class,
         PropertyExistsWithoutAssertRector::class,
         AddProphecyTraitRector::class,
         WithConsecutiveRector::class,

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 51 Rules Overview
+# 52 Rules Overview
 
 ## AddDoesNotPerformAssertionToNonAssertingTestRector
 
@@ -708,6 +708,34 @@ Turns PHPUnit TestCase assertObjectHasAttribute into `property_exists` compariso
 -$this->assertClassNotHasAttribute("property", "Class");
 +$this->assertFalse(property_exists(new Class, "property"));
 +$this->assertTrue(property_exists(new Class, "property"));
+```
+
+<br>
+
+## PublicDataProviderClassMethodRector
+
+Change data provider methods to public
+
+- class: [`Rector\PHPUnit\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector`](../rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php)
+
+```diff
+ use PHPUnit\Framework\TestCase;
+
+ final class SomeTest extends TestCase
+ {
+     /**
+      * @dataProvider provideData()
+      */
+     public function test()
+     {
+     }
+
+-    protected static function provideData()
++    public static function provideData()
+     {
+         yield [1];
+     }
+ }
 ```
 
 <br>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/cover_no_bracket_name.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/cover_no_bracket_name.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CoverNoBracketName extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test()
+    {
+    }
+
+    protected function provideData()
+    {
+        yield [1];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CoverNoBracketName extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test()
+    {
+    }
+
+    public function provideData()
+    {
+        yield [1];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/handle_abstract_data_provider.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/handle_abstract_data_provider.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class HandleAbstractDataProvider extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test()
+    {
+    }
+
+    protected abstract function provideData();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class HandleAbstractDataProvider extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test()
+    {
+    }
+
+    abstract public function provideData();
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/multiple_data_providers.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/multiple_data_providers.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MultipleDataProviders extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     * @dataProvider provideMoreData()
+     */
+    public function test()
+    {
+    }
+
+    protected function provideData()
+    {
+        yield [1];
+    }
+
+    protected function provideMoreData()
+    {
+        yield [1];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MultipleDataProviders extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     * @dataProvider provideMoreData()
+     */
+    public function test()
+    {
+    }
+
+    public function provideData()
+    {
+        yield [1];
+    }
+
+    public function provideMoreData()
+    {
+        yield [1];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/respect_parent_abstract_class.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/respect_parent_abstract_class.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source\AnotherAbstractClass;
+
+final class RespectParentAbstractClass extends AnotherAbstractClass
+{
+    protected function dataProvider(): array
+    {
+        return [
+            [1, 2],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source\AnotherAbstractClass;
+
+final class RespectParentAbstractClass extends AnotherAbstractClass
+{
+    public function dataProvider(): array
+    {
+        return [
+            [1, 2],
+        ];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/respect_parent_data_provider.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/respect_parent_data_provider.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source\AbstractClassWithDataProvider;
+
+final class RespectParentDataProvider extends AbstractClassWithDataProvider
+{
+    protected function provideData(): array
+    {
+        return [[1, 2]];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source\AbstractClassWithDataProvider;
+
+final class RespectParentDataProvider extends AbstractClassWithDataProvider
+{
+    public function provideData(): array
+    {
+        return [[1, 2]];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/skip_already_public.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/skip_already_public.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipAlreadyStatic extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public function provideData()
+    {
+        yield [1];
+    }
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/some_class.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Fixture/some_class.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    protected function provideData()
+    {
+        yield [1];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public function provideData()
+    {
+        yield [1];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/PublicDataProviderClassMethodRectorTest.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/PublicDataProviderClassMethodRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PublicDataProviderClassMethodRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Source/AbstractClassWithDataProvider.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Source/AbstractClassWithDataProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractClassWithDataProvider extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(): void
+    {
+
+    }
+
+    abstract protected function provideData(): array;
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Source/AnotherAbstractClass.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Source/AnotherAbstractClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AnotherAbstractClass extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testWithDataProvider($value1, $value2): void
+    {
+
+    }
+
+    abstract protected function dataProvider(): array;
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Source/SomeClassToMock.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/Source/SomeClassToMock.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\Source;
+
+class SomeClassToMock {}

--- a/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(PublicDataProviderClassMethodRector::class);
+};

--- a/rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php
+++ b/rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php
@@ -112,14 +112,6 @@ CODE_SAMPLE
 
     private function skipMethod(ClassMethod $classMethod): bool
     {
-        if ($classMethod->isPublic()) {
-            return true;
-        }
-
-        if ($classMethod->stmts === null) {
-            return false;
-        }
-
-        return false;
+        return $classMethod->isPublic();
     }
 }

--- a/rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php
+++ b/rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit100\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\PublicDataProviderClassMethodRectorTest
+ */
+final class PublicDataProviderClassMethodRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,
+        private readonly VisibilityManipulator $visibilityManipulator,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change data provider methods to public', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    protected static function provideData()
+    {
+        yield [1];
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [1];
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        // 1. find all data providers
+        $dataProviderClassMethods = $this->dataProviderClassMethodFinder->find($node);
+
+        $hasChanged = false;
+
+        foreach ($dataProviderClassMethods as $dataProviderClassMethod) {
+            if ($this->skipMethod($dataProviderClassMethod)) {
+                continue;
+            }
+
+            $this->visibilityManipulator->makePublic($dataProviderClassMethod);
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function skipMethod(ClassMethod $classMethod): bool
+    {
+        if ($classMethod->isPublic()) {
+            return true;
+        }
+
+        if ($classMethod->stmts === null) {
+            return false;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
# Changes

* Adds a new rule for making data provider methods public.
* Adds a new set of tests for the rule.
* Updates docs
* Adds the rule to the PHPUnit100 config.

# Why

PHPUnit 10 expects data providers to be both Public and Static whereas before both were not a requirement. There was already a rule for static data providers but protected/private scenario hasn't been covered. For ease of use I've created a new rule rather than changing the static rule to cover both scenarios.