### PR TITLE
[PHPUnit][CodeQuality] Skip no arg on AssertEmptyNullableObjectToAssertInstanceofRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEmptyNullableObjectToAssertInstanceofRector/Fixture/skip_no_arg.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEmptyNullableObjectToAssertInstanceofRector/Fixture/skip_no_arg.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoArg extends TestCase
+{
+    public function test()
+    {
+        $this->assertEmpty();
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertEmptyNullableObjectToAssertInstanceofRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEmptyNullableObjectToAssertInstanceofRector.php
@@ -85,7 +85,15 @@ CODE_SAMPLE
             return null;
         }
 
-        $firstArg = $node->getArgs()[0];
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (! $firstArg instanceof Arg) {
+            return null;
+        }
+
         $firstArgType = $this->getType($firstArg->value);
 
         if (! $firstArgType instanceof UnionType) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8527 for whatever reason to not have arg on the first place, eg: different object caller.