### PR TITLE
[PHPUnit60] Fix false positive in AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/keep_deep_calls_before_assert_helper.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/keep_deep_calls_before_assert_helper.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class KeepDeepCallsBeforeAssertHelper extends TestCase
+{
+    public function testSomething(): void
+    {
+        // a deep, non-asserting call chain visited before the assert helper;
+        // it must not exhaust the nested-call budget and hide the assertion below
+        $this->prepare();
+
+        $this->checkResult(true);
+    }
+
+    private function prepare(): void
+    {
+        $this->stepTwo();
+    }
+
+    private function stepTwo(): void
+    {
+        $this->stepThree();
+    }
+
+    private function stepThree(): void
+    {
+        $this->stepFour();
+    }
+
+    private function stepFour(): void
+    {
+        $this->stepFive();
+    }
+
+    private function stepFive(): void
+    {
+        // no assertion here
+    }
+
+    private function checkResult(bool $bool): void
+    {
+        self::assertTrue($bool);
+    }
+}

--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -61,29 +61,34 @@ final class AssertCallAnalyzer
     {
         ++$this->classMethodNestingLevel;
 
-        // probably no assert method in the end
-        if ($this->classMethodNestingLevel > self::MAX_NESTED_METHOD_CALL_LEVEL) {
-            return false;
+        try {
+            // probably no assert method in the end
+            if ($this->classMethodNestingLevel > self::MAX_NESTED_METHOD_CALL_LEVEL) {
+                return false;
+            }
+
+            $cacheHash = md5($this->betterStandardPrinter->prettyPrint([$classMethod]));
+
+            if (isset($this->containsAssertCallByClassMethod[$cacheHash])) {
+                return $this->containsAssertCallByClassMethod[$cacheHash];
+            }
+
+            // A. try "->assert" shallow search first for performance
+            $hasDirectAssertOrMockCall = $this->hasDirectAssertOrMockCall($classMethod);
+            if ($hasDirectAssertOrMockCall) {
+                $this->containsAssertCallByClassMethod[$cacheHash] = $hasDirectAssertOrMockCall;
+                return true;
+            }
+
+            // B. look for nested calls
+            $hasNestedAssertOrMockCall = $this->hasNestedAssertCall($classMethod);
+            $this->containsAssertCallByClassMethod[$cacheHash] = $hasNestedAssertOrMockCall;
+
+            return $hasNestedAssertOrMockCall;
+        } finally {
+            // restore depth so sibling calls in the same DFS keep their full budget
+            --$this->classMethodNestingLevel;
         }
-
-        $cacheHash = md5($this->betterStandardPrinter->prettyPrint([$classMethod]));
-
-        if (isset($this->containsAssertCallByClassMethod[$cacheHash])) {
-            return $this->containsAssertCallByClassMethod[$cacheHash];
-        }
-
-        // A. try "->assert" shallow search first for performance
-        $hasDirectAssertOrMockCall = $this->hasDirectAssertOrMockCall($classMethod);
-        if ($hasDirectAssertOrMockCall) {
-            $this->containsAssertCallByClassMethod[$cacheHash] = $hasDirectAssertOrMockCall;
-            return true;
-        }
-
-        // B. look for nested calls
-        $hasNestedAssertOrMockCall = $this->hasNestedAssertCall($classMethod);
-        $this->containsAssertCallByClassMethod[$cacheHash] = $hasNestedAssertOrMockCall;
-
-        return $hasNestedAssertOrMockCall;
     }
 
     public function isAssertMethodCall(MethodCall|StaticCall $call): bool


### PR DESCRIPTION
## What

`AssertCallAnalyzer::containsAssertCall()` incremented `$classMethodNestingLevel` on every call but **never decremented it**. So instead of tracking real recursion depth, the counter accumulated across the whole depth-first walk of a single test method.

## Why it caused false positives

When a non-asserting call (e.g. a production static call) was visited *before* an assert-performing helper, it burned through the level-5 budget. The later helper recursion then hit `level > MAX_NESTED_METHOD_CALL_LEVEL` and short-circuited to `false`, so a test that *does* assert via a helper was wrongly tagged `@doesNotPerformAssertions`.

Order-dependent: any test where a non-asserting call precedes the assert helper in source order.

Found while investigating why `webonyx/graphql-php` skips this rule as "False-positive". Running the rule there flagged 7+ tests that assert through helpers (`$this->runTestCase()`, `$this->expectGraphQLValue()`, `$this->checkHandlesNonNullableLists()`, ...). With this fix only genuine `markTestSkipped()` tests remain.

## Fix

Wrap the body in `try { ... } finally { --$this->classMethodNestingLevel; }` so the depth is restored on unwind — sibling calls in the same DFS keep their full budget.

## Test

Added keep fixture `keep_deep_calls_before_assert_helper.php.inc`: a deep non-asserting chain visited before an assert helper. Fails on the old code (annotation added), passes with the fix.