### PR TITLE
[phpunit 10] Add ParentTestClassConstructorRector

### DIFF
--- a/config/sets/phpunit100.php
+++ b/config/sets/phpunit100.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\AddProphecyTraitRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector;
@@ -23,6 +24,7 @@ return static function (RectorConfig $rectorConfig): void {
         WithConsecutiveRector::class,
         RemoveSetMethodsMethodCallRector::class,
         PropertyExistsWithoutAssertRector::class,
+        ParentTestClassConstructorRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/mocking_helper.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/mocking_helper.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MockingHelper extends TestCase
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MockingHelper extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct(static::class);
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_abstract_classes.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_abstract_classes.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class SkipAbstractClasses extends TestCase
+{
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_already_added.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_already_added.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipAlreadyAdded extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct(static::class);
+    }
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_in_case_of_test.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_in_case_of_test.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipInCaseOfTest extends TestCase
+{
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_in_case_of_test_case.php.inc
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/Fixture/skip_in_case_of_test_case.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipInCaseOfTestCase extends TestCase
+{
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/ParentTestClassConstructorRectorTest.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/ParentTestClassConstructorRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ParentTestClassConstructorRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ParentTestClassConstructorRector::class);
+};

--- a/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
+++ b/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
@@ -76,6 +76,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->shouldSkipClass($node)) {
+            return null;
+        }
+
         // it already has a constructor, skip as it might require specific tweaking
         if ($node->getMethod(MethodName::CONSTRUCT)) {
             return null;
@@ -95,5 +99,25 @@ CODE_SAMPLE
         $staticClassConstFetch = new ClassConstFetch(new Name('static'), 'class');
 
         return new StaticCall(new Name('parent'), MethodName::CONSTRUCT, [new Arg($staticClassConstFetch)]);
+    }
+
+    private function shouldSkipClass(Class_ $class): bool
+    {
+        if ($class->isAbstract()) {
+            return true;
+        }
+
+        if ($class->isAnonymous()) {
+            return true;
+        }
+
+        $className = $this->getName($class);
+
+        // loaded automatically by PHPUnit
+        if (str_ends_with($className, 'Test')) {
+            return true;
+        }
+
+        return str_ends_with($className, 'TestCase');
     }
 }

--- a/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
+++ b/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
@@ -20,6 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @see https://github.com/sebastianbergmann/phpunit/issues/3975
  * @see https://github.com/sebastianbergmann/phpunit/commit/705874f1b867fd99865e43cb5eaea4e6d141582f
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\ParentTestClassConstructorRectorTest
@@ -114,10 +115,10 @@ CODE_SAMPLE
         $className = $this->getName($class);
 
         // loaded automatically by PHPUnit
-        if (str_ends_with($className, 'Test')) {
+        if (str_ends_with((string) $className, 'Test')) {
             return true;
         }
 
-        return str_ends_with($className, 'TestCase');
+        return str_ends_with((string) $className, 'TestCase');
     }
 }

--- a/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
+++ b/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit100\Rector\Class_;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Arg;
+use PhpParser\Modifiers;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\MethodName;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/sebastianbergmann/phpunit/commit/705874f1b867fd99865e43cb5eaea4e6d141582f
+ *
+ * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\ParentTestClassConstructorRectorTest
+ */
+final class ParentTestClassConstructorRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('PHPUnit\Framework\TestCase requires a parent constructor call', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeHelper extends TestCase
+{
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeHelper extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct(static::class);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        // it already has a constructor, skip as it might require specific tweaking
+        if ($node->getMethod(MethodName::CONSTRUCT)) {
+            return null;
+        }
+
+        $constructorClassMethod = new ClassMethod(MethodName::CONSTRUCT);
+        $constructorClassMethod->flags |= Modifiers::PUBLIC;
+        $constructorClassMethod->stmts[] = new Expression($this->createParentConstructorCall());
+
+        $node->stmts = array_merge([$constructorClassMethod], $node->stmts);
+
+        return $node;
+    }
+
+    private function createParentConstructorCall(): StaticCall
+    {
+        $staticClassConstFetch = new ClassConstFetch(new Name('static'), 'class');
+
+        return new StaticCall(new Name('parent'), MethodName::CONSTRUCT, [new Arg($staticClassConstFetch)]);
+    }
+}

--- a/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
+++ b/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\PHPUnit100\Rector\Class_;
 
-use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Arg;
 use PhpParser\Modifiers;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;


### PR DESCRIPTION
Fixes BC break in case of non-test `TestCase` class use, ref https://github.com/sebastianbergmann/phpunit/commit/705874f1b867fd99865e43cb5eaea4e6d141582f

Ref https://github.com/sebastianbergmann/phpunit/issues/3975

