### PR TITLE
AddCoversClassAttributeRector: skip abstract classes

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/skips_abstract_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/skips_abstract_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class MyAbstractClassTest extends TestCase {}
+abstract class MyAbstractClass {}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
@@ -157,6 +157,10 @@ final class AddCoversClassAttributeRector extends AbstractRector
                 continue;
             }
 
+            if ($classReflection->isAbstract()) {
+                continue;
+            }
+
             return $className;
         }
 


### PR DESCRIPTION
quoting sebastian bergmann:

> This has no effect as AttributeParserTestCase is an abstract class and only metadata on concrete test classes is used.

see https://github.com/sebastianbergmann/phpunit/pull/5814#discussion_r1568275673