### PR TITLE
[AnnotationsToAttribute] Skip not in test on AnnotationWithValueToAttributeRector

### DIFF
--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector/Fixture/skip_not_in_test.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector/Fixture/skip_not_in_test.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector\Fixture;
+
+final class SkipNotInTest
+{
+    /**
+     * @uses Foo::Bar
+     */
+    public function run()
+    {
+    }
+}

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector/Fixture/uses_in_test.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector/Fixture/uses_in_test.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class UsesInTest extends TestCase
+{
+    /**
+     * @uses Foo::Bar
+     */
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class UsesInTest extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\UsesClass(Foo::Bar)]
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector/config/configured_rule.php
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector/config/configured_rule.php
@@ -13,5 +13,6 @@ return static function (RectorConfig $rectorConfig): void {
             'disabled' => false,
         ]),
         new AnnotationWithValueToAttribute('dataProvider', 'PHPUnit\Framework\Attributes\DataProvider'),
+        new AnnotationWithValueToAttribute('uses', 'PHPUnit\Framework\Attributes\UsesClass'),
     ]);
 };

--- a/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
@@ -15,6 +15,7 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
@@ -38,6 +39,7 @@ final class AnnotationWithValueToAttributeRector extends AbstractRector implemen
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
     ) {
     }
 
@@ -95,6 +97,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return null;


### PR DESCRIPTION
Like other rules, the `AnnotationWithValueToAttributeRector` should verify in test class as well.