### PR TITLE
Remove NamedArgumentForDataProviderRector from the PHPUnit 11 set as optional upgrade path

### DIFF
--- a/config/sets/phpunit110.php
+++ b/config/sets/phpunit110.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([NamedArgumentForDataProviderRector::class]);
 };


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-phpunit/issues/346