### PR TITLE
[CodeQuality] Skip compare to mixed on AssertEqualsToSameRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/assert_same_constant_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/assert_same_constant_array.php.inc
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 final class AssertSameConstantArray extends TestCase
 {
-    public function test($result)
+    public function test(array $result)
     {
         $expected = [1 => 2];
         $this->assertEquals($expected, $result);
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 
 final class AssertSameConstantArray extends TestCase
 {
-    public function test($result)
+    public function test(array $result)
     {
         $expected = [1 => 2];
         $this->assertSame($expected, $result);

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/class_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/class_constant.php.inc
@@ -8,7 +8,7 @@ use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\
 
 final class ClassConstant extends TestCase
 {
-    public function test($result)
+    public function test(string $result)
     {
         $this->assertEquals(SimpleConstantList::BOTTOM, $result);
     }
@@ -26,7 +26,7 @@ use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\
 
 final class ClassConstant extends TestCase
 {
-    public function test($result)
+    public function test(string $result)
     {
         $this->assertSame(SimpleConstantList::BOTTOM, $result);
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/php80_enum.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/php80_enum.php.inc
@@ -7,7 +7,7 @@ use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\
 
 final class Php80Enum extends TestCase
 {
-    public function test($result)
+    public function test(string $result)
     {
         $this->assertEquals(SimpleEnum::LEFT, $result);
     }
@@ -24,7 +24,7 @@ use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\
 
 final class Php80Enum extends TestCase
 {
-    public function test($result)
+    public function test(string $result)
     {
         $this->assertSame(SimpleEnum::LEFT, $result);
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_compare_mixed.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_compare_mixed.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipCompareMixed extends TestCase
+{
+    public function test(mixed $result)
+    {
+        $this->assertEquals('test', $result);
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -107,11 +107,11 @@ final class AssertEqualsToSameRector extends AbstractRector
             $secondArgType = TypeCombinator::removeNull($this->nodeTypeResolver->getNativeType($args[1]->value));
 
             // loose comparison
-            if ($firstArgType instanceof IntegerType && ($secondArgType instanceof FloatType || $secondArgType instanceof MixedType)) {
+            if ($firstArgType instanceof IntegerType && $secondArgType instanceof FloatType) {
                 return null;
             }
 
-            if ($firstArgType instanceof FloatType && ($secondArgType instanceof IntegerType || $secondArgType instanceof MixedType)) {
+            if ($firstArgType instanceof FloatType && $secondArgType instanceof IntegerType) {
                 return null;
             }
 
@@ -119,6 +119,11 @@ final class AssertEqualsToSameRector extends AbstractRector
                 $args[1]->value,
                 new ObjectType('Stringable')
             )) {
+                return null;
+            }
+
+            // compare to mixed type is can be anything
+            if ($secondArgType instanceof MixedType) {
                 return null;
             }
         }


### PR DESCRIPTION
compare to mixed is never guessable the type, can be anything, so this PR skip it.