### PR TITLE
Added testcase to demonstrate rector#8977

### DIFF
--- a/tests/AnnotationsToAttributes/Fixture/inline_docblock_tag.php.inc
+++ b/tests/AnnotationsToAttributes/Fixture/inline_docblock_tag.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Example {@link https://example.com}
+ * @covers \Tests\BarController
+ */
+class BarController extends TestCase
+{
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Example {@link https://example.com}
+ */
+#[\PHPUnit\Framework\Attributes\CoversClass(\Tests\BarController::class)]
+class BarController extends TestCase
+{
+}
+
+?>


### PR DESCRIPTION
Where an inline docblock is used in another tag, all subsequent tags are removed.

https://github.com/rectorphp/rector/issues/8977

I've tried to keep this as small as possible but have deliberately incldued:
* a text node
* a tag before the tag containing the inline tag
* a tag after the tag containing the inline tag
* the tag we want to convert to attribute