### PR TITLE
[CodeQuality] Add CreateMockToDirectNewRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/EntityDocumentCreateMockToDirectNewRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/EntityDocumentCreateMockToDirectNewRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EntityDocumentCreateMockToDirectNewRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/Fixture/skip_no_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/Fixture/skip_no_property.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoProperty extends TestCase
+{
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/Fixture/some_file.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/Fixture/some_file.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Source\Table;
+
+
+final class SomeFileTest extends TestCase
+{
+    public function test()
+    {
+        $tableMock = $this->createMock(Table::class);
+
+        $tableMock
+            ->expects(self::once())
+            ->method('isLocked')
+            ->willReturn(true);
+
+        $tableMock
+            ->expects(self::once())
+            ->method('setLocked')
+            ->with(false)
+            ->willReturn($tableMock);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Source\Table;
+
+
+final class SomeFileTest extends TestCase
+{
+    public function test()
+    {
+        $table = new \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Source\Table();
+
+        $table->setLocked(true);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/Source/Table.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/Source/Table.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\Source;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Table
+{
+    private bool $isLocked;
+
+    public function setLocked(bool $locked): void
+    {
+        $this->isLocked = $locked;
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->isLocked;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector;
+
+return RectorConfig::configure()
+    ->withRules([EntityDocumentCreateMockToDirectNewRector::class]);

--- a/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
+++ b/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\NodeAnalyser;
+
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\Reflection\ClassReflection;
+
+final readonly class DoctrineEntityDocumentAnalyser
+{
+    /**
+     * @var string[]
+     */
+    private const ENTITY_DOCBLOCK_MARKERS = ['@Document', '@ORM\\Document', '@Entity', '@ORM\\Entity'];
+
+    public function isEntityClass(ClassReflection $classReflection): bool
+    {
+        $resolvedPhpDocBlock = $classReflection->getResolvedPhpDoc();
+        if (! $resolvedPhpDocBlock instanceof ResolvedPhpDocBlock) {
+            return false;
+        }
+
+        foreach (self::ENTITY_DOCBLOCK_MARKERS as $entityDocBlockMarkers) {
+            if (str_contains($resolvedPhpDocBlock->getPhpDocString(), $entityDocBlockMarkers)) {
+                return true;
+            }
+        }
+
+        // @todo apply attributes as well
+
+        return false;
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/EntityDocumentCreateMockToDirectNewRector.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeFinder;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\PHPUnit\CodeQuality\NodeAnalyser\DoctrineEntityDocumentAnalyser;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector\EntityDocumentCreateMockToDirectNewRectorTest
+ */
+final class EntityDocumentCreateMockToDirectNewRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly DoctrineEntityDocumentAnalyser $doctrineEntityDocumentAnalyser,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Move from value object mocking, to direct use of value object', []);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?ClassMethod
+    {
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $mockedVariablesToTypes = $this->collectMockedVariableToTypeAndRefactorAssign($node);
+        if ($mockedVariablesToTypes === []) {
+            return null;
+        }
+
+        foreach ($mockedVariablesToTypes as $mockedVariableName => $mockedClass) {
+            foreach ($node->stmts as $key => $stmt) {
+                if (! $stmt instanceof Expression) {
+                    continue;
+                }
+
+                if (! $stmt->expr instanceof MethodCall) {
+                    continue;
+                }
+
+                $methodCall = $stmt->expr;
+
+                $onVariableMethodCall = $this->findMethodCallOnVariableNamed($methodCall, $mockedVariableName);
+                if (! $onVariableMethodCall instanceof Node) {
+                    continue;
+                }
+
+                // 2. find $mock->method("name")
+                $methodName = $this->resolveMethodCallFirstArgValue($methodCall, 'method');
+                if (! is_string($methodName)) {
+                    throw new ShouldNotHappenException('Unable to resolve method name');
+                }
+
+                // is set method mocked? Just remove it
+                if (str_starts_with($methodName, 'set')) {
+                    unset($node->stmts[$key]);
+                }
+
+                $methodName = $this->resolveMethodName($methodName, $mockedClass);
+
+                $willReturnExpr = $this->resolveMethodCallFirstArgValue($methodCall, 'willReturn');
+
+                if ($methodName && $willReturnExpr instanceof Expr) {
+                    $stmt->expr = new MethodCall(new Variable($mockedVariableName), new Identifier($methodName), [
+                        new Arg($willReturnExpr),
+                    ]);
+                }
+            }
+
+        }
+
+        // 3. replace value without "mock" in name
+        $mockedVariableNames = array_keys($mockedVariablesToTypes);
+
+        $this->traverseNodesWithCallable($node, function (Node $node) use ($mockedVariableNames): ?Variable {
+            if (! $node instanceof Variable) {
+                return null;
+            }
+
+            if (! is_string($node->name)) {
+                return null;
+            }
+
+            if (! in_array($node->name, $mockedVariableNames)) {
+                return null;
+            }
+
+            return new Variable(str_replace('Mock', '', $node->name));
+        });
+
+        return $node;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function collectMockedVariableToTypeAndRefactorAssign(ClassMethod $classMethod): array
+    {
+        if ($classMethod->stmts === null) {
+            return [];
+        }
+
+        $mockedVariablesToTypes = [];
+
+        foreach ($classMethod->stmts as $stmt) {
+            // find assign mock
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            $stmtExpr = $stmt->expr;
+            if (! $stmtExpr instanceof Assign) {
+                continue;
+            }
+
+            /** @var Assign $assign */
+            $assign = $stmtExpr;
+            if (! $assign->expr instanceof MethodCall) {
+                continue;
+            }
+
+            $methodCall = $assign->expr;
+            if (! $this->isName($methodCall->name, 'createMock')) {
+                continue;
+            }
+
+            $firstArg = $methodCall->getArgs()[0];
+
+            $mockedClass = $this->valueResolver->getValue($firstArg->value);
+            if (! is_string($mockedClass)) {
+                continue;
+            }
+
+            if (! $this->reflectionProvider->hasClass($mockedClass)) {
+                continue;
+            }
+
+            $mockClassReflection = $this->reflectionProvider->getClass($mockedClass);
+            if ($mockClassReflection->isAbstract()) {
+                continue;
+            }
+
+            if (! $this->doctrineEntityDocumentAnalyser->isEntityClass($mockClassReflection)) {
+                continue;
+            }
+
+            // ready to replace :)
+            $assign->expr = new New_(new FullyQualified($mockedClass));
+
+            $mockedVariableName = $this->getName($assign->var);
+            $mockedVariablesToTypes[$mockedVariableName] = $mockedClass;
+        }
+
+        return $mockedVariablesToTypes;
+    }
+
+    private function resolveMethodCallFirstArgValue(MethodCall $methodCall, string $methodName): string|Expr|null
+    {
+        $nodeFinder = new NodeFinder();
+
+        $methodNameMethodCall = $nodeFinder->findFirst($methodCall, function (Node $node) use ($methodName): bool {
+            if (! $node instanceof MethodCall) {
+                return false;
+            }
+
+            return $this->isName($node->name, $methodName);
+        });
+
+        if (! $methodNameMethodCall instanceof MethodCall) {
+            return null;
+        }
+
+        $methodNameArg = $methodNameMethodCall->getArgs()[0];
+
+        if ($methodNameArg->value instanceof String_) {
+            return $methodNameArg->value->value;
+        }
+
+        return $methodNameArg->value;
+    }
+
+    private function resolveMethodName(string $methodName, string $mockedClass): string
+    {
+        // guess the setter name
+        if (str_starts_with($methodName, 'get')) {
+            return 'set' . ucfirst(substr($methodName, 3));
+        }
+
+        if (str_starts_with($methodName, 'is')) {
+            $mockedClassReflection = $this->reflectionProvider->getClass($mockedClass);
+
+            $isSetterMethodNames = ['set' . ucfirst($methodName), 'set' . substr($methodName, 2)];
+
+            foreach ($isSetterMethodNames as $isSetterMethodName) {
+                if ($mockedClassReflection->hasMethod($isSetterMethodName)) {
+                    return $isSetterMethodName;
+                }
+            }
+        }
+
+        return $methodName;
+    }
+
+    private function findMethodCallOnVariableNamed(MethodCall $methodCall, string $desiredVariableName): ?MethodCall
+    {
+        $nodeFinder = new NodeFinder();
+
+        $foundMethodCall = $nodeFinder->findFirst($methodCall, function (Node $node) use ($desiredVariableName): bool {
+            if (! $node instanceof MethodCall) {
+                return false;
+            }
+
+            if (! $node->var instanceof Variable) {
+                return false;
+            }
+
+            return $this->isName($node->var, $desiredVariableName);
+        });
+
+        if (! $foundMethodCall instanceof MethodCall) {
+            return null;
+        }
+
+        return $foundMethodCall;
+    }
+}


### PR DESCRIPTION
Instead of weak mocking setup, use object directly with type control and IDE support :tada: 

```diff
-$articleMock = $this->createMock(Article::class);
-$articleMock->method('getName')->willReturn('How stand up against mocking');
+$article = new Article();
+$article->setName('How stand up against mocking');
```


This rule is applied on Doctrine ORM + ODM entitites only, to have migration under control.