### PR TITLE
Use Int_ over deprecated LNumber

### DIFF
--- a/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
@@ -7,7 +7,7 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\TypeCombinator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -95,7 +95,7 @@ CODE_SAMPLE
         }
 
         $expectedArg = $node->getArgs()[0];
-        if (! $expectedArg->value instanceof String_ && ! $expectedArg->value instanceof LNumber) {
+        if (! $expectedArg->value instanceof String_ && ! $expectedArg->value instanceof Int_) {
             return null;
         }
 
@@ -109,7 +109,7 @@ CODE_SAMPLE
 
         if ($expectedType->isLiteralString()->yes() && $directVariableType->isInteger()->yes()) {
             // update expected type to provided type
-            $expectedArg->value = new LNumber((int) $expectedArg->value->value);
+            $expectedArg->value = new Int_((int) $expectedArg->value->value);
 
             return $node;
         }


### PR DESCRIPTION
LNumber is deprecated, use `Int_` instead, ref https://github.com/rectorphp/rector-phpunit/pull/510#pullrequestreview-3131899805