### PR TITLE
[PHPUnit 9] Rename assertRegExp/assertNotRegExp to assertMatchesRegularExpression/assertDoesNotMatchRegularExpression on phpunit 90 set

### DIFF
--- a/config/sets/phpunit90.php
+++ b/config/sets/phpunit90.php
@@ -25,5 +25,20 @@ return static function (RectorConfig $rectorConfig): void {
             'expectExceptionMessageRegExp',
             'expectExceptionMessageMatches'
         ),
+
+
+        // @see https://github.com/sebastianbergmann/phpunit/issues/4086
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'assertRegExp',
+            'assertMatchesRegularExpression'
+        ),
+
+        // @see https://github.com/sebastianbergmann/phpunit/issues/4089
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'assertNotRegExp',
+            'assertDoesNotMatchRegularExpression'
+        ),
     ]);
 };


### PR DESCRIPTION
ok, on phpunit v8, `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` doesn't exists yet, so needs to apply on phpunit 9 set.

Fixes https://github.com/rectorphp/rector/issues/9714