### PR TITLE
[CodeQuality] Skip return createMock() on TypeWillReturnCallableArrowFunctionRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -57,3 +57,7 @@ parameters:
             identifier: assign.propertyType
 
         - '#::provideMinPhpVersion\(\) never returns \d+ so it can be removed from the return type#'
+
+        -
+            message: '#Call to an undefined method PHPStan\\Type\\Type\:\:getClassReflection\(\)#'
+            path: rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php

--- a/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Fixture/skip_return_create_mock.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Fixture/skip_return_create_mock.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormInterface;
+
+final class SkipReturnCreateMock extends TestCase
+{
+    public function test($value): void
+    {
+        $form = $this->createMock(FormInterface::class);
+
+        $form->method('add')
+            ->willReturnCallback(function ($name, $type, $options) use (&$calls) {
+                 $calls[] = compact('name', 'type', 'options');
+                 return $this->createMock(FormInterface::class);
+             });
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
+++ b/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
@@ -130,7 +131,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         $currentClassReflection = $this->reflectionResolver->resolveClassReflection($node);
-        if (! $currentClassReflection instanceof \PHPStan\Reflection\ClassReflection) {
+        if (! $currentClassReflection instanceof ClassReflection) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
+++ b/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
@@ -26,6 +26,7 @@ use Rector\PHPUnit\CodeQuality\Reflection\MethodParametersAndReturnTypesResolver
 use Rector\PHPUnit\CodeQuality\ValueObject\ParamTypesAndReturnType;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -45,6 +46,7 @@ final class TypeWillReturnCallableArrowFunctionRector extends AbstractRector
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly SetUpAssignedMockTypesResolver $setUpAssignedMockTypesResolver,
         private readonly MethodParametersAndReturnTypesResolver $methodParametersAndReturnTypesResolver,
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -127,11 +129,17 @@ CODE_SAMPLE
 
         $hasChanged = false;
 
+        $currentClassReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $currentClassReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return null;
+        }
+
         $propertyNameToMockedTypes = $this->setUpAssignedMockTypesResolver->resolveFromClass($node);
 
         $this->traverseNodesWithCallable($node->getMethods(), function (Node $node) use (
             &$hasChanged,
-            $propertyNameToMockedTypes
+            $propertyNameToMockedTypes,
+            $currentClassReflection
         ) {
             if (! $node instanceof MethodCall || $node->isFirstClassCallable()) {
                 return null;
@@ -188,7 +196,8 @@ CODE_SAMPLE
 
             $parameterTypesAndReturnType = $this->methodParametersAndReturnTypesResolver->resolveFromReflection(
                 $callerType,
-                $methodName
+                $methodName,
+                $currentClassReflection
             );
 
             if (! $parameterTypesAndReturnType instanceof ParamTypesAndReturnType) {
@@ -229,19 +238,15 @@ CODE_SAMPLE
                 $hasChanged = true;
             }
 
-            if (! $innerArg->returnType instanceof Node) {
-                $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
-                    $parameterTypesAndReturnType->getReturnType(),
-                    TypeKind::RETURN
-                );
+            $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+                $parameterTypesAndReturnType->getReturnType(),
+                TypeKind::RETURN
+            );
 
-                if ($returnTypeNode instanceof Node) {
-                    $innerArg->returnType = $returnTypeNode;
-                    $hasChanged = true;
-                }
+            if ($returnTypeNode instanceof Node) {
+                $innerArg->returnType = $returnTypeNode;
+                $hasChanged = true;
             }
-
-            $hasChanged = true;
         });
 
         if (! $hasChanged) {

--- a/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
+++ b/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Enum\ClassName;
@@ -17,7 +18,8 @@ final class MethodParametersAndReturnTypesResolver
 {
     public function resolveFromReflection(
         IntersectionType $intersectionType,
-        string $methodName
+        string $methodName,
+        ClassReflection $currentClassReflection
     ): ?ParamTypesAndReturnType {
         foreach ($intersectionType->getTypes() as $intersectionedType) {
             if (! $intersectionedType instanceof ObjectType) {
@@ -39,8 +41,8 @@ final class MethodParametersAndReturnTypesResolver
 
             $mockedMethodReflection = $classReflection->getNativeMethod($methodName);
 
-            $parameterTypes = $this->resolveParameterTypes($mockedMethodReflection);
-            $returnType = $this->resolveReturnType($mockedMethodReflection);
+            $parameterTypes = $this->resolveParameterTypes($mockedMethodReflection, $currentClassReflection);
+            $returnType = $this->resolveReturnType($mockedMethodReflection, $currentClassReflection);
 
             return new ParamTypesAndReturnType($parameterTypes, $returnType);
         }
@@ -51,7 +53,7 @@ final class MethodParametersAndReturnTypesResolver
     /**
      * @return Type[]
      */
-    private function resolveParameterTypes(ExtendedMethodReflection $extendedMethodReflection): array
+    private function resolveParameterTypes(ExtendedMethodReflection $extendedMethodReflection, ClassReflection $currentClassReflection): array
     {
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
             $extendedMethodReflection->getVariants()
@@ -59,18 +61,30 @@ final class MethodParametersAndReturnTypesResolver
 
         $parameterTypes = [];
         foreach ($extendedParametersAcceptor->getParameters() as $parameterReflection) {
-            $parameterTypes[] = $parameterReflection->getType();
+            $parameterType = $parameterReflection->getType();
+
+            if ($parameterType->isObject()->yes() && $currentClassReflection->getName() !== $parameterType->getClassReflection()->getName()) {
+                return [];
+            }
+
+            $parameterTypes[] = $parameterType;
         }
 
         return $parameterTypes;
     }
 
-    private function resolveReturnType(ExtendedMethodReflection $extendedMethodReflection): Type
+    private function resolveReturnType(ExtendedMethodReflection $extendedMethodReflection, ClassReflection $currentClassReflection): Type
     {
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
             $extendedMethodReflection->getVariants()
         );
 
-        return $extendedParametersAcceptor->getReturnType();
+        $returnType =  $extendedParametersAcceptor->getReturnType();
+
+        if ($returnType->isObject()->yes() && $currentClassReflection->getName() !== $returnType->getClassReflection()->getName()) {
+            return new MixedType();
+        }
+
+        return $returnType;
     }
 }

--- a/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
+++ b/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
@@ -53,8 +53,10 @@ final class MethodParametersAndReturnTypesResolver
     /**
      * @return Type[]
      */
-    private function resolveParameterTypes(ExtendedMethodReflection $extendedMethodReflection, ClassReflection $currentClassReflection): array
-    {
+    private function resolveParameterTypes(
+        ExtendedMethodReflection $extendedMethodReflection,
+        ClassReflection $currentClassReflection
+    ): array {
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
             $extendedMethodReflection->getVariants()
         );
@@ -73,13 +75,15 @@ final class MethodParametersAndReturnTypesResolver
         return $parameterTypes;
     }
 
-    private function resolveReturnType(ExtendedMethodReflection $extendedMethodReflection, ClassReflection $currentClassReflection): Type
-    {
+    private function resolveReturnType(
+        ExtendedMethodReflection $extendedMethodReflection,
+        ClassReflection $currentClassReflection
+    ): Type {
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
             $extendedMethodReflection->getVariants()
         );
 
-        $returnType =  $extendedParametersAcceptor->getReturnType();
+        $returnType = $extendedParametersAcceptor->getReturnType();
 
         if ($returnType->isObject()->yes() && $currentClassReflection->getName() !== $returnType->getClassReflection()->getName()) {
             return new MixedType();

--- a/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
+++ b/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
@@ -63,7 +63,7 @@ final class MethodParametersAndReturnTypesResolver
 
         $parameterTypes = [];
         foreach ($extendedParametersAcceptor->getParameters() as $parameterReflection) {
-            $parameterType = $parameterReflection->getType();
+            $parameterType = $parameterReflection->getNativeType();
 
             if ($parameterType->isObject()->yes() && $currentClassReflection->getName() !== $parameterType->getClassReflection()->getName()) {
                 return [];
@@ -83,7 +83,7 @@ final class MethodParametersAndReturnTypesResolver
             $extendedMethodReflection->getVariants()
         );
 
-        $returnType = $extendedParametersAcceptor->getReturnType();
+        $returnType = $extendedParametersAcceptor->getNativeReturnType();
 
         if ($returnType->isObject()->yes() && $currentClassReflection->getName() !== $returnType->getClassReflection()->getName()) {
             return new MixedType();

--- a/stubs/Symfony/Component/Form/FormInterface.php
+++ b/stubs/Symfony/Component/Form/FormInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Form;
+
+if (interface_exists('Symfony\Component\Form\FormInterface')) {
+    return;
+}
+
+interface FormInterface
+{
+    public function add(): static;
+}


### PR DESCRIPTION
@TomasVotruba I tested in our project, this cause diff:

```diff
1) Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\TypeWillReturnCallableArrowFunctionRectorTest::test with data set #3 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "skip_return_create_mock.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
         $form = $this->createMock(FormInterface::class);
 
         $form->method('add')
-            ->willReturnCallback(function ($name, $type, $options) use (&$calls) {
+            ->willReturnCallback(function ($name, $type, $options) use (&$calls): static {
                  $calls[] = compact('name', 'type', 'options');
                  return $this->createMock(FormInterface::class);
              });
```

which cause error:

```diff
There was 1 error:

Return value must be of type SomeTest, MockObject_FormInterface_afa3944a returned
```