### PR TITLE
[Alternative 2] Skip assertEquals() on MatchAssertSameExpectedTypeRector

### DIFF
--- a/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/MatchAssertSameExpectedTypeRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, ['assertSame', 'assertEquals'])) {
+        if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($node, ['assertSame'])) {
             return null;
         }
 


### PR DESCRIPTION
@TomasVotruba this is another alternative solution to not change to assertEquals for failure test https://github.com/rectorphp/rector-phpunit/actions/runs/17128495249/job/48586074883#step:5:43

this however, not make sense, because existing assertSame already failure **before rector apply**:

```php
class SomeTest extends TestCase
{
    public function test()
    {
        $this->assertSame('123', $this->getOrderId());
    }

    private function getOrderId(): int
    {
        return 123;
    }
}
```

```
There was 1 failure:

1) ArrayLookup\Tests\CollectorTest::test
Failed asserting that 123 is identical to '123'.
```

`assertSame` is works on identical value, so it already error on the first execution, which means user already know that and patch first before run the rector, so the rule doesn't make any improvement imo.