### PR TITLE
Bump to PHP 8.4

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -50,7 +50,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -23,7 +23,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Rector upgrades rules for PHPUnit",
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.4"
     },
     "require-dev": {
         "boundwize/structarmed": "^0.9",

--- a/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
+++ b/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
@@ -31,15 +31,6 @@ final readonly class DoctrineEntityDocumentAnalyser
         if (! $resolvedPhpDocBlock instanceof ResolvedPhpDocBlock) {
             return false;
         }
-
-        foreach (self::ENTITY_DOCBLOCK_MARKERS as $entityDocBlockMarkers) {
-            if (str_contains($resolvedPhpDocBlock->getPhpDocString(), $entityDocBlockMarkers)) {
-                return true;
-            }
-        }
-
-        // @todo apply attributes as well
-
-        return false;
+        return array_any(self::ENTITY_DOCBLOCK_MARKERS, fn(string $entityDocBlockMarkers): bool => str_contains($resolvedPhpDocBlock->getPhpDocString(), $entityDocBlockMarkers));
     }
 }

--- a/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
+++ b/rules/CodeQuality/NodeAnalyser/DoctrineEntityDocumentAnalyser.php
@@ -31,6 +31,7 @@ final readonly class DoctrineEntityDocumentAnalyser
         if (! $resolvedPhpDocBlock instanceof ResolvedPhpDocBlock) {
             return false;
         }
+
         return array_any(self::ENTITY_DOCBLOCK_MARKERS, fn(string $entityDocBlockMarkers): bool => str_contains($resolvedPhpDocBlock->getPhpDocString(), $entityDocBlockMarkers));
     }
 }

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -85,14 +85,7 @@ CODE_SAMPLE
         if (! $docComment instanceof Doc) {
             return null;
         }
-
-        $hasAnnotation = false;
-        foreach (NewLineSplitter::split($docComment->getText()) as $row) {
-            if (in_array(trim($row), ['*@test', '* @test'], true)) {
-                $hasAnnotation = true;
-                break;
-            }
-        }
+        $hasAnnotation = array_any(NewLineSplitter::split($docComment->getText()), fn(string $row): bool => in_array(trim($row), ['*@test', '* @test'], true));
 
         if (! $hasAnnotation) {
             return null;

--- a/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReplaceTestAnnotationWithPrefixedFunctionRector.php
@@ -85,6 +85,7 @@ CODE_SAMPLE
         if (! $docComment instanceof Doc) {
             return null;
         }
+
         $hasAnnotation = array_any(NewLineSplitter::split($docComment->getText()), fn(string $row): bool => in_array(trim($row), ['*@test', '* @test'], true));
 
         if (! $hasAnnotation) {

--- a/rules/CodeQuality/Rector/Class_/PreferTestsWithCamelCaseRector.php
+++ b/rules/CodeQuality/Rector/Class_/PreferTestsWithCamelCaseRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
+use PhpParser\Node\Identifier;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -86,7 +87,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $classMethod->name = new Node\Identifier($newName);
+            $classMethod->name = new Identifier($newName);
             $hasChanged = true;
         }
 
@@ -100,8 +101,8 @@ CODE_SAMPLE
     private function toCamelCase(string $value): string
     {
         $words = explode(' ', str_replace(['-', '_'], ' ', $value));
-        $words = array_map(fn (string $word): string => ucfirst($word), $words);
+        $words = array_map(ucfirst(...), $words);
 
-        return lcfirst(implode($words));
+        return lcfirst(implode('', $words));
     }
 }

--- a/rules/CodeQuality/Rector/Class_/PreferTestsWithSnakeCaseRector.php
+++ b/rules/CodeQuality/Rector/Class_/PreferTestsWithSnakeCaseRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
+use PhpParser\Node\Identifier;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -86,7 +87,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $classMethod->name = new Node\Identifier($newName);
+            $classMethod->name = new Identifier($newName);
             $hasChanged = true;
         }
 

--- a/rules/CodeQuality/Rector/Expression/AssertArrayCastedObjectToAssertSameRector.php
+++ b/rules/CodeQuality/Rector/Expression/AssertArrayCastedObjectToAssertSameRector.php
@@ -161,13 +161,6 @@ CODE_SAMPLE
      */
     private function hasAllKeysString(array $assertedArrayValues): bool
     {
-        // all keys must be string
-        foreach (array_keys($assertedArrayValues) as $key) {
-            if (! is_string($key)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(array_keys($assertedArrayValues), fn(int|string $key): bool => is_string($key));
     }
 }

--- a/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertCompareOnCountableWithMethodToAssertCountRector.php
@@ -104,7 +104,7 @@ final class AssertCompareOnCountableWithMethodToAssertCountRector extends Abstra
         ) {
             $type = $this->getType($comparedExpr->var);
 
-            if ((new ObjectType('Countable'))->isSuperTypeOf($type)->yes()) {
+            if (new ObjectType('Countable')->isSuperTypeOf($type)->yes()) {
                 $args = $assertArgs;
                 $args[1] = new Arg($comparedExpr->var);
 

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
@@ -118,13 +118,6 @@ CODE_SAMPLE
         if (! $classReflection instanceof ClassReflection) {
             return false;
         }
-
-        foreach (self::PARENT_CLASSES as $parentClass) {
-            if ($classReflection->is($parentClass)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::PARENT_CLASSES, fn(string $parentClass): bool => $classReflection->is($parentClass));
     }
 }

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
@@ -118,6 +118,7 @@ CODE_SAMPLE
         if (! $classReflection instanceof ClassReflection) {
             return false;
         }
+
         return array_any(self::PARENT_CLASSES, fn(string $parentClass): bool => $classReflection->is($parentClass));
     }
 }

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
@@ -270,13 +270,7 @@ CODE_SAMPLE
      */
     private function isAtLeastOneMockPropertyMockedOnce(array $usingTestMethodsByMockPropertyName): bool
     {
-        foreach ($usingTestMethodsByMockPropertyName as $usingTestMethods) {
-            if (count($usingTestMethods) !== 0) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($usingTestMethodsByMockPropertyName, fn(array $usingTestMethods): bool => $usingTestMethods !== []);
     }
 
     private function isMissingExpectsOnMockObjectMethodCallInSetUp(Class_ $class): bool

--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -96,6 +96,7 @@ final class AssertCallAnalyzer
         if (! is_string($callName)) {
             return false;
         }
+
         return array_any(self::ASSERT_METHOD_NAME_PREFIXES, fn(string $assertMethodNamePrefix): bool => str_starts_with($callName, $assertMethodNamePrefix));
     }
 

--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -96,14 +96,7 @@ final class AssertCallAnalyzer
         if (! is_string($callName)) {
             return false;
         }
-
-        foreach (self::ASSERT_METHOD_NAME_PREFIXES as $assertMethodNamePrefix) {
-            if (str_starts_with($callName, $assertMethodNamePrefix)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::ASSERT_METHOD_NAME_PREFIXES, fn(string $assertMethodNamePrefix): bool => str_starts_with($callName, $assertMethodNamePrefix));
     }
 
     private function hasDirectAssertOrMockCall(ClassMethod $classMethod): bool

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -34,6 +34,7 @@ final readonly class TestsNodeAnalyzer
         if (! $classReflection instanceof ClassReflection) {
             return false;
         }
+
         return array_any(PHPUnitClassName::TEST_CLASSES, fn(string $testCaseObjectClass): bool => $classReflection->is($testCaseObjectClass));
     }
 

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -34,14 +34,7 @@ final readonly class TestsNodeAnalyzer
         if (! $classReflection instanceof ClassReflection) {
             return false;
         }
-
-        foreach (PHPUnitClassName::TEST_CLASSES as $testCaseObjectClass) {
-            if ($classReflection->is($testCaseObjectClass)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(PHPUnitClassName::TEST_CLASSES, fn(string $testCaseObjectClass): bool => $classReflection->is($testCaseObjectClass));
     }
 
     public function isTestClassMethod(ClassMethod $classMethod): bool


### PR DESCRIPTION
Bumps minimum PHP to 8.4.

- composer.json: `php: >=8.3` → `>=8.4`
- CI workflows (code_analysis, rector): php-version `8.3` → `8.4`

`rector/rector-src` dev-main already requires PHP ^8.4.