### PR TITLE
Fix example of return type on AddParamTypeFromDependsRector

### DIFF
--- a/rules/CodeQuality/Rector/Class_/AddParamTypeFromDependsRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddParamTypeFromDependsRector.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SomeTest extends TestCase
 {
-    public function test()
+    public function test(): \stdClass
     {
         return new \stdClass();
     }
@@ -62,7 +62,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SomeTest extends TestCase
 {
-    public function test()
+    public function test(): \stdClass
     {
         return new \stdClass();
     }


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-phpunit/pull/525#pullrequestreview-3173255472