### PR TITLE
Adds AssertCountWithZeroToAssertEmptyRector rule

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -15,6 +15,7 @@ use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefi
 use Rector\PHPUnit\CodeQuality\Rector\Foreach_\SimplifyForeachInstanceOfRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;
@@ -72,6 +73,7 @@ return static function (RectorConfig $rectorConfig): void {
         UseSpecificWillMethodRector::class,
         UseSpecificWithMethodRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
+        AssertCountWithZeroToAssertEmptyRector::class,
 
         /**
          * Improve direct testing of your code, without mock creep. Make it simple, clear and easy to maintain:

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/AssertCountWithZeroToAssertEmptyRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/AssertCountWithZeroToAssertEmptyRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertCountWithZeroToAssertEmptyRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/count_to_empty.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/count_to_empty.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Source\Collection;
+
+final class CountToEmpty extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertCount(0, $collection);
+        $this->assertCount(0, $collection, 'message here!');
+        $this->assertNotCount(0, $collection);
+        $this->assertNotCount(0, $collection, 'message here!');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Source\Collection;
+
+final class CountToEmpty extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertEmpty($collection);
+        $this->assertEmpty($collection, 'message here!');
+        $this->assertNotEmpty($collection);
+        $this->assertNotEmpty($collection, 'message here!');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_first_class_callable.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Source\Collection;
+
+final class SkipOnFirstClassCallable extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertCount(...);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_non_test_class.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Source\Collection;
+
+final class SkipOnNonTestClass
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertCount(5, $collection);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_non_test_class.php.inc
@@ -9,7 +9,7 @@ final class SkipOnNonTestClass
     public function test()
     {
         $collection = new Collection();
-        $this->assertCount(5, $collection);
+        $this->assertCount(0, $collection);
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_non_zero_argument.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Fixture/skip_on_non_zero_argument.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Source\Collection;
+
+final class SkipOnNonZeroArgument extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $collection = new Collection();
+        $this->assertCount(5, $collection);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Source/Collection.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/Source/Collection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\Source;
+
+class Collection implements \Countable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AssertCountWithZeroToAssertEmptyRector::class);
+};

--- a/rules/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector\AssertCountWithZeroToAssertEmptyRectorTest
+ */
+final class AssertCountWithZeroToAssertEmptyRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change $this->assertCount(0, ...) to $this->assertEmpty(...)',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+    $this->assertCount(0, $countable);
+    $this->assertNotCount(0, $countable);
+    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+    $this->assertEmpty($countable);
+    $this->assertNotEmpty($countable);
+    CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<MethodCall|StaticCall>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): MethodCall|StaticCall|null
+    {
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, ['assertCount', 'assertNotCount'])) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (count($node->getArgs()) < 2) {
+            return null;
+        }
+
+        $type = $this->getType($node->getArgs()[0]->value);
+        $value = ($type->getConstantScalarValues()[0] ?? null);
+        if ($value === 0) {
+            $args = $node->getArgs();
+            if ($this->isName($node->name, 'assertNotCount')) {
+                $node->name = new Name('assertNotEmpty');
+            } else {
+                $node->name = new Name('assertEmpty');
+            }
+
+            array_shift($args);
+            $node->args = $args;
+            return $node;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
# Changes

* Adds a new AssertCountWithZeroToAssertEmptyRector.
* Adds tests for the rule.
* Added to code quality set.

# Why

This is just a small but useful rector rule. It will convert use of `assertCount` with a first parameter of zero to be `assertEmpty`. Also handles the `not` use as well.

```diff
-$this->assertCount(0, $array);
+$this->assertEmpty($array);
-$this->assertNotCount(0, $array);
+$this->assertNotEmpty($array);
```