### PR TITLE
[PHPUnit12] Skip used as next arg with MockObject Type on ExpressionCreateMockToCreateStubRector

### DIFF
--- a/rules-tests/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector/Fixture/skip_used_as_next_arg_mockobject_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector/Fixture/skip_used_as_next_arg_mockobject_type.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector\Source\ClassWithDependency;
+
+final class SkipUsedAsNextArgMockObjectType extends TestCase
+{
+    public function test()
+    {
+        $mock = $this->createMock(ClassWithDependency::class);
+        $this->configureMock($mock);
+    }
+
+    private function configureMock(\PHPUnit\Framework\MockObject\MockObject $mock)
+    {
+        $mock->method('someMethod')->willReturn(1);
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector/Fixture/skip_used_as_next_arg_mockobject_type_named.php.inc
+++ b/rules-tests/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector/Fixture/skip_used_as_next_arg_mockobject_type_named.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector\Source\ClassWithDependency;
+
+final class SkipUsedAsNextArgMockObjectTypeNamed extends TestCase
+{
+    public function test()
+    {
+        $mock = $this->createMock(ClassWithDependency::class);
+        $this->configureMock(mock: $mock, otherParam: 1);
+    }
+
+    private function configureMock($otherParam, \PHPUnit\Framework\MockObject\MockObject $mock)
+    {
+        $mock->method('someMethod')->willReturn(1);
+    }
+}

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector.php
@@ -129,7 +129,6 @@ CODE_SAMPLE
             // test from doc blocks
             $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $testWithPhpDocTagNode);
 
-            /** @var GenericTagValueNode $genericTagValueNode */
             $genericTagValueNode = $testWithPhpDocTagNode->value;
             $testWithItems = explode("\n", trim($genericTagValueNode->value));
 

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -124,10 +124,6 @@ final readonly class MockObjectExprDetector
                             ->yes()) {
                         return true;
                     }
-
-                    if (! isset($parameters[$index])) {
-                        continue;
-                    }
                 }
 
                 if (isset($parameters[$argIndex])) {

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -116,7 +116,7 @@ final readonly class MockObjectExprDetector
 
                 $parameters = $variants[0]->getParameters();
 
-                foreach ($parameters as $index => $parameterReflection) {
+                foreach ($parameters as $parameterReflection) {
                     $paramType = $parameterReflection->getType();
                     if ($arg->name instanceof Identifier
                         && $this->nodeNameResolver->isName($arg->name, $parameterReflection->getName())

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -91,7 +91,7 @@ final readonly class MockObjectExprDetector
             }
 
             // check if variable is passed as arg to a method that declares MockObject type parameter
-            foreach ($methodCall->getArgs() as $arg) {
+            foreach ($methodCall->getArgs() as $argIndex => $arg) {
                 if (! $arg instanceof Arg) {
                     continue;
                 }
@@ -117,7 +117,7 @@ final readonly class MockObjectExprDetector
                 $parameters = $variants[0]->getParameters();
 
                 foreach ($parameters as $index => $parameterReflection) {
-                    $paramType = $parameters[$index]->getType();
+                    $paramType = $parameterReflection->getType();
                     if ($arg->name instanceof Identifier
                         && $this->nodeNameResolver->isName($arg->name, $parameterReflection->getName())
                         && $mockObjectType->isSuperTypeOf($paramType)
@@ -128,7 +128,10 @@ final readonly class MockObjectExprDetector
                     if (! isset($parameters[$index])) {
                         continue;
                     }
+                }
 
+                if (isset($parameters[$argIndex])) {
+                    $paramType = $parameters[$argIndex]->getType();
                     if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
                         return true;
                     }

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -132,7 +132,6 @@ final readonly class MockObjectExprDetector
                     if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
                         return true;
                     }
-
                 }
             }
         }

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\NodeAnalyser;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPUnit\CodeQuality\NodeFinder\VariableFinder;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\Reflection\ReflectionResolver;
 
 final readonly class MockObjectExprDetector
 {
@@ -20,6 +25,7 @@ final readonly class MockObjectExprDetector
         private BetterNodeFinder $betterNodeFinder,
         private NodeNameResolver $nodeNameResolver,
         private VariableFinder $variableFinder,
+        private ReflectionResolver $reflectionResolver,
     ) {
     }
 
@@ -67,6 +73,8 @@ final readonly class MockObjectExprDetector
         /** @var array<Expr\MethodCall> $methodCalls */
         $methodCalls = $this->betterNodeFinder->findInstancesOfScoped((array) $classMethod->stmts, [MethodCall::class]);
 
+        $mockObjectType = new ObjectType(PHPUnitClassName::MOCK_OBJECT);
+
         foreach ($methodCalls as $methodCall) {
             if (! $methodCall->var instanceof Variable) {
                 continue;
@@ -75,6 +83,41 @@ final readonly class MockObjectExprDetector
             if ($this->nodeNameResolver->isName($methodCall->var, $variableName)) {
                 // variable is being called on, most like mocking, lets skip
                 return true;
+            }
+
+            if ($methodCall->isFirstClassCallable()) {
+                continue;
+            }
+
+            // check if variable is passed as arg to a method that declares MockObject type parameter
+            foreach ($methodCall->getArgs() as $position => $arg) {
+                if (! $arg instanceof Arg) {
+                    continue;
+                }
+
+                if (! $arg->value instanceof Variable) {
+                    continue;
+                }
+
+                if (! $this->nodeNameResolver->isName($arg->value, $variableName)) {
+                    continue;
+                }
+
+                $methodReflection = $this->reflectionResolver->resolveMethodReflectionFromMethodCall($methodCall);
+                if (! $methodReflection instanceof MethodReflection) {
+                    continue;
+                }
+
+                $parameters = $methodReflection->getVariants()[0]
+                    ->getParameters();
+                if (! isset($parameters[$position])) {
+                    continue;
+                }
+
+                $paramType = $parameters[$position]->getType();
+                if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
+                    return true;
+                }
             }
         }
 

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -105,26 +105,23 @@ final readonly class MockObjectExprDetector
                 }
 
                 $variants = $methodReflection->getVariants();
-                if (! isset($variants[0])) {
-                    continue;
-                }
-
-                $parameters = $variants[0]->getParameters();
-
-                foreach ($parameters as $parameter) {
-                    $paramType = $parameter->getType();
-                    if ($arg->name instanceof Identifier
-                        && $this->nodeNameResolver->isName($arg->name, $parameter->getName())
-                        && $mockObjectType->isSuperTypeOf($paramType)
-                            ->yes()) {
-                        return true;
+                foreach ($variants as $variant) {
+                    $parameters = $variant->getParameters();
+                    foreach ($parameters as $parameter) {
+                        $paramType = $parameter->getType();
+                        if ($arg->name instanceof Identifier
+                            && $this->nodeNameResolver->isName($arg->name, $parameter->getName())
+                            && $mockObjectType->isSuperTypeOf($paramType)
+                                ->yes()) {
+                            return true;
+                        }
                     }
-                }
 
-                if (isset($parameters[$argIndex])) {
-                    $paramType = $parameters[$argIndex]->getType();
-                    if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
-                        return true;
+                    if (isset($parameters[$argIndex])) {
+                        $paramType = $parameters[$argIndex]->getType();
+                        if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -92,10 +92,6 @@ final readonly class MockObjectExprDetector
 
             // check if variable is passed as arg to a method that declares MockObject type parameter
             foreach ($methodCall->getArgs() as $argIndex => $arg) {
-                if (! $arg instanceof Arg) {
-                    continue;
-                }
-
                 if (! $arg->value instanceof Variable) {
                     continue;
                 }

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\MethodReflection;
@@ -90,7 +91,7 @@ final readonly class MockObjectExprDetector
             }
 
             // check if variable is passed as arg to a method that declares MockObject type parameter
-            foreach ($methodCall->getArgs() as $position => $arg) {
+            foreach ($methodCall->getArgs() as $arg) {
                 if (! $arg instanceof Arg) {
                     continue;
                 }
@@ -108,15 +109,30 @@ final readonly class MockObjectExprDetector
                     continue;
                 }
 
-                $parameters = $methodReflection->getVariants()[0]
-                    ->getParameters();
-                if (! isset($parameters[$position])) {
+                $variants = $methodReflection->getVariants();
+                if (! isset($variants[0])) {
                     continue;
                 }
 
-                $paramType = $parameters[$position]->getType();
-                if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
-                    return true;
+                $parameters = $variants[0]->getParameters();
+
+                foreach ($parameters as $index => $parameterReflection) {
+                    $paramType = $parameters[$index]->getType();
+                    if ($arg->name instanceof Identifier
+                        && $this->nodeNameResolver->isName($arg->name, $parameterReflection->getName())
+                        && $mockObjectType->isSuperTypeOf($paramType)
+                            ->yes()) {
+                        return true;
+                    }
+
+                    if (! isset($parameters[$index])) {
+                        continue;
+                    }
+
+                    if ($mockObjectType->isSuperTypeOf($paramType)->yes()) {
+                        return true;
+                    }
+
                 }
             }
         }

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -116,10 +116,10 @@ final readonly class MockObjectExprDetector
 
                 $parameters = $variants[0]->getParameters();
 
-                foreach ($parameters as $parameterReflection) {
-                    $paramType = $parameterReflection->getType();
+                foreach ($parameters as $parameter) {
+                    $paramType = $parameter->getType();
                     if ($arg->name instanceof Identifier
-                        && $this->nodeNameResolver->isName($arg->name, $parameterReflection->getName())
+                        && $this->nodeNameResolver->isName($arg->name, $parameter->getName())
                         && $mockObjectType->isSuperTypeOf($paramType)
                             ->yes()) {
                         return true;

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\NodeAnalyser;
 
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;

--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -134,7 +134,6 @@ CODE_SAMPLE
                 continue;
             }
 
-            /** @var GenericTagValueNode $genericTagValueNode */
             $genericTagValueNode = $seePhpDocTagNode->value;
 
             $seeTagClass = ltrim($genericTagValueNode->value, '\\');

--- a/rules/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector.php
+++ b/rules/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector.php
@@ -106,7 +106,6 @@ CODE_SAMPLE
                 continue;
             }
 
-            /** @var Assign $assign */
             $assign = $stmt->expr;
 
             if (! $assign->var instanceof Variable) {


### PR DESCRIPTION
When used as `MockObject` on next arg with `MockObject` type, it should be skipped:

```php
    public function test()
    {
        $mock = $this->createMock(ClassWithDependency::class);
        $this->configureMock($mock);
    }

    private function configureMock(\PHPUnit\Framework\MockObject\MockObject $mock)
    {
        $mock->method('someMethod')->willReturn(1);
    }
```

we have this case on our project ;)