### PR TITLE
YieldDataProviderRector: added failling test

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/YieldDataProviderRector/Fixture/use_data_provider_with_phpdoc.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YieldDataProviderRector/Fixture/use_data_provider_with_phpdoc.php.inc
@@ -37,7 +37,7 @@ namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\YieldDataProviderRector
 
 use PHPUnit\Framework\TestCase;
 
-final class UseDataProviderTest extends TestCase
+final class UseDataProviderTestPhpdoc extends TestCase
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     #[\PHPUnit\Framework\Attributes\DataProvider('provideDataForProvider')]

--- a/rules-tests/CodeQuality/Rector/Class_/YieldDataProviderRector/Fixture/use_data_provider_with_phpdoc.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YieldDataProviderRector/Fixture/use_data_provider_with_phpdoc.php.inc
@@ -4,7 +4,7 @@ namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\YieldDataProviderRector
 
 use PHPUnit\Framework\TestCase;
 
-final class UseDataProviderTest extends TestCase
+final class UseDataProviderTestPhpdoc extends TestCase
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     #[\PHPUnit\Framework\Attributes\DataProvider('provideDataForProvider')]

--- a/rules-tests/CodeQuality/Rector/Class_/YieldDataProviderRector/Fixture/use_data_provider_with_phpdoc.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YieldDataProviderRector/Fixture/use_data_provider_with_phpdoc.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\YieldDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class UseDataProviderTest extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataForProvider')]
+    public function test(string $filePath): void
+    {
+    }
+
+    /** @return array<int, array<string>> */
+    public static function provideDataForProvider()
+    {
+        return [
+            ['<?php implode("", $foo, );', '<?php implode($foo, "", );']
+        ];
+    }
+
+    public static function dataProvider()
+    {
+        return [
+            ['<?php implode(\'\', $foo, );', '<?php implode($foo, );'],
+            ['<?php implode(\'\', $foo, );', '<?php implode($foo, );']
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\YieldDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class UseDataProviderTest extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataForProvider')]
+    public function test(string $filePath): void
+    {
+    }
+
+    /** @return Iterator<int, array<string>> */
+    public static function provideDataForProvider(): \Iterator
+    {
+        yield ['<?php implode("", $foo, );', '<?php implode($foo, "", );'];
+    }
+
+    public static function dataProvider(): \Iterator
+    {
+        yield ['<?php implode(\'\', $foo, );', '<?php implode($foo, );'];
+        yield ['<?php implode(\'\', $foo, );', '<?php implode($foo, );'];
+    }
+}
+
+?>


### PR DESCRIPTION
I think it would be useful, if rector transforms a `array` return type into a `Iterator`, that it also fixes a possible `@return` phpdoc type of a dataprovider (otherwise PHPStan is starting to yell about incompatible native vs. phpdoc return-type