### PR TITLE
ReplaceTestAnnotationWithPrefixedFunctionRector does not match @test annotation if it is being part of string

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector/Fixture/skip_test_annotation_as_part_of_text.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector/Fixture/skip_test_annotation_as_part_of_text.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\Fixture;
+
+class SkipTestAnnotationAsPartOfText extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * there is some comment with something@test
+     * @test-different-annotation
+     */
+    public function onePlusOneShouldBeTwo()
+    {
+        $this->assertSame(2, 1+1);
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -12,9 +12,9 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Util\NewLineSplitter;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use function explode;
 use function in_array;
 
 /**
@@ -87,7 +87,7 @@ CODE_SAMPLE
         }
 
         $hasAnnotation = false;
-        foreach(explode(PHP_EOL, $docComment->getText()) as $row) {
+        foreach(NewLineSplitter::split($docComment->getText()) as $row) {
             if (in_array(trim($row), ['*@test', '* @test'])) {
                 $hasAnnotation = true;
             }

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -14,6 +14,8 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use function explode;
+use function in_array;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\ReplaceTestAnnotationWithPrefixedFunctionRectorTest
@@ -84,7 +86,14 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! str_contains($docComment->getText(), '@test')) {
+        $hasAnnotation = false;
+        foreach(explode(PHP_EOL, $docComment->getText()) as $row) {
+            if (in_array(trim($row), ['*@test', '* @test'])) {
+                $hasAnnotation = true;
+            }
+        }
+
+        if (! $hasAnnotation) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -90,6 +90,7 @@ CODE_SAMPLE
         foreach(NewLineSplitter::split($docComment->getText()) as $row) {
             if (in_array(trim($row), ['*@test', '* @test'])) {
                 $hasAnnotation = true;
+                break;
             }
         }
 


### PR DESCRIPTION
Fix for: https://github.com/rectorphp/rector/issues/9752