### PR TITLE
Ensure check isFirstClassCallable() before getArgs() call on CallLike

### DIFF
--- a/rules/CodeQuality/Rector/Class_/PreferPHPUnitSelfCallRector.php
+++ b/rules/CodeQuality/Rector/Class_/PreferPHPUnitSelfCallRector.php
@@ -101,6 +101,11 @@ CODE_SAMPLE
             $classReflection = $this->reflectionResolver->resolveClassReflection($node);
             if ($classReflection instanceof ClassReflection && $classReflection->hasNativeMethod($methodName)) {
                 $method = $classReflection->getNativeMethod($methodName);
+
+                if ($node->isFirstClassCallable()) {
+                    return null;
+                }
+
                 if ($method->isStatic()) {
                     $hasChanged = true;
 

--- a/rules/CodeQuality/Rector/Class_/PreferPHPUnitThisCallRector.php
+++ b/rules/CodeQuality/Rector/Class_/PreferPHPUnitThisCallRector.php
@@ -98,6 +98,10 @@ CODE_SAMPLE
                 return null;
             }
 
+            if ($node->isFirstClassCallable()) {
+                return null;
+            }
+
             $hasChanged = true;
             return $this->nodeFactory->createMethodCall('this', $methodName, $node->getArgs());
         });

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -60,6 +60,10 @@ final class AssertCompareOnCountableWithMethodToAssertCountRector extends Abstra
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (count($node->getArgs()) < 2) {
             return null;
         }

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector.php
@@ -71,6 +71,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $args = $node->getArgs();
 
         $firstValue = $args[0]->value;

--- a/rules/CodeQuality/Rector/MethodCall/NarrowIdenticalWithConsecutiveRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/NarrowIdenticalWithConsecutiveRector.php
@@ -93,6 +93,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $firstArg = $node->getArgs()[0];
 
         // skip as most likely nested array of unique values

--- a/rules/CodeQuality/Rector/MethodCall/SingleWithConsecutiveToWithRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/SingleWithConsecutiveToWithRector.php
@@ -87,6 +87,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (count($node->getArgs()) !== 1) {
             return null;
         }

--- a/rules/PHPUnit100/Rector/StmtsAwareInterface/WithConsecutiveRector.php
+++ b/rules/PHPUnit100/Rector/StmtsAwareInterface/WithConsecutiveRector.php
@@ -223,6 +223,10 @@ CODE_SAMPLE
                 return null;
             }
 
+            if ($node->isFirstClassCallable()) {
+                return null;
+            }
+
             $firstArg = $node->getArgs()[0];
             if (! $firstArg->value instanceof MethodCall && ! $firstArg->value instanceof StaticCall) {
                 return null;


### PR DESCRIPTION
to avoid assert error on first class callable.