### PR TITLE
[CodeQuality] fix assertInstanceOf casing

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/add_instance_only_once.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/add_instance_only_once.php.inc
@@ -46,7 +46,7 @@ final class AddInstanceOnlyOnce extends TestCase
     public function test(): void
     {
         $someObject = $this->getSomeObject();
-        $this->assertInstanceof(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
         $value = $someObject->getSomeMethod();
 
         $this->assertSame(123, $value);

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/call_on_nullable.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/call_on_nullable.php.inc
@@ -43,7 +43,7 @@ final class CallOnNullable extends TestCase
     public function test(): void
     {
         $someObject = $this->getSomeObject();
-        $this->assertInstanceof(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
         $value = $someObject->getSomeMethod();
 
         $this->assertSame(123, $value);

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/multiple_assert.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector/Fixture/multiple_assert.php.inc
@@ -57,13 +57,13 @@ final class MultipleAssert extends TestCase
     public function test(): void
     {
         $someObject = $this->getSomeObject();
-        $this->assertInstanceof(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject);
         $value = $someObject->getSomeMethod();
 
         $this->assertSame(123, $value);
 
         $someObject2 = $this->getSomeObject2();
-        $this->assertInstanceof(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject2);
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector\Source\SomeClassUsedInTests::class, $someObject2);
         $value2 = $someObject2->getSomeMethod();
 
         $this->assertSame(123, $value2);

--- a/rules/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableInstanceRector.php
@@ -74,7 +74,7 @@ final class SomeTest extends TestCase
     public function test()
     {
         $someObject = $this->getSomeObject();
-        $this->assertInstanceof(SomeClass::class, $someObject);
+        $this->assertInstanceOf(SomeClass::class, $someObject);
 
         $value = $someObject->getSomeMethod();
     }
@@ -130,8 +130,8 @@ CODE_SAMPLE
             }
 
             // adding type here + popping the variable name out
-            $assertInstanceofExpression = $this->createAssertInstanceof($matchedNullableVariableNameToType);
-            array_splice($node->stmts, $key + $next, 0, [$assertInstanceofExpression]);
+            $assertInstanceOfExpression = $this->createAssertInstanceOf($matchedNullableVariableNameToType);
+            array_splice($node->stmts, $key + $next, 0, [$assertInstanceOfExpression]);
 
             // remove variable name from nullable ones
             $hasChanged = true;
@@ -162,14 +162,14 @@ CODE_SAMPLE
         return count($type->getTypes()) === 2;
     }
 
-    private function createAssertInstanceof(VariableNameToType $variableNameToType): Expression
+    private function createAssertInstanceOf(VariableNameToType $variableNameToType): Expression
     {
         $args = [
             new Arg(new ClassConstFetch(new FullyQualified($variableNameToType->getObjectType()), 'class')),
             new Arg(new Variable($variableNameToType->getVariableName())),
         ];
 
-        $methodCall = new MethodCall(new Variable('this'), 'assertInstanceof', $args);
+        $methodCall = new MethodCall(new Variable('this'), 'assertInstanceOf', $args);
 
         return new Expression($methodCall);
     }


### PR DESCRIPTION
> Call to method PHPUnit\Framework\Assert::assertInstanceOf() with incorrect case: assertInstanceof

<img width="821" alt="grafik" src="https://github.com/user-attachments/assets/118cedaf-9227-4037-a2a1-41e8cbc0b7ae" />
