### PR TITLE
Removed named args in data provides

### DIFF
--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_multiple_yields.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_multiple_yields.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithMultipleYields extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield ['namedArg' => 100, 'another' => 'arg1'];
+        yield ['secondNamedArg' => 27, 'theOther' => 'arg2'];
+        yield [3.2 => 32, 'nonOfOne' => 3];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithMultipleYields extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [100, 'arg1'];
+        yield [27, 'arg2'];
+        yield [32, 3];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_named_and_not_named_args.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_named_and_not_named_args.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithNamedAndNotNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield ['namedArg' => 100, null];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithNamedAndNotNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [100, null];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_named_args.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_named_args.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield ['namedArg' => 100, 'another' => 'arg1'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [100, 'arg1'];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_no_named_args.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_no_named_args.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithNoNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [100];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithNoNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [100];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_return.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_return.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithReturn extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        return ['namedArg' => 100, 'another' => 'arg1'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithReturn extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        return [100, 'arg1'];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_several_named_and_not_named_args.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/Fixture/provide_data_with_several_named_and_not_named_args.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithSeveralNamedAndNotNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [
+            'namedArg' => 100,
+            null,
+            fn() => 'G-EAZY',
+            'Key' => fn() => 'Post Malone',
+            'another' => 'arg1',
+            new \Exception(),
+            true,
+            'false' => false
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProvideDataWithSeveralNamedAndNotNamedArgs extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [
+            100,
+            null,
+            fn() => 'G-EAZY',
+            fn() => 'Post Malone',
+            'arg1',
+            new \Exception(),
+            true,
+            false
+        ];
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/RemoveNamedArgsInDataProviderRectorTest.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/RemoveNamedArgsInDataProviderRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveNamedArgsInDataProviderRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveNamedArgsInDataProviderRector::class);
+};

--- a/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
+++ b/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\PHPUnit100\Rector\Class_;
 
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Stmt\Class_;
@@ -92,13 +96,13 @@ CODE_SAMPLE
 
         $dataProviders = $this->dataProviderClassMethodFinder->find($node);
         foreach ($dataProviders as $dataProvider) {
-            /** @var Node\Stmt\Expression $stmt */
+            /** @var Expression $stmt */
             foreach ($dataProvider->getStmts() ?? [] as $stmt) {
                 $expr = $stmt->expr;
-                if ($expr instanceof Node\Expr\Yield_) {
+                if ($expr instanceof Yield_) {
                     $this->handleStmt($expr->value);
                     $hasChanged = true;
-                } elseif ($expr instanceof Node\Expr\Array_) {
+                } elseif ($expr instanceof Array_) {
                     $this->handleStmt($expr);
                     $hasChanged = true;
                 }
@@ -112,13 +116,14 @@ CODE_SAMPLE
         return null;
     }
 
-    private function handleStmt(Node\Expr\Array_ $expr): void
+    private function handleStmt(Array_ $array): void
     {
-        foreach ($expr->items as $item) {
+        foreach ($array->items as $item) {
             if (! $item instanceof ArrayItem) {
                 continue;
             }
-            if (! $item->key instanceof Node\Scalar\Int_) {
+
+            if (! $item->key instanceof Int_) {
                 $item->key = null;
             }
         }

--- a/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
+++ b/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit100\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Stmt\Class_;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
+use Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector\RemoveNamedArgsInDataProviderRectorTest;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see RemoveNamedArgsInDataProviderRectorTest
+ */
+final class RemoveNamedArgsInDataProviderRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove named arguments in data provider', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield ['namedArg' => 100];
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [100];
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        $dataProviders = $this->dataProviderClassMethodFinder->find($node);
+        foreach ($dataProviders as $dataProvider) {
+            /** @var Node\Stmt\Expression $stmt */
+            foreach ($dataProvider->getStmts() ?? [] as $stmt) {
+                $expr = $stmt->expr;
+                if ($expr instanceof Node\Expr\Yield_) {
+                    $this->handleYieldStmt($expr);
+                    $hasChanged = true;
+                } elseif ($expr instanceof Node\Expr\Array_) {
+                    $this->handleReturnStmt($expr);
+                    $hasChanged = true;
+                }
+            }
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function handleYieldStmt(Node\Expr\Yield_ $expr): void
+    {
+        /** @var Node\Expr\Array_ $value */
+        $value = $expr->value;
+        foreach ($value->items as $item) {
+            if (! $item instanceof ArrayItem) {
+                continue;
+            }
+            if (! $item->key instanceof Node\Scalar\Int_) {
+                $item->key = null;
+            }
+        }
+    }
+
+    private function handleReturnStmt(Node\Expr\Array_ $expr): void
+    {
+        foreach ($expr->items as $item) {
+            if (! $item instanceof ArrayItem) {
+                continue;
+            }
+            if (! $item->key instanceof Node\Scalar\Int_) {
+                $item->key = null;
+            }
+        }
+    }
+}

--- a/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
+++ b/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
@@ -96,10 +96,10 @@ CODE_SAMPLE
             foreach ($dataProvider->getStmts() ?? [] as $stmt) {
                 $expr = $stmt->expr;
                 if ($expr instanceof Node\Expr\Yield_) {
-                    $this->handleYieldStmt($expr);
+                    $this->handleStmt($expr->value);
                     $hasChanged = true;
                 } elseif ($expr instanceof Node\Expr\Array_) {
-                    $this->handleReturnStmt($expr);
+                    $this->handleStmt($expr);
                     $hasChanged = true;
                 }
             }
@@ -112,21 +112,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function handleYieldStmt(Node\Expr\Yield_ $expr): void
-    {
-        /** @var Node\Expr\Array_ $value */
-        $value = $expr->value;
-        foreach ($value->items as $item) {
-            if (! $item instanceof ArrayItem) {
-                continue;
-            }
-            if (! $item->key instanceof Node\Scalar\Int_) {
-                $item->key = null;
-            }
-        }
-    }
-
-    private function handleReturnStmt(Node\Expr\Array_ $expr): void
+    private function handleStmt(Node\Expr\Array_ $expr): void
     {
         foreach ($expr->items as $item) {
             if (! $item instanceof ArrayItem) {


### PR DESCRIPTION
Hi, according to #429 , I created a rule to remove the keys from the provided array in data provider methods.