### PR TITLE
[Set] Extract mock-to-stub rules into dedicated PHPUNIT_MOCK_TO_STUB set

### DIFF
--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
+use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        // stubs over mocks
+        CreateStubOverCreateMockArgRector::class,
+        CreateStubInCoalesceArgRector::class,
+        ExpressionCreateMockToCreateStubRector::class,
+        PropertyCreateMockToCreateStubRector::class,
+    ]);
+};

--- a/config/sets/phpunit120.php
+++ b/config/sets/phpunit120.php
@@ -3,22 +3,15 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
-use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
-use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
-use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([PHPUnitSetList::PHPUNIT_MOCK_TO_STUB]);
+
     $rectorConfig->rules([
         RemoveOverrideFinalConstructTestCaseRector::class,
         AssertIsTypeMethodCallRector::class,
-
-        // stubs over mocks
-        CreateStubOverCreateMockArgRector::class,
-        CreateStubInCoalesceArgRector::class,
-        ExpressionCreateMockToCreateStubRector::class,
-        PropertyCreateMockToCreateStubRector::class,
     ]);
 };

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -27,6 +27,8 @@ final class PHPUnitSetList
 
     public const string PHPUNIT_120 = __DIR__ . '/../../config/sets/phpunit120.php';
 
+    public const string PHPUNIT_MOCK_TO_STUB = __DIR__ . '/../../config/sets/phpunit-mock-to-stub.php';
+
     public const string PHPUNIT_CODE_QUALITY = __DIR__ . '/../../config/sets/phpunit-code-quality.php';
 
     public const string ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/annotations-to-attributes.php';


### PR DESCRIPTION
Extracts the 4 `createMock()` → `createStub()` rules out of the PHPUnit 12.0 set into a standalone, reusable set.

## New set

`PHPUnitSetList::PHPUNIT_MOCK_TO_STUB` → `config/sets/phpunit-mock-to-stub.php`:

- `CreateStubOverCreateMockArgRector`
- `CreateStubInCoalesceArgRector`
- `ExpressionCreateMockToCreateStubRector`
- `PropertyCreateMockToCreateStubRector`

## No breaking change

`phpunit120.php` now references the new set via `PHPUNIT_MOCK_TO_STUB`, so existing PHPUnit 12.0 users keep identical behavior, while the mock→stub migration can also be run on its own.