### PR TITLE
Add `class-leak` to composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
         "check-cs": "vendor/bin/ecs check --ansi",
+        "class-leak": "vendor/bin/class-leak check config src rules",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "rector": "vendor/bin/rector process --ansi",
         "docs": "vendor/bin/rule-doc-generator generate src rules --output-file docs/rector_rules_overview.md --ansi"


### PR DESCRIPTION
- to increase its visibility
- to fix errors locally instead of seeing on GH Actions


Originally found here: https://github.com/rectorphp/rector-phpunit/pull/319#issuecomment-2017405159