### PR TITLE
Add fixture for numeric string to keep as is on TestWithAnnotationToAttributeRector

### DIFF
--- a/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector/Fixture/with_numeric_string.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector/Fixture/with_numeric_string.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector\Fixture;
+
+class WithNumericString extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @testWith ["2"]
+     *           ["benjamin.sisko@ds9.example.com"]
+     */
+    public function testSomething(string $userId): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector\Fixture;
+
+class WithNumericString extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\TestWith(['2'])]
+    #[\PHPUnit\Framework\Attributes\TestWith(['benjamin.sisko@ds9.example.com'])]
+    public function testSomething(string $userId): void
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Fixture for patch on rector-src

- https://github.com/rectorphp/rector-src/pull/6608

for issue:

- https://github.com/rectorphp/rector/issues/8941