### PR TITLE
[CodeQuality] Handle crash on multiple assert cause undefined variable on AddInstanceofAssertForNullableInstanceRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/multiple_assert.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/multiple_assert.php.inc
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests;
+
+final class MultipleAssert extends TestCase
+{
+    public function test(): void
+    {
+        $someObject = $this->getSomeObject();
+        $value = $someObject->getSomeMethod();
+
+        $this->assertSame(123, $value);
+
+        $someObject2 = $this->getSomeObject2();
+        $value2 = $someObject2->getSomeMethod();
+
+        $this->assertSame(123, $value2);
+    }
+
+    private function getSomeObject(): ?SomeClassUsedInTests
+    {
+        if (mt_rand(0, 1)) {
+            return new SomeClassUsedInTests();
+        }
+
+        return null;
+    }
+
+    private function getSomeObject2(): ?SomeClassUsedInTests
+    {
+        if (mt_rand(0, 1)) {
+            return new SomeClassUsedInTests();
+        }
+
+        return null;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests;
+
+final class MultipleAssert extends TestCase
+{
+    public function test(): void
+    {
+        $someObject = $this->getSomeObject();
+        $this->assertInstanceof(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
+        $value = $someObject->getSomeMethod();
+
+        $this->assertSame(123, $value);
+
+        $someObject2 = $this->getSomeObject2();
+        $this->assertInstanceof(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject2);
+        $value2 = $someObject2->getSomeMethod();
+
+        $this->assertSame(123, $value2);
+    }
+
+    private function getSomeObject(): ?SomeClassUsedInTests
+    {
+        if (mt_rand(0, 1)) {
+            return new SomeClassUsedInTests();
+        }
+
+        return null;
+    }
+
+    private function getSomeObject2(): ?SomeClassUsedInTests
+    {
+        if (mt_rand(0, 1)) {
+            return new SomeClassUsedInTests();
+        }
+
+        return null;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector.php
@@ -118,6 +118,7 @@ CODE_SAMPLE
         $hasChanged = false;
         $variableNameToTypeCollection = $this->nullableObjectAssignCollector->collect($node);
 
+        $next = 0;
         foreach ($node->stmts as $key => $stmt) {
             // has callable on nullable variable of already collected name?
             $matchedNullableVariableNameToType = $this->matchedNullableVariableNameToType(
@@ -130,13 +131,15 @@ CODE_SAMPLE
 
             // adding type here + popping the variable name out
             $assertInstanceofExpression = $this->createAssertInstanceof($matchedNullableVariableNameToType);
-            array_splice($node->stmts, $key, 0, [$assertInstanceofExpression]);
+            array_splice($node->stmts, $key + $next, 0, [$assertInstanceofExpression]);
 
             // remove variable name from nullable ones
             $hasChanged = true;
 
             // from now on, the variable is not nullable, remove to avoid double asserts
             $variableNameToTypeCollection->remove($matchedNullableVariableNameToType);
+
+            ++$next;
         }
 
         if (! $hasChanged) {


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-phpunit/pull/466#issuecomment-2762717039
Ref https://getrector.com/demo/b6a49070-ed48-44a0-885c-54dabbfdbf22

second assert is inserted before variable definition so cause undefined variable

```
Undefined variable $someObject2
```