### PR TITLE
[PHPUnit100] Fix typo in AssertIssetToAssertObjectHasPropertyRector

### DIFF
--- a/rules-tests/PHPUnit100/Rector/MethodCall/AssertIssetToAssertObjectHasPropertyRector/Fixture/some_isset_to_property.php.inc
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/AssertIssetToAssertObjectHasPropertyRector/Fixture/some_isset_to_property.php.inc
@@ -26,7 +26,7 @@ final class SomeIssetToProperty extends TestCase
     public function test()
     {
         $object = new \stdClass();
-        $this->assertObjectHasAttribute('someProperty', $object);
+        $this->assertObjectHasProperty('someProperty', $object);
     }
 }
 

--- a/rules/PHPUnit100/Rector/MethodCall/AssertIssetToAssertObjectHasPropertyRector.php
+++ b/rules/PHPUnit100/Rector/MethodCall/AssertIssetToAssertObjectHasPropertyRector.php
@@ -115,8 +115,8 @@ CODE_SAMPLE
         }
 
         $this->identifierManipulator->renameNodeWithMap($node, [
-            AssertMethod::ASSERT_TRUE => 'assertObjectHasAttribute',
-            AssertMethod::ASSERT_FALSE => 'assertObjectNotHasAttribute',
+            AssertMethod::ASSERT_TRUE => 'assertObjectHasProperty',
+            AssertMethod::ASSERT_FALSE => 'assertObjectNotHasProperty',
         ]);
 
         $oldArgs = $node->getArgs();


### PR DESCRIPTION
AssertIssetToAssertObjectHasPropertyRector rule should change assertion to "assertObjectHasProperty". 
Function assertObjectHasAttribute doesn't exist in PHPUnit 10.5