### PR TITLE
Failling test: MergeWithCallableAndWillReturnRector forgest to introduce closure `use`

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/MergeWithCallableAndWillReturnRector/Fixture/will-add-closure-use.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/MergeWithCallableAndWillReturnRector/Fixture/will-add-closure-use.php.inc
@@ -1,0 +1,56 @@
+<?php
+
+namespace Rector\Tests\PHPUnit\CodeQuality\Rector\MethodCall\MergeWithCallableAndWillReturnRector\Fixture;
+
+final class DemoFile extends PHPUnit\Framework\TestCase
+{
+    public function test_it(): void
+    {
+        $initialStatements = [
+            new FakeNode(),
+            new FakeNode(),
+        ];
+
+        $this->fileParserMock
+            ->expects($this->once())
+            ->method('parse')
+            ->with($this->callback(
+                function (SplFileInfo $fileInfo): bool {
+                    $this->assertSame('/path/to/file', $fileInfo->getRealPath());
+
+                    return true;
+                },
+            ))
+            ->willReturn([$initialStatements, []])
+        ;
+    }
+
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\PHPUnit\CodeQuality\Rector\MethodCall\MergeWithCallableAndWillReturnRector\Fixture;
+
+final class DemoFile extends PHPUnit\Framework\TestCase
+{
+    public function test_it(): void
+    {
+        $initialStatements = [
+            new FakeNode(),
+            new FakeNode(),
+        ];
+
+        $this->fileParserMock
+            ->expects($this->once())
+            ->method('parse')
+            ->willReturnCallback(function (SplFileInfo $fileInfo) use ($initialStatements): array {
+                $this->assertSame('/path/to/file', $fileInfo->getRealPath());
+
+                return [$initialStatements, []];
+            })
+        ;
+    }
+
+}
+?>


### PR DESCRIPTION
rector currently transforms the source into a syntax error 

<img width="666" height="448" alt="grafik" src="https://github.com/user-attachments/assets/c626c50b-3f68-4d29-b1a9-3dcd24da892e" />

because it forgets to introduce a `use ($initialStatements)` for the variable involved