### PR TITLE
 [PHPUnit 12] Add RemoveOverrideFinalConstructTestCaseRector 

### DIFF
--- a/config/sets/phpunit110.php
+++ b/config/sets/phpunit110.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(NamedArgumentForDataProviderRector::class);
 };

--- a/config/sets/phpunit120.php
+++ b/config/sets/phpunit120.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+};

--- a/config/sets/phpunit120.php
+++ b/config/sets/phpunit120.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveOverrideFinalConstructTestCaseRector::class);
 };

--- a/rules-tests/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector/Fixture/fixture.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct(static::class);
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+}
+?>

--- a/rules-tests/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector/RemoveOverrideFinalConstructTestCaseRectorTest.php
+++ b/rules-tests/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector/RemoveOverrideFinalConstructTestCaseRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveOverrideFinalConstructTestCaseRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveOverrideFinalConstructTestCaseRector::class);
+};

--- a/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
+++ b/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
@@ -119,6 +119,10 @@ CODE_SAMPLE
             return true;
         }
 
-        return str_ends_with((string) $className, 'TestCase');
+        if (str_ends_with((string) $className, 'TestCase')) {
+            return true;
+        }
+
+        return (bool) $class->getAttribute('hasRemovedFinalConstruct');
     }
 }

--- a/rules/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector.php
+++ b/rules/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector.php
@@ -5,15 +5,8 @@ declare(strict_types=1);
 namespace Rector\PHPUnit\PHPUnit120\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\Return_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;

--- a/rules/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector.php
+++ b/rules/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit120\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\MethodName;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector\RemoveOverrideFinalConstructTestCaseRectorTest
+ */
+final class RemoveOverrideFinalConstructTestCaseRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove override final construct test case',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    use PHPUnit\Framework\TestCase;
+
+                    final class SomeClass extends TestCase
+                    {
+                        public function __construct()
+                        {
+                            parent::__construct(static::class);
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                    use PHPUnit\Framework\TestCase;
+
+                    final class SomeClass extends TestCase
+                    {
+                    }
+                    CODE_SAMPLE
+                    ,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): Node|null
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
+
+        if ($constructClassMethod instanceof ClassMethod) {
+            foreach ($node->stmts as $key => $stmt) {
+                if ($stmt instanceof ClassMethod && $this->isName($stmt, MethodName::CONSTRUCT)) {
+                    unset($node->stmts[$key]);
+
+                    $node->setAttribute('hasRemovedFinalConstruct', true);
+                    return $node;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -52,6 +52,11 @@ final class PHPUnitSetList
     /**
      * @var string
      */
+    public const PHPUNIT_120 = __DIR__ . '/../../config/sets/phpunit120.php';
+
+    /**
+     * @var string
+     */
     public const PHPUNIT_CODE_QUALITY = __DIR__ . '/../../config/sets/phpunit-code-quality.php';
 
     /**


### PR DESCRIPTION
- add phpunit 12 rule to remove `__construct` as already final
- use attribute flag `hasRemovedFinalConstruct` so in rule `ParentTestClassConstructorRector` can be checked to avoid flip flop change when both rules accidentally registered.
- Register missing phpunit 11 rule on config.

Fixes Closes https://github.com/rectorphp/rector/issues/9180