### PR TITLE
[AnnotationsToAttributes] Fix @covers qualified::method conversion

### DIFF
--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_class.php.inc
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass
+ * @covers \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\AnotherExistingClass::someMethod
  */
 final class CoversClass extends TestCase
 {
@@ -23,6 +24,7 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 use PHPUnit\Framework\TestCase;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
+#[\PHPUnit\Framework\Attributes\CoversMethod(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\AnotherExistingClass::class, 'someMethod')]
 final class CoversClass extends TestCase
 {
     public function test()

--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_method.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector/Fixture/covers_method.php.inc
@@ -12,6 +12,13 @@ final class CoversMethod extends TestCase
     public function test()
     {
     }
+
+    /**
+     * @covers \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\AnotherExistingClass::someMethod
+     */
+    public function test_foo()
+    {
+    }
 }
 
 ?>
@@ -23,9 +30,14 @@ namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnot
 use PHPUnit\Framework\TestCase;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\ExistingClass::class)]
+#[\PHPUnit\Framework\Attributes\CoversMethod(\Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\Source\AnotherExistingClass::class, 'someMethod')]
 final class CoversMethod extends TestCase
 {
     public function test()
+    {
+    }
+
+    public function test_foo()
     {
     }
 }

--- a/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
@@ -149,6 +149,7 @@ final class AssertFuncCallToPHPUnitAssertRector extends AbstractRector
         if (str_ends_with($className, 'Test')) {
             return true;
         }
+
         return str_ends_with($className, 'TestCase');
     }
 

--- a/tests/Issues/DoubleAnnotation/Fixture/some_test.php.inc
+++ b/tests/Issues/DoubleAnnotation/Fixture/some_test.php.inc
@@ -29,7 +29,7 @@ namespace Rector\PHPUnit\Tests\Issues\DoubleAnnotation\Fixture;
 use PHPUnit\Framework\TestCase;
 use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector\Fixture\SomeClass;
 
-#[\PHPUnit\Framework\Attributes\CoversClass(\SomeClass::class)]
+#[\PHPUnit\Framework\Attributes\CoversMethod(\SomeClass::class, 'method')]
 final class SomeTest extends TestCase
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('generatorInput')]
@@ -42,4 +42,3 @@ final class SomeTest extends TestCase
     {
     }
 }
-


### PR DESCRIPTION
The PHPUnit 9.6 `@covers` annotation supports specification of methods:
https://docs.phpunit.de/en/9.6/annotations.html#covers

That is:

```
/**
 * @covers \someClass::someMethod
 */
```

The `CoversAnnotationWithValueToAttributeRector` conversion is currently unaware of this and converting it to a `CoversClass` attribute, that is:

```
#[\PHPUnit\Framework\Attributes\CoversClass(\someClass::someMethod)
```

This is, of course, a syntax error. It should create a `CoversMethod` attribute:

```
#[\PHPUnit\Framework\Attributes\CoversClass(\someClass::class, 'someMethod')
```

This patch changes the behaviour to look for a `::` in the annotation and, if found, grab the class and use the `CoversMethod` Attribute with the class and method name. The behaviour for an annotation that _starts_ with `::` is unaffected.