### PR TITLE
[PHPUnit90] Handle crash on different object without second arg on SpecificAssertContainsWithoutIdentityRector

### DIFF
--- a/rules-tests/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector/Fixture/skip_no_second_arg.php.inc
+++ b/rules-tests/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector/Fixture/skip_no_second_arg.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit90\Rector\MethodCall\SpecificAssertContainsWithoutIdentityRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class SkipNoSecondArg extends TestCase
+{
+    public function test()
+    {
+        $objects = [ new stdClass(), new stdClass(), new stdClass() ];
+        $this->transport()->queue()->assertContains(new stdClass());
+    }
+}

--- a/rules/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
@@ -92,6 +92,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (count($node->getArgs()) < 2) {
+            return null;
+        }
+
         // when second argument is string: do nothing
         $secondArgType = $this->getType($node->getArgs()[1]->value);
         if ($secondArgType instanceof StringType) {

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -41,7 +41,10 @@ final readonly class TestsNodeAnalyzer
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
 
             // fluent call PHPUnit methods
-            if ($classReflection instanceof ClassReflection && str_starts_with($classReflection->getName(),'PHPUnit\\')) {
+            if ($classReflection instanceof ClassReflection && str_starts_with(
+                $classReflection->getName(),
+                'PHPUnit\\'
+            )) {
                 $classReflection = $this->reflectionResolver->resolveClassReflection($node);
             }
         } else {

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -34,10 +34,10 @@ final readonly class TestsNodeAnalyzer
 
     public function isInTestClass(Node $node): bool
     {
-        if ($node->var instanceof Variable && $this->nodeNameResolver->isNames($node->var, ['this', 'self'])) {
-            $classReflection = $this->reflectionResolver->resolveClassReflection($node);
-        } else {
+        if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isNames($node->var, ['this', 'self']))) {
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
+        } else {
+            $classReflection = $this->reflectionResolver->resolveClassReflection($node);
         }
 
         if (! $classReflection instanceof ClassReflection) {

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\NodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
@@ -33,7 +34,11 @@ final readonly class TestsNodeAnalyzer
 
     public function isInTestClass(Node $node): bool
     {
-        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if ($node->var instanceof Variable && $this->nodeNameResolver->isNames($node->var, ['this', 'self'])) {
+            $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        } else {
+            $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
+        }
 
         if (! $classReflection instanceof ClassReflection) {
             return false;

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -34,9 +34,9 @@ final readonly class TestsNodeAnalyzer
 
     public function isInTestClass(Node $node): bool
     {
-        if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isNames(
+        if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isName(
             $node->var,
-            ['this', 'self', 'parent', 'static']
+            'this'
         ))) {
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
         } else {

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -36,7 +36,7 @@ final readonly class TestsNodeAnalyzer
     {
         if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isNames(
             $node->var,
-            ['this', 'self']
+            ['this', 'self', 'parent', 'static']
         ))) {
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
         } else {

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -39,6 +39,11 @@ final readonly class TestsNodeAnalyzer
             'this'
         ))) {
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
+
+            // fluent call PHPUnit methods
+            if ($classReflection instanceof ClassReflection && str_starts_with($classReflection->getName(),'PHPUnit\\')) {
+                $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+            }
         } else {
             $classReflection = $this->reflectionResolver->resolveClassReflection($node);
         }

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -34,7 +34,10 @@ final readonly class TestsNodeAnalyzer
 
     public function isInTestClass(Node $node): bool
     {
-        if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isNames($node->var, ['this', 'self']))) {
+        if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isNames(
+            $node->var,
+            ['this', 'self']
+        ))) {
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
         } else {
             $classReflection = $this->reflectionResolver->resolveClassReflection($node);

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -7,7 +7,6 @@ namespace Rector\PHPUnit\NodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
@@ -34,22 +33,7 @@ final readonly class TestsNodeAnalyzer
 
     public function isInTestClass(Node $node): bool
     {
-        if ($node instanceof MethodCall && (! $node->var instanceof Variable || ! $this->nodeNameResolver->isName(
-            $node->var,
-            'this'
-        ))) {
-            $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
-
-            // fluent call PHPUnit methods
-            if ($classReflection instanceof ClassReflection && str_starts_with(
-                $classReflection->getName(),
-                'PHPUnit\\'
-            )) {
-                $classReflection = $this->reflectionResolver->resolveClassReflection($node);
-            }
-        } else {
-            $classReflection = $this->reflectionResolver->resolveClassReflection($node);
-        }
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
 
         if (! $classReflection instanceof ClassReflection) {
             return false;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9104
Ref https://getrector.com/demo/7a606a35-711f-4797-b1ef-eb293a19ca0d