### PR TITLE
[PHPUnit12] Drop ConstraintValidatorTestCase from AllowMockObjectsWhereParentClassRector triggers

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector/Fixture/skip_constraint_validator_test_case.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector/Fixture/skip_constraint_validator_test_case.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsWhereParentClassRector\Fixture;
+
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class SkipConstraintValidatorTestCase extends ConstraintValidatorTestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someMock;
+}

--- a/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector/Fixture/skip_constraint_validator_test_case_via_intermediate.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector/Fixture/skip_constraint_validator_test_case_via_intermediate.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsWhereParentClassRector\Fixture;
+
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+abstract class IntermediateConstraintValidatorBase extends ConstraintValidatorTestCase
+{
+}
+
+final class SkipConstraintValidatorTestCaseViaIntermediate extends IntermediateConstraintValidatorBase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someMock;
+}

--- a/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector/Fixture/some_class.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector/Fixture/some_class.php.inc
@@ -2,9 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsWhereParentClassRector\Fixture;
 
-use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 
-final class SomeClass extends ConstraintValidatorTestCase
+final class SomeClass extends TypeTestCase
 {
     private \PHPUnit\Framework\MockObject\MockObject $someMock;
 }
@@ -15,10 +15,10 @@ final class SomeClass extends ConstraintValidatorTestCase
 
 namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsWhereParentClassRector\Fixture;
 
-use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 
 #[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
-final class SomeClass extends ConstraintValidatorTestCase
+final class SomeClass extends TypeTestCase
 {
     private \PHPUnit\Framework\MockObject\MockObject $someMock;
 }

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
@@ -30,10 +30,7 @@ final class AllowMockObjectsWhereParentClassRector extends AbstractRector
     /**
      * @var string[]
      */
-    private const array PARENT_CLASSES = [
-        PHPUnitClassName::SYMFONY_CONSTRAINT_VALIDATOR_TEST_CASE,
-        PHPUnitClassName::SYMFONY_TYPE_TEST_CASE,
-    ];
+    private const array PARENT_CLASSES = [PHPUnitClassName::SYMFONY_TYPE_TEST_CASE];
 
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -75,18 +72,18 @@ final class AllowMockObjectsWhereParentClassRector extends AbstractRector
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
-use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 
-final class SomeTest extends ConstraintValidatorTestCase
+final class SomeTest extends TypeTestCase
 {
 }
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 
 #[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
-final class SomeTest extends ConstraintValidatorTestCase
+final class SomeTest extends TypeTestCase
 {
 }
 CODE_SAMPLE

--- a/src/Enum/PHPUnitClassName.php
+++ b/src/Enum/PHPUnitClassName.php
@@ -27,8 +27,6 @@ final class PHPUnitClassName
 
     public const string STUB = 'PHPUnit\Framework\MockObject\Stub';
 
-    public const string SYMFONY_CONSTRAINT_VALIDATOR_TEST_CASE = 'Symfony\Component\Validator\Test\ConstraintValidatorTestCase';
-
     public const string SYMFONY_TYPE_TEST_CASE = 'Symfony\Component\Form\Test\TypeTestCase';
 
     /**

--- a/stubs/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/stubs/Symfony/Component/Form/Test/TypeTestCase.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\Form\Test;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class TypeTestCase extends TestCase
+{
+}


### PR DESCRIPTION
## Summary

Closes rectorphp/rector#9650

The rule wrongly adds `#[AllowMockObjectsWithoutExpectations]` to subclasses of `ConstraintValidatorTestCase`. The underlying need was removed upstream by symfony/symfony#62745 (shipped in symfony/validator 6.4.31 / 7.3.9 / 7.4.3 / 8.0.3).

## Changes

- Remove `SYMFONY_CONSTRAINT_VALIDATOR_TEST_CASE` from `PARENT_CLASSES`
- Update rule's code sample to `TypeTestCase` (the remaining trigger)
- Remove the now-orphaned enum constant
- Convert existing `some_class.php.inc` to `TypeTestCase` and add a stub so it autoloads (the `TypeTestCase` path was previously never end-to-end tested)
- Add a transitive skip fixture for real-world inheritance chains

## Tests

- `skip_constraint_validator_test_case.php.inc` — direct subclass, no attribute added
- `skip_constraint_validator_test_case_via_intermediate.php.inc` — transitive subclass via abstract base, no attribute added
- `some_class.php.inc` (updated) — `TypeTestCase` direct subclass, attribute correctly added

## Alternatives

Open to either if preferred: version-aware detection via `Composer\InstalledVersions::getVersion('symfony/validator')`, or a configurable parent-exclusion list.

---

Ported from preview PR akankov/rector-phpunit#1 (by @akankov)
