### PR TITLE
Add ReplaceTestFunctionPrefixWithAttributeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/Fixture/fixture_camelCase.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/Fixture/fixture_camelCase.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function testOnePlusOneShouldBeTwo()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function onePlusOneShouldBeTwo()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/Fixture/fixture_just_test_name.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/Fixture/fixture_just_test_name.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function test_()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function test_()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/Fixture/fixture_snake_case.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/Fixture/fixture_snake_case.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function test_one_plus_one_should_be_two()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function one_plus_one_should_be_two()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/ReplaceTestFunctionPrefixWithAttributeRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/ReplaceTestFunctionPrefixWithAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeQuality\Rector\ClassMethod\ReplaceTestFunctionPrefixWithAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceTestFunctionPrefixWithAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestFunctionPrefixWithAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplaceTestFunctionPrefixWithAttributeRector::class);
+};

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector.php
@@ -71,7 +71,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! str_starts_with($node->name->toString(), 'test')) {
+        if (!str_starts_with($node->name->toString(), 'test')) {
             return null;
         }
 
@@ -79,10 +79,12 @@ CODE_SAMPLE
             return null;
         }
 
-        if (str_starts_with($node->name->toString(), 'test_')) {
-            $node->name->name = lcfirst(substr($node->name->name, 5));
-        } elseif (str_starts_with($node->name->toString(), 'test')) {
-            $node->name->name = lcfirst(substr($node->name->name, 4));
+        if ($node->name->toString() !== 'test' && $node->name->toString() !== 'test_') {
+            if (str_starts_with($node->name->toString(), 'test_')) {
+                $node->name->name = lcfirst(substr($node->name->name, 5));
+            } elseif (str_starts_with($node->name->toString(), 'test')) {
+                $node->name->name = lcfirst(substr($node->name->name, 4));
+            }
         }
 
         $coversAttributeGroup = $this->createAttributeGroup();

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector.php
@@ -71,7 +71,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (!str_starts_with($node->name->toString(), 'test')) {
+        if (! str_starts_with($node->name->toString(), 'test')) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestFunctionPrefixWithAttributeRector.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\ReplaceTestAnnotationWithPrefixedFunctionRectorTest
+ */
+final class ReplaceTestFunctionPrefixWithAttributeRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace @test with prefixed function', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function testOnePlusOneShouldBeTwo()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    #[Test]
+    public function onePlusOneShouldBeTwo()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        if (! str_starts_with($node->name->toString(), 'test')) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttributes($node, ['PHPUnit\\Framework\\Attributes\\Test'])) {
+            return null;
+        }
+
+        if (str_starts_with($node->name->toString(), 'test_')) {
+            $node->name->name = lcfirst(substr($node->name->name, 5));
+        } elseif (str_starts_with($node->name->toString(), 'test')) {
+            $node->name->name = lcfirst(substr($node->name->name, 4));
+        }
+
+        $coversAttributeGroup = $this->createAttributeGroup();
+        $node->attrGroups = array_merge($node->attrGroups, [$coversAttributeGroup]);
+
+        return $node;
+    }
+
+    private function createAttributeGroup(): AttributeGroup
+    {
+        $attributeClass = 'PHPUnit\\Framework\\Attributes\\Test';
+
+        return $this->phpAttributeGroupFactory->createFromClassWithItems($attributeClass, []);
+    }
+}


### PR DESCRIPTION
We have a project with lots of phpunit tests that were defined using just the `test` prefix on the function name. We'd like to move these to using the `#[Test]` attribute.

Since we probably aren't the only people with this setup we thought we'd contribute it back :)