### PR TITLE
Fix assert PHPStan on ConfiguredMockEntityToSetterObjectRector

### DIFF
--- a/rules/CodeQuality/Rector/Expression/ConfiguredMockEntityToSetterObjectRector.php
+++ b/rules/CodeQuality/Rector/Expression/ConfiguredMockEntityToSetterObjectRector.php
@@ -26,7 +26,6 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Expression\ConfiguredMockEntityToSetterObjectRector\ConfiguredMockEntityToSetterObjectRectorTest

--- a/rules/CodeQuality/Rector/Expression/ConfiguredMockEntityToSetterObjectRector.php
+++ b/rules/CodeQuality/Rector/Expression/ConfiguredMockEntityToSetterObjectRector.php
@@ -138,7 +138,6 @@ CODE_SAMPLE
         }
 
         if ($node instanceof Expression) {
-            Assert::isInstanceOf($assign, Assign::class);
             return $this->createForAssign($doctrineClass, $assign, $definedGettersArg->value, $node);
         }
 


### PR DESCRIPTION
Ref latest composer update on latest CI:

https://github.com/rectorphp/rector-src/actions/runs/23165998943/job/67306010618#step:7:10