### PR TITLE
[CodeQuality] Skip loose compare float vs integer on AssertEqualsToSameRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_loose_compare.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_loose_compare.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipLooseCompare extends TestCase
+{
+    public function test()
+    {
+        $this->assertEquals(1, 1.0);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_loose_compare2.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_loose_compare2.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipLooseCompare2 extends TestCase
+{
+    public function test()
+    {
+        $this->assertEquals(1.0, 1);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_mixed_array_dim_fetch.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_mixed_array_dim_fetch.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipMixedArrayDimFetch extends TestCase
+{
+    public function test()
+    {
+        $data = $this->getData();
+        $this->assertEquals(1.0, $data[0]);
+    }
+
+    private function getData(): array
+    {
+        return [1];
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -6,6 +6,7 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -15,6 +16,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
@@ -107,6 +109,10 @@ final class AssertEqualsToSameRector extends AbstractRector
         }
 
         if ($firstArgType instanceof IntegerType && $secondArgType instanceof FloatType) {
+            return null;
+        }
+
+        if ($args[1]->value instanceof ArrayDimFetch && $secondArgType instanceof MixedType) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -86,7 +86,7 @@ final class AssertEqualsToSameRector extends AbstractRector
         }
 
         $args = $node->getArgs();
-        if (! isset($args[0])) {
+        if (! isset($args[0], $args[1])) {
             return null;
         }
 
@@ -99,13 +99,24 @@ final class AssertEqualsToSameRector extends AbstractRector
             return null;
         }
 
+        $firstArgType = $this->nodeTypeResolver->getNativeType($args[0]->value);
+        $secondArgType = $this->nodeTypeResolver->getNativeType($args[1]->value);
+
+        if ($firstArgType instanceof FloatType && $secondArgType instanceof IntegerType) {
+            return null;
+        }
+
+        if ($firstArgType instanceof IntegerType && $secondArgType instanceof FloatType) {
+            return null;
+        }
+
         $hasChanged = $this->identifierManipulator->renameNodeWithMap($node, self::RENAME_METHODS_MAP);
         return $hasChanged ? $node : null;
     }
 
     private function shouldSkipConstantArrayType(Expr $expr): bool
     {
-        $type = $this->getType($expr);
+        $type = $this->nodeTypeResolver->getNativeType($expr);
 
         if (! $type instanceof ConstantArrayType) {
             return false;
@@ -162,7 +173,7 @@ final class AssertEqualsToSameRector extends AbstractRector
             return true;
         }
 
-        $valueNodeType = $this->nodeTypeResolver->getType($expr);
+        $valueNodeType = $this->nodeTypeResolver->getNativeType($expr);
         return $this->isScalarType($valueNodeType);
     }
 }

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -6,7 +6,6 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -101,19 +101,18 @@ final class AssertEqualsToSameRector extends AbstractRector
             return null;
         }
 
-        $firstArgType = $this->nodeTypeResolver->getNativeType($args[0]->value);
-        $secondArgType = $this->nodeTypeResolver->getNativeType($args[1]->value);
+        if ($this->isName($node->name, 'assertEquals')) {
+            $firstArgType = $this->nodeTypeResolver->getNativeType($args[0]->value);
+            $secondArgType = $this->nodeTypeResolver->getNativeType($args[1]->value);
 
-        if ($firstArgType instanceof FloatType && $secondArgType instanceof IntegerType) {
-            return null;
-        }
+            // loose comparison
+            if ($firstArgType instanceof IntegerType && ($secondArgType instanceof FloatType || $secondArgType instanceof MixedType)) {
+                return null;
+            }
 
-        if ($firstArgType instanceof IntegerType && $secondArgType instanceof FloatType) {
-            return null;
-        }
-
-        if ($args[1]->value instanceof ArrayDimFetch && $secondArgType instanceof MixedType) {
-            return null;
+            if ($firstArgType instanceof FloatType && ($secondArgType instanceof IntegerType || $secondArgType instanceof MixedType)) {
+                return null;
+            }
         }
 
         $hasChanged = $this->identifierManipulator->renameNodeWithMap($node, self::RENAME_METHODS_MAP);


### PR DESCRIPTION
The following should be skipped:

```php
$this->assertEquals(1.0, 1);
```

as cause error on assertSame().