### PR TITLE
Fix InstanceOfComparisonRector for variables

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/fixture.php.inc
@@ -8,7 +8,11 @@ final class MyOfComparissonTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
+        $expectedInstance = Foo::class;
+        $expectedNamespacedInstance = \Namespaced\Foo::class;
         $this->assertTrue($something instanceof Foo);
+        $this->assertTrue($something instanceof $expectedInstance);
+        $this->assertTrue($something instanceof $expectedNamespacedInstance);
         $this->assertFalse($something instanceof \Namespaced\Foo);
     }
 }
@@ -25,7 +29,11 @@ final class MyOfComparissonTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
+        $expectedInstance = Foo::class;
+        $expectedNamespacedInstance = \Namespaced\Foo::class;
         $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture\Foo::class, $something);
+        $this->assertInstanceOf($expectedInstance, $something);
+        $this->assertInstanceOf($expectedNamespacedInstance, $something);
         $this->assertNotInstanceOf(\Namespaced\Foo::class, $something);
     }
 }

--- a/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -72,9 +72,11 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
         if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, $oldMethodNames)) {
             return null;
         }
+
         if ($node->isFirstClassCallable()) {
             return null;
         }
+
         $firstArgumentValue = $node->getArgs()[0]
 ->value;
         if (! $firstArgumentValue instanceof Instanceof_) {
@@ -101,6 +103,7 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
             if ($className === null) {
                 throw new ShouldNotHappenException();
             }
+
             $firstArgument = new Arg($this->nodeFactory->createClassConstReference($className));
         } else {
             $firstArgument = new Arg($comparison->class);

--- a/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PHPStan\Type\ObjectType;
+use PhpParser\Node\Expr\Variable;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -34,7 +34,7 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
 
     public function __construct(
         private readonly IdentifierManipulator $identifierManipulator,
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {
     }
 
@@ -98,15 +98,14 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
 
         $argument = $comparison->expr;
         unset($oldArguments[0]);
-        if ($this->getType($comparison->class) instanceof ObjectType) {
+        if ($comparison->class instanceof Variable) {
+            $firstArgument = new Arg($comparison->class);
+        } else {
             $className = $this->getName($comparison->class);
             if ($className === null) {
                 throw new ShouldNotHappenException();
             }
-
             $firstArgument = new Arg($this->nodeFactory->createClassConstReference($className));
-        } else {
-            $firstArgument = new Arg($comparison->class);
         }
 
         $node->args = array_merge([$firstArgument, new Arg($argument)], $oldArguments);

--- a/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -16,7 +16,6 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-
 use function array_keys;
 use function array_merge;
 
@@ -28,7 +27,10 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
     /**
      * @var array<string, string>
      */
-    private const RENAME_METHODS_MAP = ['assertTrue' => 'assertInstanceOf', 'assertFalse' => 'assertNotInstanceOf'];
+    private const RENAME_METHODS_MAP = [
+        'assertTrue' => 'assertInstanceOf',
+        'assertFalse' => 'assertNotInstanceOf',
+    ];
 
     public function __construct(
         private readonly IdentifierManipulator $identifierManipulator,
@@ -67,14 +69,15 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
     public function refactor(Node $node): ?Node
     {
         $oldMethodNames = array_keys(self::RENAME_METHODS_MAP);
-        if (!$this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, $oldMethodNames)) {
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, $oldMethodNames)) {
             return null;
         }
         if ($node->isFirstClassCallable()) {
             return null;
         }
-        $firstArgumentValue = $node->getArgs()[0]->value;
-        if (!$firstArgumentValue instanceof Instanceof_) {
+        $firstArgumentValue = $node->getArgs()[0]
+->value;
+        if (! $firstArgumentValue instanceof Instanceof_) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -16,8 +16,6 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use function array_keys;
-use function array_merge;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\AssertInstanceOfComparisonRectorTest
@@ -105,6 +103,7 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
             if ($className === null) {
                 throw new ShouldNotHappenException();
             }
+
             $firstArgument = new Arg($this->nodeFactory->createClassConstReference($className));
         }
 


### PR DESCRIPTION
Rule `InstanceOfComparisonRector` doesn't work when we pass a variable as the second argument to operator `instanceof`. This PR fixes it.