### PR TITLE
[CodeQuality] Skip first class callable and argument less on MatchAssertSameExpectedTypeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector/Fixture/skip_argument_less.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector/Fixture/skip_argument_less.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\MatchAssertSameExpectedTypeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipArgumentLess extends TestCase
+{
+    public function test()
+    {
+        $this->assertSame(1);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\MatchAssertSameExpectedTypeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipFirstClassCallable extends TestCase
+{
+    public function test()
+    {
+        $this->assertSame(...);
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
@@ -86,6 +86,14 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (count($node->getArgs()) < 2) {
+            return null;
+        }
+
         $expectedArg = $node->getArgs()[0];
         if (! $expectedArg->value instanceof String_ && ! $expectedArg->value instanceof LNumber) {
             return null;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-phpunit/pull/510#pullrequestreview-3131770840