### PR TITLE
[CodeQuality] Fix flipped check condition only remove property when unused on NarrowUnusedSetUpDefinedPropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/defined_only_in_setup.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/defined_only_in_setup.php.inc
@@ -36,12 +36,12 @@ use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPrope
 
 final class DefinedOnlyInSetup extends TestCase
 {
-    private MockObject $someMock;
+    private MockObject $anotherMock;
 
     protected function setUp(): void
     {
-        $this->someMock = $this->createMock(SomeType::class);
-        $anotherMock = $this->createMock(SomeType::class);
+        $someMock = $this->createMock(SomeType::class);
+        $this->anotherMock = $this->createMock(SomeType::class);
     }
 
     public function test()

--- a/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $this->isPropertyUsedOutsideSetUpClassMethod($node, $setUpClassMethod, $property)) {
+            if ($this->isPropertyUsedOutsideSetUpClassMethod($node, $setUpClassMethod, $property)) {
                 continue;
             }
 


### PR DESCRIPTION
see https://github.com/rectorphp/rector-phpunit/pull/388#pullrequestreview-2411971619