### PR TITLE
[CodeQuality] Use static Assert:: call for assert() inside anonymous class

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_inside_anonymous_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_inside_anonymous_class.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class AssertInsideAnonymousClass extends TestCase
+{
+    public function some($response)
+    {
+        return new class($response) {
+            public function __construct($response)
+            {
+                assert((bool) $response);
+            }
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class AssertInsideAnonymousClass extends TestCase
+{
+    public function some($response)
+    {
+        return new class($response) {
+            public function __construct($response)
+            {
+                \PHPUnit\Framework\Assert::assertTrue((bool) $response);
+            }
+        };
+    }
+}
+
+?>

--- a/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
+++ b/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
@@ -32,6 +32,12 @@ final readonly class DoctrineEntityDocumentAnalyser
             return false;
         }
 
-        return array_any(self::ENTITY_DOCBLOCK_MARKERS, fn(string $entityDocBlockMarkers): bool => str_contains($resolvedPhpDocBlock->getPhpDocString(), $entityDocBlockMarkers));
+        return array_any(
+            self::ENTITY_DOCBLOCK_MARKERS,
+            fn (string $entityDocBlockMarkers): bool => str_contains(
+                $resolvedPhpDocBlock->getPhpDocString(),
+                $entityDocBlockMarkers
+            )
+        );
     }
 }

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
 
-use function in_array;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -16,6 +15,7 @@ use Rector\Rector\AbstractRector;
 use Rector\Util\NewLineSplitter;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use function in_array;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector\ReplaceTestAnnotationWithPrefixedFunctionRectorTest
@@ -86,7 +86,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $hasAnnotation = array_any(NewLineSplitter::split($docComment->getText()), fn(string $row): bool => in_array(trim($row), ['*@test', '* @test'], true));
+        $hasAnnotation = array_any(
+            NewLineSplitter::split($docComment->getText()),
+            fn (string $row): bool => in_array(trim($row), ['*@test', '* @test'], true)
+        );
 
         if (! $hasAnnotation) {
             return null;

--- a/rules/CodeQuality/Rector/Class_/PreferTestsWithCamelCaseRector.php
+++ b/rules/CodeQuality/Rector/Class_/PreferTestsWithCamelCaseRector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
-use PhpParser\Node\Identifier;
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;

--- a/rules/CodeQuality/Rector/Class_/PreferTestsWithSnakeCaseRector.php
+++ b/rules/CodeQuality/Rector/Class_/PreferTestsWithSnakeCaseRector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
-use PhpParser\Node\Identifier;
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;

--- a/rules/CodeQuality/Rector/Expression/AssertArrayCastedObjectToAssertSameRector.php
+++ b/rules/CodeQuality/Rector/Expression/AssertArrayCastedObjectToAssertSameRector.php
@@ -161,6 +161,6 @@ CODE_SAMPLE
      */
     private function hasAllKeysString(array $assertedArrayValues): bool
     {
-        return array_all(array_keys($assertedArrayValues), fn(int|string $key): bool => is_string($key));
+        return array_all(array_keys($assertedArrayValues), fn (int|string $key): bool => is_string($key));
     }
 }

--- a/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
@@ -110,6 +110,12 @@ CODE_SAMPLE
                     return null;
                 }
 
+                // assert() inside an anonymous class has no $this of the test case
+                if ($node instanceof Class_ && $node->isAnonymous()) {
+                    $useStaticAssert = true;
+                    return null;
+                }
+
                 if (! $node instanceof FuncCall) {
                     return null;
                 }

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
@@ -119,6 +119,6 @@ CODE_SAMPLE
             return false;
         }
 
-        return array_any(self::PARENT_CLASSES, fn(string $parentClass): bool => $classReflection->is($parentClass));
+        return array_any(self::PARENT_CLASSES, fn (string $parentClass): bool => $classReflection->is($parentClass));
     }
 }

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
@@ -270,7 +270,10 @@ CODE_SAMPLE
      */
     private function isAtLeastOneMockPropertyMockedOnce(array $usingTestMethodsByMockPropertyName): bool
     {
-        return array_any($usingTestMethodsByMockPropertyName, fn(array $usingTestMethods): bool => $usingTestMethods !== []);
+        return array_any(
+            $usingTestMethodsByMockPropertyName,
+            fn (array $usingTestMethods): bool => $usingTestMethods !== []
+        );
     }
 
     private function isMissingExpectsOnMockObjectMethodCallInSetUp(Class_ $class): bool

--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -97,7 +97,10 @@ final class AssertCallAnalyzer
             return false;
         }
 
-        return array_any(self::ASSERT_METHOD_NAME_PREFIXES, fn(string $assertMethodNamePrefix): bool => str_starts_with($callName, $assertMethodNamePrefix));
+        return array_any(
+            self::ASSERT_METHOD_NAME_PREFIXES,
+            fn (string $assertMethodNamePrefix): bool => str_starts_with($callName, $assertMethodNamePrefix)
+        );
     }
 
     private function hasDirectAssertOrMockCall(ClassMethod $classMethod): bool

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -35,7 +35,10 @@ final readonly class TestsNodeAnalyzer
             return false;
         }
 
-        return array_any(PHPUnitClassName::TEST_CLASSES, fn(string $testCaseObjectClass): bool => $classReflection->is($testCaseObjectClass));
+        return array_any(
+            PHPUnitClassName::TEST_CLASSES,
+            fn (string $testCaseObjectClass): bool => $classReflection->is($testCaseObjectClass)
+        );
     }
 
     public function isTestClassMethod(ClassMethod $classMethod): bool


### PR DESCRIPTION
Improves `AssertFuncCallToPHPUnitAssertRector`.

`assert()` inside an anonymous class has no test-case `$this`, so converting to `$this->assertTrue()` would call the method on the anonymous class instead of the `TestCase`. This now emits a static `\PHPUnit\Framework\Assert::assertTrue()` call instead, mirroring the existing static-closure handling.

### Before
```php
public function some($response)
{
    return new class($response) {
        public function __construct($response)
        {
            assert((bool) $response);
        }
    };
}
```

### After
```php
public function some($response)
{
    return new class($response) {
        public function __construct($response)
        {
            \PHPUnit\Framework\Assert::assertTrue((bool) $response);
        }
    };
}
```

Added fixture `assert_inside_anonymous_class.php.inc`.