### PR TITLE
[CodeQuality] Add fixture for assertTrue instanceof on local variable

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/local_variable_instance.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertInstanceOfComparisonRector/Fixture/local_variable_instance.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture;
+
+final class LocalVariableInstanceTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAddForm(): void
+    {
+        $form = ['formAlias' => 'testform'];
+        $result = $event->addForm($form);
+
+        $this->assertTrue($result instanceof ConfigBuilderEvent);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture;
+
+final class LocalVariableInstanceTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAddForm(): void
+    {
+        $form = ['formAlias' => 'testform'];
+        $result = $event->addForm($form);
+
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector\Fixture\ConfigBuilderEvent::class, $result);
+    }
+}
+
+?>


### PR DESCRIPTION
Adds fixture covering `$this->assertTrue($result instanceof ConfigBuilderEvent)` → `$this->assertInstanceOf(ConfigBuilderEvent::class, $result)` for AssertInstanceOfComparisonRector.