### PR TITLE
WithConsecutiveRector was applied only to dynamic invocations count

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1182,6 +1182,22 @@ Refactor deprecated `withConsecutive()` to `willReturnCallback()` structure
 +                    2 => [3, 4]
 +                };
 +        });
+
+-        $this->userServiceMock->expects(self::exactly(2))
++        $matcher = self::exactly(2);
++
++        $this->userServiceMock->expects($matcher)
+             ->method('prepare')
+-            ->withConsecutive(
+-                [1, 2],
+-                [3, 4],
+-            );
++            ->willReturnCallback(function () use ($matcher) {
++                return match ($matcher->numberOfInvocations()) {
++                    1 => [1, 2],
++                    2 => [3, 4]
++                };
++        });
      }
  }
 ```

--- a/tests/Rector/StmtsAwareInterface/WithConsecutiveRector/Fixture/some_class_static_invocation.php.inc
+++ b/tests/Rector/StmtsAwareInterface/WithConsecutiveRector/Fixture/some_class_static_invocation.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\StmtsAwareInterface\WithConsecutiveRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->userServiceMock->expects(self::exactly(2))
+            ->method('prepare')
+            ->withConsecutive(
+                [1, 2],
+                [3, 4],
+            );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\StmtsAwareInterface\WithConsecutiveRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $matcher = self::exactly(2);
+        $this->userServiceMock->expects($matcher)
+            ->method('prepare')->willReturnCallback(function () use ($matcher) {
+            return match ($matcher->numberOfInvocations()) {
+                1 => [1, 2],
+                2 => [3, 4],
+            };
+        });
+    }
+}
+
+?>


### PR DESCRIPTION
PR is intended to give ability to refactor withConsecutive when static invocation checker applied
 
According to PHPUnit [there is no difference between static and non-static assertions](https://docs.phpunit.de/en/10.5/assertions.html#static-vs-non-static-usage-of-assertion-methods) but it sounds like invocation count checkers have the same ability and there is no difference between self::exactly and $this->exactly