### PR TITLE
[PHPUnit] Handle mix AssertCountWithZeroToAssertEmptyRector + AssertEmptyNullableObjectToAssertInstanceofRector cause invalid assertNotInstanceof()

### DIFF
--- a/rules/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector.php
@@ -75,7 +75,7 @@ final class AssertCountWithZeroToAssertEmptyRector extends AbstractRector
             return null;
         }
 
-        $secondType  = $this->getType($node->getArgs()[1]->value);
+        $secondType = $this->getType($node->getArgs()[1]->value);
         if ($secondType instanceof UnionType) {
             return null;
         }

--- a/rules/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCountWithZeroToAssertEmptyRector.php
@@ -75,6 +75,11 @@ final class AssertCountWithZeroToAssertEmptyRector extends AbstractRector
             return null;
         }
 
+        $secondType  = $this->getType($node->getArgs()[1]->value);
+        if ($secondType instanceof UnionType) {
+            return null;
+        }
+
         $value = ($type->getConstantScalarValues()[0] ?? null);
         if ($value === 0) {
             $args = $node->getArgs();

--- a/tests/Issues/EmptyUnion/EmptyUnionTest.php
+++ b/tests/Issues/EmptyUnion/EmptyUnionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Issues\EmptyUnion;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EmptyUnionTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/EmptyUnion/Fixture/some_test.php.inc
+++ b/tests/Issues/EmptyUnion/Fixture/some_test.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Issues\EmptyUnion\Fixture;
+
+use ArrayIterator;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function testSomething()
+    {
+        $this->assertCount(0, $this->someCall());
+    }
+
+    public function someCall(): ?ArrayIterator
+    {
+        return new ArrayIterator([]);
+    }
+}

--- a/tests/Issues/EmptyUnion/config/configured_rule.php
+++ b/tests/Issues/EmptyUnion/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        AssertCountWithZeroToAssertEmptyRector::class,
+        AssertEmptyNullableObjectToAssertInstanceofRector::class,
+    ]);
+};


### PR DESCRIPTION
On union type, it cause invalid result:

```diff
1) Rector\PHPUnit\Tests\Issues\EmptyUnion\EmptyUnionTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "some_test.php.inc"

Applied Rector rules:
 * Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector
 * Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector

Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 {
     public function testSomething()
     {
-        $this->assertCount(0, $this->someCall());
+        $this->assertNotInstanceOf(\ArrayIterator::class, $this->someCall());
```

which wrong, on assert, it always pass iterable.