### PR TITLE
Check if an assert method is static before calling it with self

### DIFF
--- a/tests/Rector/Class_/PreferPHPUnitSelfCallRector/Fixture/skip_non_static_assert.php.inc
+++ b/tests/Rector/Class_/PreferPHPUnitSelfCallRector/Fixture/skip_non_static_assert.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\PreferPHPUnitSelfCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNonStaticAssert extends TestCase
+{
+    public function testMe()
+    {
+        $this->assertNonStatic('expected', 'actual', 'message');
+    }
+
+    public function assertNonStatic(mixed $expected, mixed $actual, string $message = '')
+    {
+        self::assertSame($expected, $actual, $message);
+    }
+}


### PR DESCRIPTION
In my project, I have self-defined `assert` methods that are not static because they need to access some instance variables. But the `PreferPHPUnitSelfCallRector` rule converts all method calls to static calls because the names match.

I created a patch that additionally checks if the `assert` method can be called statically.