### PR TITLE
[CodeQuality] Skip non private on non final class on NarrowUnusedSetUpDefinedPropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/non_private_on_final.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/non_private_on_final.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source\SomeType;
+
+final class NonPrivateOnFinalClass extends TestCase
+{
+    protected SomeType $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = new SomeType();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source\SomeType;
+
+final class NonPrivateOnFinalClass extends TestCase
+{
+    protected function setUp(): void
+    {
+        $someMock = new SomeType();
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_non_private_on_non_final.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_non_private_on_non_final.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source\SomeType;
+
+class SkipNonPrivateOnNonFinalClass extends TestCase
+{
+    protected SomeType $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = new SomeType();
+    }
+}
+

--- a/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
@@ -87,9 +87,15 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
+        $isFinalClass = $node->isFinal();
 
         foreach ($node->stmts as $key => $classStmt) {
             if (! $classStmt instanceof Property) {
+                continue;
+            }
+
+            // possibly used by child
+            if (! $isFinalClass && ! $classStmt->isPrivate()) {
                 continue;
             }
 


### PR DESCRIPTION
when class is not final, and property is non-private, it can be used by child class.