### PR TITLE
Fix AssertCompareToSpecificMethodRector to skip gettype checks, as will be deprecated in next PHPUnit version

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareToSpecificMethodRector/Fixture/skip_get_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareToSpecificMethodRector/Fixture/skip_get_type.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareToSpecificMethodRector\Fixture;
+
+final class SkipGetType extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $value = 'some';
+        $this->assertNotSame('resource', gettype($value));
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareToSpecificMethodRector.php
@@ -43,7 +43,6 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             new FunctionNameWithAssertMethods('count', self::ASSERT_COUNT, self::ASSERT_NOT_COUNT),
             new FunctionNameWithAssertMethods('sizeof', self::ASSERT_COUNT, self::ASSERT_NOT_COUNT),
             new FunctionNameWithAssertMethods('iterator_count', self::ASSERT_COUNT, self::ASSERT_NOT_COUNT),
-            new FunctionNameWithAssertMethods('gettype', 'assertInternalType', 'assertNotInternalType'),
             new FunctionNameWithAssertMethods('get_class', 'assertInstanceOf', 'assertNotInstanceOf'),
         ];
     }


### PR DESCRIPTION
While upgrade is valid for one PHPUnit version, it will be deprecated next one.
The best way to go is to skip `gettype` check.

Closes https://github.com/rectorphp/rector/issues/8593