### PR TITLE
[CodeQuality] Handle crash on native "object" type on TypeWillReturnCallableArrowFunctionRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -59,5 +59,5 @@ parameters:
         - '#::provideMinPhpVersion\(\) never returns \d+ so it can be removed from the return type#'
 
         -
-            message: '#Call to an undefined method PHPStan\\Type\\Type\:\:getClassReflection\(\)#'
+            message: '#Cannot call method getName\(\) on PHPStan\\Reflection\\ClassReflection\|null#'
             path: rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php

--- a/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Fixture/fill_known_param_type_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Fixture/fill_known_param_type_object.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\Source\SomeMockedClass;
+
+final class FillKnownParamTypeObject extends TestCase
+{
+    public function test($value): void
+    {
+        $this->createMock(SomeMockedClass::class)
+            ->method('nativeObject')
+            ->willReturnCallback(fn (object $object) => $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\Source\SomeMockedClass;
+
+final class FillKnownParamTypeObject extends TestCase
+{
+    public function test($value): void
+    {
+        $this->createMock(SomeMockedClass::class)
+            ->method('nativeObject')
+            ->willReturnCallback(fn (object $name): object => $value);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Fixture/fill_known_param_type_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Fixture/fill_known_param_type_object.php.inc
@@ -30,7 +30,7 @@ final class FillKnownParamTypeObject extends TestCase
     {
         $this->createMock(SomeMockedClass::class)
             ->method('nativeObject')
-            ->willReturnCallback(fn (object $name): object => $value);
+            ->willReturnCallback(fn (object $object): object => $value);
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Source/SomeMockedClass.php
+++ b/rules-tests/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector/Source/SomeMockedClass.php
@@ -9,4 +9,9 @@ class SomeMockedClass
     {
         return 100;
     }
+
+    public function nativeObject(object $object): object
+    {
+        return $object;
+    }
 }

--- a/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
+++ b/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php
@@ -85,7 +85,7 @@ final class MethodParametersAndReturnTypesResolver
 
         $returnType = $extendedParametersAcceptor->getNativeReturnType();
 
-        if ($returnType->isObject()->yes() && $currentClassReflection->getName() !== $returnType->getClassReflection()->getName()) {
+        if ($returnType->isObject()->yes() && $currentClassReflection->getName() !== $returnType?->getClassReflection()?->getName()) {
             return new MixedType();
         }
 


### PR DESCRIPTION
It currently got error:

```
There was 1 error:

1) Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\TypeWillReturnCallableArrowFunctionRector\TypeWillReturnCallableArrowFunctionRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
Error: Call to undefined method PHPStan\Type\ObjectWithoutClassType::getClassReflection()

/Users/samsonasik/www/rector-phpunit/rules/CodeQuality/Reflection/MethodParametersAndReturnTypesResolver.php:68
```

