### PR TITLE
[CodeQuality] Skip docblock base type on 2nd arg on MatchAssertSameExpectedTypeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector/Fixture/skip_docblock_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector/Fixture/skip_docblock_type.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\MatchAssertSameExpectedTypeRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipDocblockType extends TestCase
+{
+   public function run()
+    {
+        $this->assertSame('123', $this->getOrderId());
+    }
+
+    /**
+     * @return int
+     */
+    private function getOrderId()
+    {
+        return '123';
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
@@ -103,7 +103,7 @@ CODE_SAMPLE
 
         $variableExpr = $node->getArgs()[1]
             ->value;
-        $variableType = $this->getType($variableExpr);
+        $variableType = $this->nodeTypeResolver->getNativeType($variableExpr);
 
         $directVariableType = TypeCombinator::removeNull($variableType);
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-phpunit/pull/510#pullrequestreview-3131771613