### PR TITLE
[PHPUnit12] Handle crash on property not exists on PropertyCreateMockToCreateStubRector

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_on_property_not_exists.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_on_property_not_exists.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipPropertyNotExistsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(\stdClass::class);
+    }
+
+    public function testThis()
+    {
+        $this->assertSame('...', $this->someMock);
+    }
+}
+
+?>

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -132,6 +133,14 @@ final readonly class MockObjectExprDetector
 
     public function isPropertyUsedForMocking(Class_ $class, string $propertyName): bool
     {
+        $property = $class->getProperty($propertyName);
+
+        // possibly dynamic property on purpose
+        // mark as used
+        if (! $property instanceof Property) {
+            return true;
+        }
+
         // find out, how many are used in call likes as args
         /** @var array<Expr\MethodCall> $methodCalls */
         $methodCalls = $this->betterNodeFinder->findInstancesOfScoped($class->getMethods(), [MethodCall::class]);


### PR DESCRIPTION
Given the following code:

```php
use PHPUnit\Framework\TestCase;

final class SkipPropertyNotExistsTest extends TestCase
{
    protected function setUp(): void
    {
        $this->someMock = $this->createMock(\stdClass::class);
    }

    public function testThis()
    {
        $this->assertSame('...', $this->someMock);
    }
}
```

It got crash:

```bash
1 test triggered 1 PHP warning:

1) /Users/samsonasik/www/rector-phpunit/rules/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector.php:75
Attempt to read property "type" on null
```

Ref https://getrector.com/demo/805aa088-6c4d-4809-84e2-ccc2fd8e6fd1
Fixes https://github.com/rectorphp/rector/issues/9774