### PR TITLE
PHPUnit 10/11 Only set attribute when target attribute class exists on CoversAnnotationWithValueToAttributeRector

### DIFF
--- a/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -166,7 +166,7 @@ CODE_SAMPLE
                 if ($classReflection->isTrait()) {
                     $attributeClass = self::COVERTS_TRAIT_ATTRIBUTE;
                     if (! $this->reflectionProvider->hasClass($attributeClass)) {
-                       return null;
+                        return null;
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9183