### PR TITLE
Remove `codeCoverageIgnore` to annotation to attribute conversion

### DIFF
--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -88,7 +88,6 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('afterClass', 'PHPUnit\Framework\Attributes\AfterClass'),
         new AnnotationToAttribute('before', 'PHPUnit\Framework\Attributes\Before'),
         new AnnotationToAttribute('beforeClass', 'PHPUnit\Framework\Attributes\BeforeClass'),
-        new AnnotationToAttribute('codeCoverageIgnore', 'PHPUnit\Framework\Attributes\CodeCoverageIgnore'),
         new AnnotationToAttribute('coversNothing', 'PHPUnit\Framework\Attributes\CoversNothing'),
         new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
         new AnnotationToAttribute('large', 'PHPUnit\Framework\Attributes\Large'),

--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -88,6 +88,9 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('afterClass', 'PHPUnit\Framework\Attributes\AfterClass'),
         new AnnotationToAttribute('before', 'PHPUnit\Framework\Attributes\Before'),
         new AnnotationToAttribute('beforeClass', 'PHPUnit\Framework\Attributes\BeforeClass'),
+        // CodeCoverageIgnore attribute is deprecated.
+        // @see https://github.com/rectorphp/rector-phpunit/pull/304
+        // new AnnotationToAttribute('codeCoverageIgnore', 'PHPUnit\Framework\Attributes\CodeCoverageIgnore'),
         new AnnotationToAttribute('coversNothing', 'PHPUnit\Framework\Attributes\CoversNothing'),
         new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
         new AnnotationToAttribute('large', 'PHPUnit\Framework\Attributes\Large'),


### PR DESCRIPTION
As described in https://github.com/sebastianbergmann/phpunit/issues/5235 and https://github.com/sebastianbergmann/phpunit/issues/5513 the `CodeCoverageIgnore` attribute was a mistake and is now deprecated, therefore Rector should not try to replace annotation with the attribute.

Fixes #303 