### PR TITLE
 Add `complete-check` composer script same as it's done in `rectorphp/rector-src`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
         "check-cs": "vendor/bin/ecs check --ansi",
+        "class-leak": "vendor/bin/class-leak check config src rules",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "rector": "vendor/bin/rector process --ansi",
         "docs": "vendor/bin/rule-doc-generator generate src rules --output-file docs/rector_rules_overview.md --ansi"

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,14 @@
         ]
     },
     "scripts": {
+        "complete-check": [
+            "@check-cs",
+            "@class-leak",
+            "@phpstan",
+            "@rector",
+            "@docs",
+            "phpunit"
+        ],
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
         "check-cs": "vendor/bin/ecs check --ansi",
         "class-leak": "vendor/bin/class-leak check config src rules",


### PR DESCRIPTION
This is a follow up for https://github.com/rectorphp/rector-phpunit/pull/320 and should be merged after it.

Add `complete-check` composer script same as it's done in `rectorphp/rector-src`.

Example taken from:

https://github.com/rectorphp/rector-src/blob/fc250dd8da281cb79f5657d2f5d6c6c0053e54d1/composer.json#L106-L111