### PR TITLE
[PHPUnit100] Skip already key = null on RemoveNamedArgsInDataProviderRector

### DIFF
--- a/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
+++ b/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
@@ -128,6 +128,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($item->key === null) {
+                continue;
+            }
+
             if (! $item->key instanceof Int_ && $item->key instanceof Expr) {
                 $item->key = null;
                 $hasChanged = true;

--- a/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
+++ b/rules/PHPUnit100/Rector/Class_/RemoveNamedArgsInDataProviderRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($item->key === null) {
+            if (! $item->key instanceof Expr) {
                 continue;
             }
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/actions/runs/14168592413/job/40439865009?pr=6794