### PR TITLE
Reuse composer's script for `class-leak` rather than duplicate command line on GH action

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -18,7 +18,7 @@ jobs:
                 actions:
                     -
                         name: 'Active Classes'
-                        run: vendor/bin/class-leak check config src rules
+                        run: composer class-leak
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest


### PR DESCRIPTION
This is a follow up for https://github.com/rectorphp/rector-phpunit/pull/320 and related to https://github.com/rectorphp/rector-phpunit/pull/319#issuecomment-2035137884

Instead of duplicating command line on `code_analysis.yaml` action file, we can just reuse `composer class-leak` from `composer.json`.

Each time `composer class-leak` is updated, it will be automatically used on GH Action, so no need to update duplicated command twice.

Without it, we will have an issue when we start addign `--skip-type` for `vendor/bin/class-leak` in `code_analysis.yaml`. The same `--skip-type` would be added to 2 places without this PR.