### PR TITLE
[Attribute] Handle comment below @dataProvider doc on DataProviderAnnotationToAttributeRector

### DIFF
--- a/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/with_comment_above.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/with_comment_above.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+class WithCommentAbove extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * This is a useless test to demonstrate a problem.
+     *
+     * @dataProvider dataProvider
+     */
+    public function testProvider(bool $expected): void
+    {
+        self::assertSame($expected, $expected);
+    }
+
+    public static function dataProvider(): iterable
+    {
+        yield [true];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+class WithCommentAbove extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * This is a useless test to demonstrate a problem.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testProvider(bool $expected): void
+    {
+        self::assertSame($expected, $expected);
+    }
+
+    public static function dataProvider(): iterable
+    {
+        yield [true];
+    }
+}
+
+?>

--- a/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/with_comment_below.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/with_comment_below.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+class WithCommentBelow extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     *
+     * This is a useless test to demonstrate a problem.
+     */
+    public function testProvider(bool $expected): void
+    {
+        self::assertSame($expected, $expected);
+    }
+
+    public static function dataProvider(): iterable
+    {
+        yield [true];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+class WithCommentBelow extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testProvider(bool $expected): void
+    {
+        self::assertSame($expected, $expected);
+    }
+
+    public static function dataProvider(): iterable
+    {
+        yield [true];
+    }
+}
+
+?>

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
 
             $originalAttributeValue = $desiredTagValueNode->value->value;
 
-            $node->attrGroups[] = $this->createAttributeGroup($originalAttributeValue);
+            $node->attrGroups[] = $this->createAttributeGroup(strtok($originalAttributeValue, " \t\n\r\0\x0B"));
 
             // cleanup
             $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $desiredTagValueNode);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-phpunit/issues/499

when comment is below `@dataProvider`, it can be kept, when below, it marked as part of it, so it removed.