### PR TITLE
Improve AssertInstanceOfComparisonRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/get_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/get_class.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture;
+
+use stdClass;
+
+final class GetClass extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $something = new stdClass();
+        self::assertSame('stdClass', get_class($something));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture;
+
+use stdClass;
+
+final class GetClass extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $something = new stdClass();
+        self::assertInstanceOf('stdClass', $something);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/skip_first_param.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/skip_first_param.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture;
+
+final class SkipFirstParam extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertSame(get_class($something), 'stdClass');
+    }
+}
+
+?>
+    -----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture;
+
+final class SkipFirstParam extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertSame(get_class($something), 'stdClass');
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector.php
@@ -6,10 +6,12 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -49,6 +51,10 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
                     '$this->assertFalse($foo instanceof Foo, "message");',
                     '$this->assertNotInstanceOf("Foo", $foo, "message");',
                 ),
+                new CodeSample(
+                    '$this->assertNotEquals(SomeInstance::class, get_class($value));',
+                    '$this->assertNotInstanceOf(SomeInstance::class, $value);'
+                ),
             ],
         );
     }
@@ -66,12 +72,19 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        $oldMethodNames = array_keys(self::RENAME_METHODS_MAP);
-        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, $oldMethodNames)) {
+        if ($node->isFirstClassCallable()) {
             return null;
         }
 
-        if ($node->isFirstClassCallable()) {
+        if ($this->testsNodeAnalyzer->isPHPUnitMethodCallNames(
+            $node,
+            ['assertSame', 'assertNotSame', 'assertEquals', 'assertNotEquals']
+        )) {
+            return $this->refactorGetClass($node);
+        }
+
+        $oldMethodNames = array_keys(self::RENAME_METHODS_MAP);
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, $oldMethodNames)) {
             return null;
         }
 
@@ -85,6 +98,34 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
         $this->changeArgumentsOrder($node);
 
         return $node;
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    private function refactorGetClass(Node $node): ?Node
+    {
+        // we need 2 args
+        if (! isset($node->args[1])) {
+            return null;
+        }
+
+        $secondArgument = $node->getArgs()[1];
+        $secondArgumentValue = $secondArgument->value;
+
+        if ($secondArgumentValue instanceof FuncCall && $this->isName($secondArgumentValue->name, 'get_class')) {
+            $node->args[1] = $secondArgumentValue->getArgs()[0];
+
+            if ($this->isNames($node->name, ['assertSame', 'assertEquals'])) {
+                $node->name = new Identifier('assertInstanceOf');
+            } elseif ($this->isNames($node->name, ['assertNotSame', 'assertNotEquals'])) {
+                $node->name = new Identifier('assertNotInstanceOf');
+            }
+
+            return $node;
+        }
+
+        return null;
     }
 
     private function changeArgumentsOrder(MethodCall|StaticCall $node): void


### PR DESCRIPTION
With the two recent PRs, 

AssertCompareToSpecificMethodRector is now fully covered by both
- AssertInstanceOfComparisonRector
- AssertCompareOnCountableWithMethodToAssertCountRector

Do we want to
- Deprecate AssertCompareToSpecificMethodRector in another PR ?
- At least remove AssertCompareToSpecificMethodRector from the CodeQuality set ? (Since it won't fix anything not covered by others rules)

@TomasVotruba 