### PR TITLE
Update to use ramsey/composer-install@v2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,6 @@ jobs:
                     php-version: 8.2
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v1"
+            -   uses: "ramsey/composer-install@v2"
 
             -   run: vendor/bin/phpunit


### PR DESCRIPTION
v1 got error cache and deprecated github output notice recently, see https://github.com/rectorphp/rector-downgrade-php/actions/runs/15288269729/job/43002974649#step:4:289

this PR fix it, similar with patch at https://github.com/rectorphp/rector-downgrade-php/pull/283/commits/305713b852b7ea75f14a864425f94fe99ba9edd3