### PR TITLE
[PHPUnit10] Replace deleted PHPUnit methods

### DIFF
--- a/rules-tests/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture_static.php.inc
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector/Fixture/fixture_static.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyPropertyExistsWithoutAssertRectorTest extends TestCase
+{
+    public function test()
+    {
+        $this->assertClassHasStaticAttribute('property', 'stdClass');
+        $this->assertClassHasStaticAttribute('property', stdClass::class);
+        $this->classHasStaticAttribute('property', stdClass::class, 'message');
+        $this->assertClassNotHasStaticAttribute('property', 'Namespaced\stdClass', 'message');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyPropertyExistsWithoutAssertRectorTest extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(property_exists('stdClass', 'property'));
+        $this->assertTrue(property_exists(stdClass::class, 'property'));
+        $this->assertTrue(property_exists(stdClass::class, 'property'), 'message');
+        $this->assertFalse(property_exists('Namespaced\stdClass', 'property'), 'message');
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector/PropertyExistsWithoutAssertRectorTest.php
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector/PropertyExistsWithoutAssertRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PropertyExistsWithoutAssertRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(PropertyExistsWithoutAssertRector::class);
+};

--- a/rules/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
+++ b/rules/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit100\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @url https://github.com/sebastianbergmann/phpunit/issues/4601
+ *
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\PropertyExistsWithoutAssertRector\PropertyExistsWithoutAssertRectorTest
+ */
+final class PropertyExistsWithoutAssertRector extends AbstractRector
+{
+    /**
+     * @var array<string, string>
+     */
+    private const RENAME_METHODS_WITH_OBJECT_MAP = [
+        'assertClassHasStaticAttribute' => 'assertTrue',
+        'classHasStaticAttribute' => 'assertTrue',
+        'assertClassNotHasStaticAttribute' => 'assertFalse',
+    ];
+
+    public function __construct(
+        private readonly IdentifierManipulator $identifierManipulator,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace delited PHPUnit methods: assertClassHasStaticAttribute, classHasStaticAttribute and assertClassNotHasStaticAttribute by property_exists()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$this->assertClassHasStaticAttribute("Class", "property");
+$this->classHasStaticAttribute("Class", "property");
+$this->assertClassNotHasStaticAttribute("Class", "property");
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$this->assertTrue(property_exists("Class", "property"));
+$this->assertTrue(property_exists("Class", "property"));
+$this->assertFalse(property_exists("Class", "property"));
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $map = self::RENAME_METHODS_WITH_OBJECT_MAP;
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, array_keys($map))) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable() || ! isset($node->getArgs()[0], $node->getArgs()[1])) {
+            return null;
+        }
+
+        $firstNode = new Arg($node->getArgs()[0]->value);
+
+        if ($node->getArgs()[1]->value instanceof ClassConstFetch) {
+            $secondNode = $node->getArgs()[1];
+        } else {
+            $secondNode = new Arg($node->getArgs()[1]->value);
+        }
+
+        $funcCall = new FuncCall(new Name('property_exists'), [$secondNode, $firstNode]);
+
+        $newArgs = $this->nodeFactory->createArgs([$funcCall]);
+
+        unset($node->args[0], $node->args[1]);
+        $node->args = array_merge($newArgs, $node->getArgs());
+
+        $this->identifierManipulator->renameNodeWithMap($node, $map);
+
+        return $node;
+    }
+}


### PR DESCRIPTION
Replace deleted PHPUnit methods: 
assertClassHasStaticAttribute
classHasStaticAttribute
assertClassNotHasStaticAttribute 

by property_exists()

https://github.com/sebastianbergmann/phpunit/issues/4601