### PR TITLE
feat: make AddCoversClassAttributeRector configurable

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/adds_covers_class_functional_test.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/adds_covers_class_functional_test.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeServiceFunctionalTest extends TestCase {}
+class SomeService {}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture\SomeService::class)]
+class SomeServiceFunctionalTest extends TestCase {}
+class SomeService {}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/adds_covers_class_integration_test.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/Fixture/adds_covers_class_integration_test.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class UserRepositoryIntegrationTest extends TestCase {}
+class UserRepository {}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Utils\Rector\Tests\Rector\AddCoversClassAttributeRector\Fixture\UserRepository::class)]
+class UserRepositoryIntegrationTest extends TestCase {}
+class UserRepository {}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddCoversClassAttributeRector/config/configured_rule.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddCoversClassAttributeRector;
+use Rector\PHPUnit\ValueObject\TestClassSuffixesConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(AddCoversClassAttributeRector::class);
+    $rectorConfig->ruleWithConfiguration(AddCoversClassAttributeRector::class, [
+        new TestClassSuffixesConfig(['Test', 'TestCase', 'FunctionalTest', 'IntegrationTest']),
+    ]);
 };

--- a/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddCoversClassAttributeRector.php
@@ -8,12 +8,15 @@ use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ReflectionProvider;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\PHPUnit\ValueObject\TestClassSuffixesConfig;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 use function array_filter;
 use function array_merge;
 use function count;
@@ -24,48 +27,57 @@ use function preg_replace;
 use function strtolower;
 use function trim;
 
-final class AddCoversClassAttributeRector extends AbstractRector
+final class AddCoversClassAttributeRector extends AbstractRector implements ConfigurableRectorInterface
 {
+    /**
+     * @var string[]
+     */
+    private array $testClassSuffixes = ['Test', 'TestCase'];
+
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
     ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Adds `#[CoversClass(...)]` attribute to test files guessing source class name.', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
-                    class SomeService
-                    {
-                    }
+        return new RuleDefinition(
+            'Adds `#[CoversClass(...)]` attribute to test files guessing source class name.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeService
+{
+}
 
-                    use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 
-                    class SomeServiceTest extends TestCase
-                    {
-                    }
-                    CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
-                    class SomeService
-                    {
-                    }
+class SomeServiceFunctionalTest extends TestCase
+{
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeService
+{
+}
 
-                    use PHPUnit\Framework\TestCase;
-                    use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-                    #[CoversClass(SomeService::class)]
-                    class SomeServiceTest extends TestCase
-                    {
-                    }
-                    CODE_SAMPLE
-                ,
-            ),
-        ]);
+#[CoversClass(SomeService::class)]
+class SomeServiceFunctionalTest extends TestCase
+{
+}
+CODE_SAMPLE
+                    ,
+                    [new TestClassSuffixesConfig(['Test', 'TestCase', 'FunctionalTest', 'IntegrationTest'])]
+                ),
+            ]
+        );
     }
 
     /**
@@ -91,11 +103,13 @@ final class AddCoversClassAttributeRector extends AbstractRector
             return null;
         }
 
-        if ($this->phpAttributeAnalyzer->hasPhpAttributes($node, [
-            'PHPUnit\\Framework\\Attributes\\CoversNothing',
-            'PHPUnit\\Framework\\Attributes\\CoversClass',
-            'PHPUnit\\Framework\\Attributes\\CoversFunction',
-        ])) {
+        if (
+            $this->phpAttributeAnalyzer->hasPhpAttributes($node, [
+                'PHPUnit\\Framework\\Attributes\\CoversNothing',
+                'PHPUnit\\Framework\\Attributes\\CoversClass',
+                'PHPUnit\\Framework\\Attributes\\CoversFunction',
+            ])
+        ) {
             return null;
         }
 
@@ -114,23 +128,44 @@ final class AddCoversClassAttributeRector extends AbstractRector
     }
 
     /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::countBetween($configuration, 0, 1);
+
+        if (isset($configuration[0])) {
+            Assert::isInstanceOf($configuration[0], TestClassSuffixesConfig::class);
+            $this->testClassSuffixes = $configuration[0]->getSuffixes();
+        }
+    }
+
+    /**
      * @return string[]
      */
     private function resolveSourceClassNames(string $className): array
     {
         $classNameParts = explode('\\', $className);
         $partCount = count($classNameParts);
-        $classNameParts[$partCount - 1] = preg_replace(['#TestCase$#', '#Test$#'], '', $classNameParts[$partCount - 1]);
+
+        // Sort suffixes by length (longest first) to ensure more specific patterns match first
+        $sortedSuffixes = $this->testClassSuffixes;
+        usort($sortedSuffixes, static fn (string $a, string $b): int => strlen($b) <=> strlen($a));
+
+        $patterns = [];
+        foreach ($sortedSuffixes as $sortedSuffix) {
+            $patterns[] = '#' . preg_quote($sortedSuffix, '#') . '$#';
+        }
+
+        $classNameParts[$partCount - 1] = preg_replace($patterns, '', $classNameParts[$partCount - 1]);
 
         $possibleTestClassNames = [implode('\\', $classNameParts)];
 
         $partsWithoutTests = array_filter(
             $classNameParts,
-            static fn (string|null $part): bool => $part === null ? false : ! in_array(
-                strtolower($part),
-                ['test', 'tests'],
-                true
-            ),
+            static fn (string|null $part): bool => $part === null
+                ? false
+                : ! in_array(strtolower($part), ['test', 'tests'], true)
         );
 
         $possibleTestClassNames[] = implode('\\', $partsWithoutTests);

--- a/src/ValueObject/TestClassSuffixesConfig.php
+++ b/src/ValueObject/TestClassSuffixesConfig.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\ValueObject;
+
+final readonly class TestClassSuffixesConfig
+{
+    /**
+     * @param string[] $suffixes
+     */
+    public function __construct(
+        private array $suffixes = ['Test', 'TestCase']
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSuffixes(): array
+    {
+        return $this->suffixes;
+    }
+}


### PR DESCRIPTION
Hello 👋🏽 

In some projects we have a style guide to add different suffixes to test names based on their testing level. Like `FunctionalTest` or `IntegrationTest` So this PR makes the `AddCoversClassAttributeRector` rule configurable.