### PR TITLE
[PHPUnit120] Add MockObjectVarToStubRector

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -57,6 +57,7 @@ use Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTest
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
 use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
 use Rector\PHPUnit\PHPUnit90\Rector\MethodCall\ReplaceAtMethodWithDesiredMatcherRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
@@ -136,6 +137,7 @@ return static function (RectorConfig $rectorConfig): void {
         CreateStubOverCreateMockArgRector::class,
         ExpressionCreateMockToCreateStubRector::class,
         PropertyCreateMockToCreateStubRector::class,
+        MockObjectVarToStubRector::class,
         InlineStubPropertyToCreateStubMethodCallRector::class,
 
         // @test first, enable later

--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -7,6 +7,7 @@ use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
@@ -15,5 +16,6 @@ return static function (RectorConfig $rectorConfig): void {
         CreateStubInCoalesceArgRector::class,
         ExpressionCreateMockToCreateStubRector::class,
         PropertyCreateMockToCreateStubRector::class,
+        MockObjectVarToStubRector::class,
     ]);
 };

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/intersection_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/intersection_type.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class IntersectionTypeTest extends TestCase
+{
+    /**
+     * @var FieldModel&MockObject
+     */
+    private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class IntersectionTypeTest extends TestCase
+{
+    /**
+     * @var FieldModel&Stub
+     */
+    private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+}
+
+?>

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/skip_no_mock_object.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/skip_no_mock_object.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoMockObjectTest extends TestCase
+{
+    /**
+     * @var FieldModel
+     */
+    private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/skip_non_stub_native_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/skip_non_stub_native_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipNonStubNativeTypeTest extends TestCase
+{
+    /**
+     * @var FieldModel|MockObject
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $leadFieldModel;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+final class SkipNonTestClass
+{
+    /**
+     * @var FieldModel|MockObject
+     */
+    private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/union_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/union_type.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class UnionTypeTest extends TestCase
+{
+    /**
+     * @var FieldModel|MockObject
+     */
+    private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class UnionTypeTest extends TestCase
+{
+    /**
+     * @var FieldModel|Stub
+     */
+    private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+}
+
+?>

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/MockObjectVarToStubRectorTest.php
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/MockObjectVarToStubRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MockObjectVarToStubRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
+
+return RectorConfig::configure()
+    ->withRules(rules: [MockObjectVarToStubRector::class]);

--- a/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
+++ b/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit120\Rector\Property;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\MockObjectVarToStubRectorTest
+ */
+final class MockObjectVarToStubRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Property
+    {
+        // only properties already converted to a Stub native type
+        if (! $this->isStubNativeType($node->type)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $varTagValueNode = $phpDocInfo->getVarTagValueNode();
+        if (!$varTagValueNode instanceof VarTagValueNode) {
+            return null;
+        }
+
+        if (! $this->replaceMockObjectWithStub($varTagValueNode)) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Update the @var docblock of a property changed to a Stub native type, from MockObject to Stub',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+/**
+ * @var FieldModel|MockObject
+ */
+private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+/**
+ * @var FieldModel|Stub
+ */
+private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    private function isStubNativeType(?Node $typeNode): bool
+    {
+        if ($typeNode instanceof IntersectionType) {
+            return array_any($typeNode->types, fn(Identifier|Name $innerType): bool => $this->isStubName($innerType));
+        }
+
+        return $this->isStubName($typeNode);
+    }
+
+    private function isStubName(?Node $node): bool
+    {
+        return $node instanceof Node && $this->getName($node) === PHPUnitClassName::STUB;
+    }
+
+    private function replaceMockObjectWithStub(VarTagValueNode $varTagValueNode): bool
+    {
+        $typeNode = $varTagValueNode->type;
+
+        // fresh nodes (without original token positions) are re-printed, mutating in place is not
+        if ($typeNode instanceof UnionTypeNode || $typeNode instanceof IntersectionTypeNode) {
+            $hasChanged = false;
+            foreach ($typeNode->types as $key => $innerType) {
+                if ($innerType instanceof IdentifierTypeNode && $this->isMockObjectIdentifier($innerType)) {
+                    $typeNode->types[$key] = new IdentifierTypeNode($this->resolveStubName($innerType->name));
+                    $hasChanged = true;
+                }
+            }
+
+            return $hasChanged;
+        }
+
+        if ($typeNode instanceof IdentifierTypeNode && $this->isMockObjectIdentifier($typeNode)) {
+            $varTagValueNode->type = new IdentifierTypeNode($this->resolveStubName($typeNode->name));
+            return true;
+        }
+
+        return false;
+    }
+
+    private function isMockObjectIdentifier(IdentifierTypeNode $identifierTypeNode): bool
+    {
+        $lastBackslashPosition = strrpos($identifierTypeNode->name, '\\');
+        $shortName = $lastBackslashPosition === false
+            ? $identifierTypeNode->name
+            : substr($identifierTypeNode->name, $lastBackslashPosition + 1);
+
+        return $shortName === 'MockObject';
+    }
+
+    private function resolveStubName(string $name): string
+    {
+        $lastBackslashPosition = strrpos($name, '\\');
+
+        return $lastBackslashPosition === false
+            ? 'Stub'
+            : substr($name, 0, $lastBackslashPosition + 1) . 'Stub';
+    }
+}

--- a/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
+++ b/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\PHPUnit\PHPUnit120\Rector\Property;
 
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -17,6 +17,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -29,6 +30,7 @@ final class MockObjectVarToStubRector extends AbstractRector
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {
     }
 
@@ -42,6 +44,11 @@ final class MockObjectVarToStubRector extends AbstractRector
      */
     public function refactor(Node $node): ?Property
     {
+        // only inside PHPUnit TestCase scope
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
         // only properties already converted to a Stub native type
         if (! $this->isStubNativeType($node->type)) {
             return null;
@@ -53,7 +60,7 @@ final class MockObjectVarToStubRector extends AbstractRector
         }
 
         $varTagValueNode = $phpDocInfo->getVarTagValueNode();
-        if (!$varTagValueNode instanceof VarTagValueNode) {
+        if (! $varTagValueNode instanceof VarTagValueNode) {
             return null;
         }
 
@@ -93,7 +100,7 @@ CODE_SAMPLE
     private function isStubNativeType(?Node $typeNode): bool
     {
         if ($typeNode instanceof IntersectionType) {
-            return array_any($typeNode->types, fn(Identifier|Name $innerType): bool => $this->isStubName($innerType));
+            return array_any($typeNode->types, fn (Identifier|Name $innerType): bool => $this->isStubName($innerType));
         }
 
         return $this->isStubName($typeNode);


### PR DESCRIPTION
Adds `MockObjectVarToStubRector` — companion to `PropertyCreateMockToCreateStubRector`.

When a property native type is already `\PHPUnit\Framework\MockObject\Stub`, but its `@var` docblock still references `MockObject`, the docblock is updated.

```php
/**
 * @var FieldModel|MockObject
 */
private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
```

becomes

```php
/**
 * @var FieldModel|Stub
 */
private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
```

Handles union (`|`), intersection (`&`), and plain `@var` forms. Only fires when the native type is `Stub`, so real mock properties are untouched.

Registered in both the `phpunit-code-quality` and `phpunit-mock-to-stub` sets.