### PR TITLE
Improve AssertCompareOnCountableWithMethodToAssertCountRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/count.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/count.php.inc
@@ -13,6 +13,11 @@ final class Count extends \PHPUnit\Framework\TestCase
         $this->assertEquals(5, $collection->count());
         \PHPUnit\Framework\TestCase::assertSame(5, $collection->count());
         self::assertSame(5, $collection->count());
+
+        $this->assertNotSame(6, $collection->count());
+        $this->assertNotEquals(6, $collection->count());
+        \PHPUnit\Framework\TestCase::assertNotSame(6, $collection->count());
+        self::assertNotSame(6, $collection->count());
     }
 }
 
@@ -33,6 +38,11 @@ final class Count extends \PHPUnit\Framework\TestCase
         $this->assertCount(5, $collection);
         \PHPUnit\Framework\TestCase::assertCount(5, $collection);
         self::assertCount(5, $collection);
+
+        $this->assertNotCount(6, $collection);
+        $this->assertNotCount(6, $collection);
+        \PHPUnit\Framework\TestCase::assertNotCount(6, $collection);
+        self::assertNotCount(6, $collection);
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/direct_count_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/direct_count_call.php.inc
@@ -8,6 +8,7 @@ final class DirectCountCall extends \PHPUnit\Framework\TestCase
     {
         $items = [1, 2, 3];
         $this->assertSame(3, count($items));
+        $this->assertNotSame(4, count($items));
     }
 }
 
@@ -23,6 +24,7 @@ final class DirectCountCall extends \PHPUnit\Framework\TestCase
     {
         $items = [1, 2, 3];
         $this->assertCount(3, $items);
+        $this->assertNotCount(4, $items);
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/other_count_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector/Fixture/other_count_call.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Fixture;
+
+final class OtherCountCall extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertEquals(10, iterator_count($something));
+
+        $count = 92;
+        $this->assertNotEquals($count, sizeof($something), 'third argument');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector\Fixture;
+
+final class OtherCountCall extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertCount(10, $something);
+
+        $count = 92;
+        $this->assertNotCount($count, $something, 'third argument');
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -40,6 +40,10 @@ final class AssertCompareOnCountableWithMethodToAssertCountRector extends Abstra
     $this->assertCount(1, $countable);
     CODE_SAMPLE
                 ),
+                new CodeSample(
+                    '$this->assertSame(10, count($anything), "message");',
+                    '$this->assertCount(10, $anything, "message");'
+                ),
             ]
         );
     }
@@ -57,7 +61,10 @@ final class AssertCompareOnCountableWithMethodToAssertCountRector extends Abstra
      */
     public function refactor(Node $node): MethodCall|StaticCall|null
     {
-        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, ['assertSame', 'assertEquals'])) {
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames(
+            $node,
+            ['assertSame', 'assertNotSame', 'assertEquals', 'assertNotEquals']
+        )) {
             return null;
         }
 
@@ -72,12 +79,15 @@ final class AssertCompareOnCountableWithMethodToAssertCountRector extends Abstra
 
         $comparedExpr = $assertArgs[1]->value;
 
-        if ($comparedExpr instanceof FuncCall && $this->isName($comparedExpr->name, 'count')) {
+        if (
+            $comparedExpr instanceof FuncCall
+            && $this->isNames($comparedExpr->name, ['count', 'sizeof', 'iterator_count'])
+        ) {
             $countArg = $comparedExpr->getArgs()[0];
             $assertArgs[1] = new Arg($countArg->value);
 
             $node->args = $assertArgs;
-            $node->name = new Identifier('assertCount');
+            $this->renameMethod($node);
 
             return $node;
         }
@@ -94,10 +104,19 @@ final class AssertCompareOnCountableWithMethodToAssertCountRector extends Abstra
                 $args[1] = new Arg($comparedExpr->var);
 
                 $node->args = $args;
-                $node->name = new Identifier('assertCount');
+                $this->renameMethod($node);
             }
         }
 
         return null;
+    }
+
+    private function renameMethod(MethodCall|StaticCall $node): void
+    {
+        if ($this->isNames($node->name, ['assertSame', 'assertEquals'])) {
+            $node->name = new Identifier('assertCount');
+        } elseif ($this->isNames($node->name, ['assertNotSame', 'assertNotEquals'])) {
+            $node->name = new Identifier('assertNotCount');
+        }
     }
 }


### PR DESCRIPTION
Previously
- It supported only assertEquals/assertSame
- It supported only count function

Now
- It also supports assertNotEquals/assertNotSame
- It also supports sizeof and iterator_count functions