### PR TITLE
[CodeQuality] Skip direct use without assign on NarrowUnusedSetUpDefinedPropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_direct_use_without_assign_in_setup.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_direct_use_without_assign_in_setup.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source\SomeClass;
+
+final class SkipDirectUseWithoutAssignInSetup extends TestCase
+{
+    private array $data = ['some setup data'];
+
+    protected function setUp(): void
+    {
+        new SomeClass($this->data);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Source/SomeClass.php
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Source/SomeClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source;
+
+final class SomeClass
+{
+
+}


### PR DESCRIPTION
It currently cause undefined variable error, ref https://getrector.com/demo/b2a25b32-fae8-45e1-87d8-2a8946ff701d