### PR TITLE
Create a rector rule that will rename the array keys from the PHPUnit Dataprovider

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 53 Rules Overview
+# 54 Rules Overview
 
 ## AddCoversClassAttributeRector
 
@@ -671,6 +671,38 @@ Turns getMock*() methods to `createMock()`
      {
 -        $classMock = $this->getMock("Class");
 +        $classMock = $this->createMock("Class");
+     }
+ }
+```
+
+<br>
+
+## NamedArgumentForDataProviderRector
+
+Change the array-index names to the argument name of the dataProvider
+
+- class: [`Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector`](../rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php)
+
+```diff
+ use PHPUnit\Framework\TestCase;
+
+ final class SomeTest extends TestCase
+ {
+     public static function dataProviderArray(): array
+     {
+         return [
+             [
+-                'keyA' => true,
+-                'keyB' => false,
++                'changeToKeyA' => true,
++                'changeToKeyB' => false,
+             ]
+         ];
+     }
+
+     #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+     public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+     {
      }
  }
 ```

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/array.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/array.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestArray extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'keyA' => true,
+                'keyB' => false,
+            ]
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestArray extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'changeToKeyA' => true,
+                'changeToKeyB' => false,
+            ]
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/handle_missing.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/handle_missing.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestMissing extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'keyA' => true,
+                'keyB' => false,
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilterOnce(bool $changeToKeyA): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestMissing extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'changeToKeyA' => true,
+                'changeToKeyB' => false,
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilterOnce(bool $changeToKeyA): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/mixed_keys.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/mixed_keys.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestMixedKeys extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'keyA' => true,
+                false,
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestMixedKeys extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'changeToKeyA' => true,
+                "changeToKeyB" => false,
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/skip_changed_order.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/skip_changed_order.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestSkipChangedOrder extends TestCase
+{
+    public static function dataProvider(): Generator
+    {
+        yield [
+            'keyB' => false,
+            'keyA' => true,
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testFilter(bool $keyA, bool $keyB): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestSkipChangedOrder extends TestCase
+{
+    public static function dataProvider(): Generator
+    {
+        yield [
+            'keyB' => false,
+            'keyA' => true,
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testFilter(bool $keyA, bool $keyB): void
+    {
+    }
+}
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/skip_non_tests.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/skip_non_tests.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+final class SomeTestIsNotPhpUnitTest
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'keyA' => true,
+                'keyB' => false,
+            ]
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+final class SomeTestIsNotPhpUnitTest
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                'keyA' => true,
+                'keyB' => false,
+            ]
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/skip_numeric.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/skip_numeric.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestNumeric extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                true,
+                false,
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestNumeric extends TestCase
+{
+    public static function dataProviderArray(): array
+    {
+        return [
+            [
+                true,
+                false,
+            ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/unpack.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/unpack.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestResolveVariable extends TestCase
+{
+    public static function dataProvider(): array
+    {
+        $unpack = [
+            'dataProvider1' => [
+                'a' => true,
+                'b' => true,
+            ],
+        ];
+
+        return [...$unpack];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestResolveVariable extends TestCase
+{
+    public static function dataProvider(): array
+    {
+        $unpack = [
+            'dataProvider1' => [
+                'changeToKeyA' => true,
+                'changeToKeyB' => true,
+            ],
+        ];
+
+        return [...$unpack];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/yield.php.inc
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/Fixture/yield.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestYield extends TestCase
+{
+    public static function dataProvider(): Generator
+    {
+        yield [
+            'keyA' => true,
+            'keyB' => false,
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\MethodCall\NamedArgumentForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestYield extends TestCase
+{
+    public static function dataProvider(): Generator
+    {
+        yield [
+            'changeToKeyA' => true,
+            'changeToKeyB' => false,
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+    {
+    }
+}
+?>

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/NamedArgumentForDataProviderRectorTest.php
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/NamedArgumentForDataProviderRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NamedArgumentForDataProviderRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(NamedArgumentForDataProviderRector::class);
+};

--- a/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
+++ b/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit110\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\StaticDataProviderClassMethodRectorTest
+ */
+final class NamedArgumentForDataProviderRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change the array-index names to the argument name of the dataProvider',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    use PHPUnit\Framework\TestCase;
+
+                    final class SomeTest extends TestCase
+                    {
+                        public static function dataProviderArray(): array
+                        {
+                            return [
+                                [
+                                    'keyA' => true,
+                                    'keyB' => false,
+                                ]
+                            ];
+                        }
+
+                        #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+                        public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                    use PHPUnit\Framework\TestCase;
+
+                    final class SomeTest extends TestCase
+                    {
+                        public static function dataProviderArray(): array
+                        {
+                            return [
+                                [
+                                    'changeToKeyA' => true,
+                                    'changeToKeyB' => false,
+                                ]
+                            ];
+                        }
+
+                        #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderArray')]
+                        public function testFilter(bool $changeToKeyA, bool $changeToKeyB): void
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): Node|null
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        if (! $node instanceof Class_) {
+            return null;
+        }
+
+        $wasChanged = false;
+        foreach ($node->getMethods() as $classMethod) {
+            if (! $classMethod->isPublic()) {
+                continue;
+            }
+
+            if ($classMethod->getParams() === []) {
+                continue;
+            }
+
+            $dataProviderMethodName = $this->getDataProviderMethodName($classMethod);
+
+            if ($dataProviderMethodName === null) {
+                continue;
+            }
+
+            $dataProviderMethod = $node->getMethod($dataProviderMethodName);
+            if ($dataProviderMethod === null) {
+                continue;
+            }
+
+            $namedArgumentsFromTestClass = $this->getNamedArguments($classMethod);
+
+            foreach ($this->extractDataProviderArrayItem($dataProviderMethod) as $dataProviderArrayItem) {
+                $wasChanged = $this->refactorArrayKey(
+                    $dataProviderArrayItem,
+                    $namedArgumentsFromTestClass
+                ) || $wasChanged;
+            }
+        }
+
+        return $wasChanged ? $node : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getNamedArguments(ClassMethod $classMethod): array
+    {
+        $dataProviderNameMapping = [];
+        foreach ($classMethod->getParams() as $param) {
+            if ($param->var instanceof Variable) {
+                $dataProviderNameMapping[] = $this->getName($param->var);
+            }
+        }
+
+        return array_values(array_filter($dataProviderNameMapping));
+    }
+
+    /**
+     * @param list<Node\Stmt> $stmts
+     * @return array<string, Node\Expr\Array_>
+     */
+    public function getResolvedVariables(array $stmts): array
+    {
+        $variables = [];
+        foreach ($stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $stmt->expr instanceof Assign) {
+                continue;
+            }
+
+            if (! $stmt->expr->var instanceof Variable) {
+                continue;
+            }
+
+            if (! $stmt->expr->expr instanceof Array_) {
+                continue;
+            }
+
+            $variables[$this->getName($stmt->expr->var)] = $stmt->expr->expr;
+        }
+
+        return $variables;
+    }
+
+    private function getDataProviderMethodName(ClassMethod $classMethod): string|null
+    {
+        $attributeClassName = DataProvider::class;
+        foreach ($classMethod->attrGroups as $attributeGroup) {
+            foreach ($attributeGroup->attrs as $attribute) {
+                if (! $this->isName($attribute->name, $attributeClassName)) {
+                    continue;
+                }
+
+                foreach ($attribute->args as $arg) {
+                    if ($arg->value instanceof String_) {
+                        return $arg->value->value;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $dataProviderNameMapping
+     */
+    private function refactorArrayKey(Array_ $array, array $dataProviderNameMapping): bool
+    {
+        $hasChanged = false;
+        $needToSetAllKeyNames = false;
+
+        $allArrayKeyNames = [];
+
+        foreach ($array->items as $arrayItem) {
+            if ($arrayItem?->key instanceof String_) {
+                $needToSetAllKeyNames = true;
+                $allArrayKeyNames[] = $arrayItem->key->value;
+            }
+        }
+
+        // Skip already modified keys because they could be in a different order
+        if (array_intersect($dataProviderNameMapping, $allArrayKeyNames) === $dataProviderNameMapping) {
+            return false;
+        }
+
+        foreach ($array->items as $arrayIndex => $arrayItem) {
+            if ($arrayItem === null) {
+                continue;
+            }
+
+            if (! isset($dataProviderNameMapping[$arrayIndex])) {
+                continue;
+            }
+
+            if ($arrayItem->key === null && $needToSetAllKeyNames) {
+                $arrayItem->key = String_::fromString($dataProviderNameMapping[$arrayIndex]);
+            }
+
+            if ($arrayItem->key instanceof String_ && $arrayItem->key->value !== $dataProviderNameMapping[$arrayIndex]) {
+                $arrayItem->key->value = $dataProviderNameMapping[$arrayIndex];
+                $hasChanged = true;
+            }
+        }
+
+        return $hasChanged;
+    }
+
+    /**
+     * @return iterable<Node\Expr\Array_>
+     */
+    private function extractDataProviderArrayItem(ClassMethod $classMethod): iterable
+    {
+        $stmts = $classMethod->getStmts() ?? [];
+        $resolvedVariables = $this->getResolvedVariables($stmts);
+
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Expression && $stmt->expr instanceof Yield_) {
+                $arrayItem = $stmt->expr->value;
+                if ($arrayItem instanceof Array_) {
+                    yield $arrayItem;
+                }
+            }
+
+            if ($stmt instanceof Return_ && $stmt->expr instanceof Array_) {
+                $dataProviderTestCases = $stmt->expr;
+
+                foreach ($dataProviderTestCases->items as $dataProviderTestCase) {
+                    $arrayItem = $dataProviderTestCase?->value;
+
+                    if ($arrayItem instanceof Array_) {
+                        yield $arrayItem;
+                    }
+
+                    $variableName = $arrayItem === null ? null : $this->getName($arrayItem);
+                    if (
+                        $arrayItem instanceof Variable
+                        && $variableName !== null
+                        && isset($resolvedVariables[$variableName])
+                    ) {
+                        $dataProviderList = $resolvedVariables[$variableName];
+                        foreach ($dataProviderList->items as $dataProviderItem) {
+                            if ($dataProviderItem?->value instanceof Array_) {
+                                yield $dataProviderItem->value;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
+++ b/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
@@ -21,6 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @see https://github.com/sebastianbergmann/phpunit/blob/11.0.0/ChangeLog-11.0.md and https://github.com/sebastianbergmann/phpunit/pull/5225
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\StaticDataProviderClassMethodRectorTest
  */
 final class NamedArgumentForDataProviderRector extends AbstractRector
@@ -126,10 +127,9 @@ final class NamedArgumentForDataProviderRector extends AbstractRector
             $namedArgumentsFromTestClass = $this->getNamedArguments($classMethod);
 
             foreach ($this->extractDataProviderArrayItem($dataProviderMethod) as $dataProviderArrayItem) {
-                $wasChanged = $this->refactorArrayKey(
-                    $dataProviderArrayItem,
-                    $namedArgumentsFromTestClass
-                ) || $wasChanged;
+                if ($this->refactorArrayKey($dataProviderArrayItem, $namedArgumentsFromTestClass)) {
+                    $wasChanged = true;
+                }
             }
         }
 

--- a/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
+++ b/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
@@ -21,7 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see https://github.com/sebastianbergmann/phpunit/blob/11.0.0/ChangeLog-11.0.md and https://github.com/sebastianbergmann/phpunit/pull/5225
+ * @see https://github.com/sebastianbergmann/phpunit/blob/11.0.0/ChangeLog-11.0.md
+ * @see https://github.com/sebastianbergmann/phpunit/pull/5225
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\StaticDataProviderClassMethodRectorTest
  */
 final class NamedArgumentForDataProviderRector extends AbstractRector
@@ -153,7 +154,7 @@ final class NamedArgumentForDataProviderRector extends AbstractRector
 
     /**
      * @param list<Node\Stmt> $stmts
-     * @return array<string, Node\Expr\Array_>
+     * @return array<string, Array_>
      */
     public function getResolvedVariables(array $stmts): array
     {
@@ -246,7 +247,7 @@ final class NamedArgumentForDataProviderRector extends AbstractRector
     }
 
     /**
-     * @return iterable<Node\Expr\Array_>
+     * @return iterable<Array_>
      */
     private function extractDataProviderArrayItem(ClassMethod $classMethod): iterable
     {

--- a/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
+++ b/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
@@ -93,13 +93,12 @@ final class NamedArgumentForDataProviderRector extends AbstractRector
         return [Class_::class];
     }
 
+    /**
+     * @param Class_ $node
+     */
     public function refactor(Node $node): Node|null
     {
         if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
-            return null;
-        }
-
-        if (! $node instanceof Class_) {
             return null;
         }
 


### PR DESCRIPTION
Create a rector rule that will rename the array keys from the PHPUnit Dataprovider to the argument name of the called test method to be prepared for the usage of named arguments in PHPUnit 11. This was already deprecated in PHPUnit 10.5

I think this is a risky rule because you could use the same dataProvider for multiple tests and the name of the arguments could be differ between the methods. (That's the point why i didn't added it to a new PHPUnit110 list)

Maybe it make sense to add an configurable option to remove the array key names completly to not use the named argument feature at all? 