### PR TITLE
fix AssertIsTypeMethodCallRector crash on enum case argument

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Class_/AssertIsTypeMethodCallRector/Fixture/skip_non_string_arg.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/AssertIsTypeMethodCallRector/Fixture/skip_non_string_arg.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+// skip: non-string argument (enum case) should not crash
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+enum SkipNonStringArgEnum
+{
+    case ONE;
+}
+
+final class SkipNonStringArg extends TestCase
+{
+    public function testMethod(): void
+    {
+        $this->assertThat([], $this->isType(SkipNonStringArgEnum::ONE));
+    }
+}

--- a/rules/PHPUnit120/Rector/Class_/AssertIsTypeMethodCallRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AssertIsTypeMethodCallRector.php
@@ -114,6 +114,10 @@ final class AssertIsTypeMethodCallRector extends AbstractRector
         }
 
         $argValue = $this->valueResolver->getValue($arg);
+        if (! is_string($argValue)) {
+            return null;
+        }
+
         if (isset(self::IS_TYPE_VALUE_TO_METHOD[$argValue])) {
             if ($node instanceof MethodCall) {
                 return new MethodCall($node->var, self::IS_TYPE_VALUE_TO_METHOD[$argValue]);


### PR DESCRIPTION
## Summary

- Fixes a fatal crash in `AssertIsTypeMethodCallRector` when `isType()` is called with an enum case argument inside a `TestCase` subclass
- Adds a `is_string()` guard before using the resolved arg value as an array key in `isset()`
- Adds a skip fixture to cover the non-string arg scenario

## Root cause

`ValueResolver::getValue()` returns the enum case object itself for enum arguments. Using it as an array key in `isset(self::IS_TYPE_VALUE_TO_METHOD[$argValue])` caused:

```
System error: "Cannot access offset of type App\Enums\SomeEnum in isset or empty"
```

## Fix

Added an `is_string($argValue)` guard immediately after resolving the argument value. Non-string values can never match any key in `IS_TYPE_VALUE_TO_METHOD`, so returning `null` early is both correct and safe.

Fixes https://github.com/rectorphp/rector/issues/9765

---
_Generated by [Claude Code](https://claude.ai/code/session_013NBfVf3ZKpBieeTf4xxAji)_