### PR TITLE
[PHPUnit 10] Fix typo assertObjectHasNotProperty -> assertObjectNotHasProperty

### DIFF
--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -31,7 +31,7 @@ return static function (RectorConfig $rectorConfig): void {
 
         // https://github.com/sebastianbergmann/phpunit/issues/5220
         new MethodCallRename('PHPUnit\Framework\Assert', 'assertObjectHasAttribute', 'assertObjectHasProperty'),
-        new MethodCallRename('PHPUnit\Framework\Assert', 'assertObjectNotHasAttribute', 'assertObjectHasNotProperty'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertObjectNotHasAttribute', 'assertObjectNotHasProperty'),
 
         new MethodCallRename(
             'PHPUnit\Framework\MockObject\Rule\InvocationOrder',


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-phpunit/pull/338#pullrequestreview-2133908428

**Before**

```
There was 1 error:

1) CodeIgniter\Config\BaseConfigTest::testEnvironmentOverrides
Error: Call to undefined method CodeIgniter\Config\BaseConfigTest::assertObjectHasNotProperty()

/Users/samsonasik/www/CodeIgniter4/tests/system/Config/BaseConfigTest.php:134
```

**After**

```
➜  CodeIgniter4 git:(develop) ✗ vendor/bin/phpunit tests/system/Config/BaseConfigTest.php
PHPUnit 10.5.24 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.4 with PCOV 1.0.11
Configuration: /Users/samsonasik/www/CodeIgniter4/phpunit.xml.dist

..................                                           18 / 18 (100%)

Time: 00:00.317, Memory: 14.00 MB

OK (18 tests, 48 assertions)

Generating code coverage report in Clover XML format ... done [00:00.188]

Generating code coverage report in HTML format ... done [00:00.755]
```