### PR TITLE
[Attribute] Fix typo RequiresExtension -> RequiresPhpExtension on RequiresAnnotationWithValueToAttributeRector

### DIFF
--- a/rules-tests/AnnotationsToAttributes/Rector/Class_/RequiresAnnotationWithValueToAttributeRector/Fixture/requires_fixture.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/Class_/RequiresAnnotationWithValueToAttributeRector/Fixture/requires_fixture.php.inc
@@ -43,8 +43,8 @@ use PHPUnit\Framework\TestCase;
 #[\PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily('Darwin')]
 #[\PHPUnit\Framework\Attributes\RequiresFunction('someFunction')]
 #[\PHPUnit\Framework\Attributes\RequiresMethod(\some\className::class, 'someMethod')]
-#[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli')]
-#[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli', '>= 8.3.0')]
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli')]
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli', '>= 8.3.0')]
 #[\PHPUnit\Framework\Attributes\RequiresSetting('date.timezone', 'Europe/Berlin')]
 class BarController extends TestCase
 {
@@ -54,8 +54,8 @@ class BarController extends TestCase
     #[\PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily('Darwin')]
     #[\PHPUnit\Framework\Attributes\RequiresFunction('someFunction')]
     #[\PHPUnit\Framework\Attributes\RequiresMethod(\some\className::class, 'someMethod')]
-    #[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli')]
-    #[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli', '>= 8.3.0')]
+    #[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli')]
+    #[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli', '>= 8.3.0')]
     #[\PHPUnit\Framework\Attributes\RequiresSetting('date.timezone', 'Europe/Berlin')]
     public function testWithRequires()
     {

--- a/rules/AnnotationsToAttributes/Rector/Class_/RequiresAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/RequiresAnnotationWithValueToAttributeRector.php
@@ -83,8 +83,8 @@ use PHPUnit\Framework\TestCase;
 #[\PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily('Darwin')]
 #[\PHPUnit\Framework\Attributes\RequiresFunction('someFunction')]
 #[\PHPUnit\Framework\Attributes\RequiresMethod(\some\className::class, 'someMethod')]
-#[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli')]
-#[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli', '>= 8.3.0')]
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli')]
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli', '>= 8.3.0')]
 #[\PHPUnit\Framework\Attributes\RequiresSetting('date.timezone', 'Europe/Berlin')]
 final class SomeTest extends TestCase
 {
@@ -95,8 +95,8 @@ final class SomeTest extends TestCase
     #[\PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily('Darwin')]
     #[\PHPUnit\Framework\Attributes\RequiresFunction('someFunction')]
     #[\PHPUnit\Framework\Attributes\RequiresMethod(\some\className::class, 'someMethod')]
-    #[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli')]
-    #[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli', '>= 8.3.0')]
+    #[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli')]
+    #[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli', '>= 8.3.0')]
     #[\PHPUnit\Framework\Attributes\RequiresSetting('date.timezone', 'Europe/Berlin')]
     public function test()
     {
@@ -194,7 +194,7 @@ CODE_SAMPLE
 
                 break;
             case 'extension':
-                $attributeClass = 'PHPUnit\Framework\Attributes\RequiresExtension';
+                $attributeClass = 'PHPUnit\Framework\Attributes\RequiresPhpExtension';
                 $attributeValue = explode(' ', (string) $attributeValue, 2);
                 break;
             case 'setting':

--- a/tests/AnnotationsToAttributes/Fixture/requires_fixture.php.inc
+++ b/tests/AnnotationsToAttributes/Fixture/requires_fixture.php.inc
@@ -43,8 +43,8 @@ use PHPUnit\Framework\TestCase;
 #[\PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily('Darwin')]
 #[\PHPUnit\Framework\Attributes\RequiresFunction('someFunction')]
 #[\PHPUnit\Framework\Attributes\RequiresMethod(\some\className::class, 'someMethod')]
-#[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli')]
-#[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli', '>= 8.3.0')]
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli')]
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli', '>= 8.3.0')]
 #[\PHPUnit\Framework\Attributes\RequiresSetting('date.timezone', 'Europe/Berlin')]
 class BarController extends TestCase
 {
@@ -54,8 +54,8 @@ class BarController extends TestCase
     #[\PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily('Darwin')]
     #[\PHPUnit\Framework\Attributes\RequiresFunction('someFunction')]
     #[\PHPUnit\Framework\Attributes\RequiresMethod(\some\className::class, 'someMethod')]
-    #[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli')]
-    #[\PHPUnit\Framework\Attributes\RequiresExtension('mysqli', '>= 8.3.0')]
+    #[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli')]
+    #[\PHPUnit\Framework\Attributes\RequiresPhpExtension('mysqli', '>= 8.3.0')]
     #[\PHPUnit\Framework\Attributes\RequiresSetting('date.timezone', 'Europe/Berlin')]
     public function testWithRequires()
     {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9042