### PR TITLE
[CodeQuality] Assert compare on countable

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -11,6 +11,7 @@ use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLined
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\RemoveEmptyTestMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector;
 use Rector\PHPUnit\CodeQuality\Rector\Foreach_\SimplifyForeachInstanceOfRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
@@ -43,6 +44,7 @@ return static function (RectorConfig $rectorConfig): void {
         DataProviderArrayItemsNewlinedRector::class,
 
         // specific asserts
+        AssertCompareOnCountableWithMethodToAssertCountRector::class,
         AssertCompareToSpecificMethodRector::class,
         AssertComparisonToSpecificMethodRector::class,
         AssertNotOperatorRector::class,

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 55 Rules Overview
+# 56 Rules Overview
 
 **This overview is deprecated and replaced by more advanced web search. There you can search and filter by nodes, copy-paste configs for configurable rules and more.**
 
@@ -116,6 +116,19 @@ Change annotations with value to attribute
  final class SomeTest extends TestCase
  {
  }
+```
+
+<br>
+
+## AssertCompareOnCountableWithMethodToAssertCountRector
+
+
+
+- class: [`Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector`](../rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php)
+
+```diff
+-$this->assertSame(1, $countable->count());
++$this->assertCount(1, $countable);
 ```
 
 <br>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/AssertCompareOnCountableWithMethodToAssertCountRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/AssertCompareOnCountableWithMethodToAssertCountRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertCompareOnCountableWithMethodToAssertCountRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/count.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/count.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Source\Collection;
+
+final class Count extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertSame(5, $collection->count());
+        \PHPUnit\Framework\TestCase::assertSame(5, $collection->count());
+        self::assertSame(5, $collection->count());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Source\Collection;
+
+final class Count extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertCount(5, $collection);
+        \PHPUnit\Framework\TestCase::assertCount(5, $collection);
+        self::assertCount(5, $collection);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/count.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/count.php.inc
@@ -10,6 +10,7 @@ final class Count extends \PHPUnit\Framework\TestCase
     {
         $collection = new Collection();
         $this->assertSame(5, $collection->count());
+        $this->assertEquals(5, $collection->count());
         \PHPUnit\Framework\TestCase::assertSame(5, $collection->count());
         self::assertSame(5, $collection->count());
     }
@@ -28,6 +29,7 @@ final class Count extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $collection = new Collection();
+        $this->assertCount(5, $collection);
         $this->assertCount(5, $collection);
         \PHPUnit\Framework\TestCase::assertCount(5, $collection);
         self::assertCount(5, $collection);

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/skip_on_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/skip_on_non_test_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Source\Collection;
+
+final class SkipOnNonTestClass
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertSame(5, $collection->count());
+        $this->assertEquals(5, $collection->count());
+        self::assertSame(5, $collection->count());
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Source/Collection.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Source/Collection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Source;
+
+class Collection implements \Countable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AssertCompareOnCountableWithMethodToAssertCountRector::class);
+};

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PHPStan\Type\ObjectType;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -75,7 +74,7 @@ CODE_SAMPLE
 
             if ((new ObjectType(Countable::class))->isSuperTypeOf($type)->yes()) {
                 $args = $node->getArgs();
-                $args[1] = $right->var;
+                $args[1] = new Node\Arg($right->var);
 
                 $node->args = $args;
                 $node->name = new Identifier('assertCount');

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -77,13 +77,8 @@ CODE_SAMPLE
                 $args = $node->getArgs();
                 $args[1] = $right->var;
 
-                if ($node instanceof MethodCall) {
-                    return $this->nodeFactory->createMethodCall($node->var, 'assertCount', $args);
-                }
-
-                if ($node->class instanceof Name) {
-                    return $this->nodeFactory->createStaticCall($node->class->toString(), 'assertCount', $args);
-                }
+                $node->args = $args;
+                $node->name = new Identifier('assertCount');
             }
         }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
+
+use Countable;
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\AssertCompareOnCountableWithMethodToAssertCountRectorTest
+ */
+class AssertCompareOnCountableWithMethodToAssertCountRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', [
+            new CodeSample(<<<'CODE_SAMPLE'
+$this->assertSame(1, $countable->count());
+CODE_SAMPLE
+,
+            <<<'CODE_SAMPLE'
+$this->assertCount(1, $countable);
+CODE_SAMPLE
+            )
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node\Expr\MethodCall>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class, Node\Expr\StaticCall::class];
+    }
+
+    /**
+     * @param Node\Expr\MethodCall|Node\Expr\StaticCall $node
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function refactor(Node $node)
+    {
+        $class = $node instanceof Node\Expr\StaticCall ? $node->class : $node->var;
+
+        if ($this->getType($class)->isSuperTypeOf(new ObjectType('PHPUnit\Framework\TestCase'))->no()) {
+            return null;
+        }
+
+        if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== 'assertsame') {
+            return null;
+        }
+
+        $right = $node->getArgs()[1]->value;
+
+        if (
+            ($right instanceof Node\Expr\MethodCall)
+            && $right->name instanceof Node\Identifier
+            && $right->name->toLowerString() === 'count'
+            && count($right->getArgs()) === 0
+        ) {
+            $type = $this->getType($right->var);
+
+            if ((new ObjectType(Countable::class))->isSuperTypeOf($type)->yes()) {
+                $args = $node->getArgs();
+                $args[1] = $right->var;
+
+                if ($node instanceof Node\Expr\MethodCall) {
+                    return $this->nodeFactory->createMethodCall($node->var, 'assertCount', $args);
+                }
+
+                if ($node instanceof Node\Expr\StaticCall && $node->class instanceof Node\Name) {
+                    return $this->nodeFactory->createStaticCall($node->class->toString(), 'assertCount', $args);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -6,6 +6,7 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 
 use Countable;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
@@ -74,7 +75,7 @@ CODE_SAMPLE
 
             if ((new ObjectType(Countable::class))->isSuperTypeOf($type)->yes()) {
                 $args = $node->getArgs();
-                $args[1] = new Node\Arg($right->var);
+                $args[1] = new Arg($right->var);
 
                 $node->args = $args;
                 $node->name = new Identifier('assertCount');

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 
-use Countable;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
@@ -28,17 +27,20 @@ class AssertCompareOnCountableWithMethodToAssertCountRector extends AbstractRect
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
-$this->assertSame(1, $countable->count());
-CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
-$this->assertCount(1, $countable);
-CODE_SAMPLE
-            ),
-        ]);
+        return new RuleDefinition(
+            'Replaces use of assertSame and assertEquals on Countable objects with count method',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+    $this->assertSame(1, $countable->count());
+    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+    $this->assertCount(1, $countable);
+    CODE_SAMPLE
+                ),
+            ]
+        );
     }
 
     /**
@@ -73,7 +75,7 @@ CODE_SAMPLE
         ) {
             $type = $this->getType($right->var);
 
-            if ((new ObjectType(Countable::class))->isSuperTypeOf($type)->yes()) {
+            if ((new ObjectType('Countable'))->isSuperTypeOf($type)->yes()) {
                 $args = $node->getArgs();
                 $args[1] = new Arg($right->var);
 


### PR DESCRIPTION
# Changes

- Adds the new rule `AssertCompareOnCountableWithMethodToAssertCountRector`
- Adds a test
- Updates the docs

# Why

Based on this [PHPStan PHPUnit rule](https://github.com/phpstan/phpstan-phpunit/blob/1.4.x/src/Rules/PHPUnit/AssertRuleHelper.php) it will convert comparison on Countable objects with the count method to use the `assertCount` method instead.

Works with method and static method calls.

```diff
-$this->assertSame(1, $countable->count());
+$this->assertCount(1, $countable);
```