### PR TITLE
AddCoversClassAttributeRector: Support *TestCase suffix

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/adds_covers_class_testcase.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/adds_covers_class_testcase.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class CalculatorTestCase extends TestCase {}
+class Calculator {}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture\Calculator::class)]
+class CalculatorTestCase extends TestCase {}
+class Calculator {}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
@@ -120,7 +120,7 @@ final class AddCoversClassAttributeRector extends AbstractRector
     {
         $classNameParts = explode('\\', $className);
         $partCount = count($classNameParts);
-        $classNameParts[$partCount - 1] = preg_replace('#Test$#', '', $classNameParts[$partCount - 1]);
+        $classNameParts[$partCount - 1] = preg_replace(['#TestCase$#', '#Test$#'], '', $classNameParts[$partCount - 1]);
 
         $possibleTestClassNames = [implode('\\', $classNameParts)];
 


### PR DESCRIPTION
In some projects (e.h. PHPUnit itself) testcase-names are ending in `TestCase` not just `Test`

running the new rector on phpunit itself yields a few false positives, e.g.

```diff
55) tests/unit/Framework/MockObject/TestDoubleTestCase.php:21

    ---------- begin diff ----------
@@ @@
 use PHPUnit\TestFixture\MockObject\InterfaceWithReturnTypeDeclaration;
 use stdClass;

+#[\PHPUnit\Framework\Attributes\CoversClass(\PHPUnit\Framework\MockObject\TestDoubleTestCase::class)]
 abstract class TestDoubleTestCase extends TestCase
 {
     final public function testMethodReturnsNullWhenReturnValueIsNullableAndNoReturnValueIsConfigured(): void
    ----------- end diff -----------

Applied rules:
 * AddCoversClassAttributeRector


56) tests/unit/Metadata/Parser/AnnotationParserTestCase.php:41

    ---------- begin diff ----------
@@ @@
 use PHPUnit\TestFixture\Metadata\Annotation\TestDoxTest;
 use PHPUnit\TestFixture\Metadata\Annotation\UsesTest;

+#[\PHPUnit\Framework\Attributes\CoversClass(\PHPUnit\Metadata\Parser\AnnotationParserTestCase::class)]
 abstract class AnnotationParserTestCase extends TestCase
 {
     public static function provideRequiresPhpTestMethods(): array
    ----------- end diff -----------

Applied rules:
 * AddCoversClassAttributeRector


57) tests/unit/Metadata/Parser/AttributeParserTestCase.php:52

    ---------- begin diff ----------
@@ @@
 use PHPUnit\TestFixture\Metadata\Attribute\UsesTest;
 use PHPUnit\TestFixture\Metadata\Attribute\WithoutErrorHandlerTest;

+#[\PHPUnit\Framework\Attributes\CoversClass(\PHPUnit\Metadata\Parser\AttributeParserTestCase::class)]
 abstract class AttributeParserTestCase extends TestCase
 {
     #[TestDox('Parses #[BackupGlobals] attribute on class')]
    ----------- end diff -----------

Applied rules:
 * AddCoversClassAttributeRector
```

refs https://github.com/rectorphp/rector-phpunit/pull/319#issuecomment-2053952839