### PR TITLE
AddCoversClassAttributeRector: skip interfaces & traits

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/skips_interfaces.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/skips_interfaces.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class MyBusinessTest extends TestCase {}
+interface MyBusiness {}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/skips_traits.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/skips_traits.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class MyTraitTest extends TestCase {}
+trait MyTrait {}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
@@ -148,6 +148,11 @@ final class AddCoversClassAttributeRector extends AbstractRector
                 continue;
             }
 
+            $classReflection = $this->reflectionProvider->getClass($className);
+            if ($classReflection->isInterface()) {
+                continue;
+            }
+
             return $className;
         }
 

--- a/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
@@ -153,6 +153,10 @@ final class AddCoversClassAttributeRector extends AbstractRector
                 continue;
             }
 
+            if ($classReflection->isTrait()) {
+                continue;
+            }
+
             return $className;
         }
 


### PR DESCRIPTION
`CoversClass` annotation should not be used with interfaces or traits

see 
- https://github.com/sebastianbergmann/phpunit/blob/53eebaa2a68b737b309ca2d4deb8fe961eb71200/src/Metadata/Api/CodeCoverage.php#L277-L284
- https://github.com/sebastianbergmann/phpunit/blob/53eebaa2a68b737b309ca2d4deb8fe961eb71200/src/Metadata/Api/CodeCoverage.php#L286-L293