### PR TITLE
[PHPUnit120] Add BareVarToStubIntersectionRector

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -57,6 +57,7 @@ use Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTest
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
 use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
 use Rector\PHPUnit\PHPUnit90\Rector\MethodCall\ReplaceAtMethodWithDesiredMatcherRector;
@@ -138,6 +139,7 @@ return static function (RectorConfig $rectorConfig): void {
         ExpressionCreateMockToCreateStubRector::class,
         PropertyCreateMockToCreateStubRector::class,
         MockObjectVarToStubRector::class,
+        BareVarToStubIntersectionRector::class,
         InlineStubPropertyToCreateStubMethodCallRector::class,
 
         // @test first, enable later

--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -7,6 +7,7 @@ use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -17,5 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
         ExpressionCreateMockToCreateStubRector::class,
         PropertyCreateMockToCreateStubRector::class,
         MockObjectVarToStubRector::class,
+        BareVarToStubIntersectionRector::class,
     ]);
 };

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_compare_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_compare_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertCompareContext implements Context
 {
     public function some($response)
     {
@@ -17,7 +19,9 @@ final class AssertCompareContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertCompareContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_null_compare_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_null_compare_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertNullCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertNullCompareContext implements Context
 {
     public function some($response)
     {
@@ -16,7 +18,9 @@ final class AssertNullCompareContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertNullCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertNullCompareContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/method_exists_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/method_exists_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class MethodExistsContext
+use Behat\Behat\Context\Context;
+
+final class MethodExistsContext implements Context
 {
     public function some($response)
     {
@@ -16,7 +18,9 @@ final class MethodExistsContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class MethodExistsContext
+use Behat\Behat\Context\Context;
+
+final class MethodExistsContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/simple_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/simple_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class SimpleContext
+use Behat\Behat\Context\Context;
+
+final class SimpleContext implements Context
 {
     public function some($response)
     {
@@ -18,7 +20,9 @@ final class SimpleContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class SimpleContext
+use Behat\Behat\Context\Context;
+
+final class SimpleContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/skip_non_behat_context_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/skip_non_behat_context_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
+
+final class SchemaValidationContext
+{
+    public function some($response)
+    {
+        assert($response instanceof \DateTime, 'only remaining option');
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/BareVarToStubIntersectionRectorTest.php
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/BareVarToStubIntersectionRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class BareVarToStubIntersectionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/bare_var.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/bare_var.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class BareVarTest extends TestCase
+{
+    /**
+     * @var FormBuilderInterface
+     */
+    private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class BareVarTest extends TestCase
+{
+    /**
+     * @var FormBuilderInterface&Stub
+     */
+    private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+}
+
+?>

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_already_intersection.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_already_intersection.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipAlreadyIntersectionTest extends TestCase
+{
+    /**
+     * @var FormBuilderInterface&Stub
+     */
+    private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_non_stub_native_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_non_stub_native_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNonStubNativeTypeTest extends TestCase
+{
+    /**
+     * @var FormBuilderInterface
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $formBuilder;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\Fixture;
+
+final class SkipNonTestClass
+{
+    /**
+     * @var FormBuilderInterface
+     */
+    private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_stub_short_name.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/skip_stub_short_name.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\Fixture;
+
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class SkipStubShortNameTest extends TestCase
+{
+    /**
+     * @var Stub
+     */
+    private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+}

--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector;
+
+return RectorConfig::configure()
+    ->withRules(rules: [BareVarToStubIntersectionRector::class]);

--- a/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
@@ -24,6 +24,7 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\PHPUnit\Enum\AssertMethod;
+use Rector\PHPUnit\Enum\BehatClassName;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -195,15 +196,13 @@ CODE_SAMPLE
     private function isBehatContext(Class_ $class): bool
     {
         $scope = ScopeFetcher::fetch($class);
-        if (! $scope->getClassReflection() instanceof ClassReflection) {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
             return false;
         }
 
-        $className = $scope->getClassReflection()
-            ->getName();
-
         // special case with static call
-        return str_ends_with($className, 'Context');
+        return $classReflection->is(BehatClassName::CONTEXT);
     }
 
     /**

--- a/rules/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector.php
+++ b/rules/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit120\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\BareVarToStubIntersectionRector\BareVarToStubIntersectionRectorTest
+ */
+final class BareVarToStubIntersectionRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Property
+    {
+        // only inside PHPUnit TestCase scope
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        // only properties already converted to a Stub native type
+        if (! $this->isStubNativeType($node->type)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $varTagValueNode = $phpDocInfo->getVarTagValueNode();
+        if (! $varTagValueNode instanceof VarTagValueNode) {
+            return null;
+        }
+
+        if (! $this->addStubIntersection($varTagValueNode)) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add a &Stub intersection to a bare single-class @var docblock of a property changed to a Stub native type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+/**
+ * @var FormBuilderInterface
+ */
+private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+/**
+ * @var FormBuilderInterface&Stub
+ */
+private \PHPUnit\Framework\MockObject\Stub $formBuilder;
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    private function isStubNativeType(?Node $typeNode): bool
+    {
+        if ($typeNode instanceof IntersectionType) {
+            return array_any($typeNode->types, fn (Identifier|Name $innerType): bool => $this->isStubName($innerType));
+        }
+
+        return $this->isStubName($typeNode);
+    }
+
+    private function isStubName(?Node $node): bool
+    {
+        return $node instanceof Node && $this->getName($node) === PHPUnitClassName::STUB;
+    }
+
+    private function addStubIntersection(VarTagValueNode $varTagValueNode): bool
+    {
+        $typeNode = $varTagValueNode->type;
+
+        // only a single bare class type, not already a union/intersection
+        if (! $typeNode instanceof IdentifierTypeNode) {
+            return false;
+        }
+
+        // skip Stub/MockObject themselves, only mocked class types
+        if (in_array($this->resolveShortName($typeNode->name), ['Stub', 'MockObject'], true)) {
+            return false;
+        }
+
+        $varTagValueNode->type = new BracketsAwareIntersectionTypeNode([$typeNode, new IdentifierTypeNode('Stub')]);
+
+        return true;
+    }
+
+    private function resolveShortName(string $name): string
+    {
+        $lastBackslashPosition = strrpos($name, '\\');
+
+        return $lastBackslashPosition === false ? $name : substr($name, $lastBackslashPosition + 1);
+    }
+}

--- a/rules/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector.php
+++ b/rules/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector.php
@@ -98,6 +98,10 @@ CODE_SAMPLE
 
     private function isStubNativeType(?Node $typeNode): bool
     {
+        if (! $typeNode instanceof Node) {
+            return false;
+        }
+
         if ($typeNode instanceof IntersectionType) {
             return array_any($typeNode->types, fn (Identifier|Name $innerType): bool => $this->isStubName($innerType));
         }


### PR DESCRIPTION
Similar to #689 (MockObjectVarToStubRector), adds a complementary rule.

When a property is converted to a `Stub` native type but its `@var` docblock holds only the bare mocked-class type, this rule adds the `&Stub` intersection.

```diff
 /**
- * @var FormBuilderInterface
+ * @var FormBuilderInterface&Stub
  */
 private \PHPUnit\Framework\MockObject\Stub $formBuilder;
```

Scope:
- only inside PHPUnit `TestCase`
- only properties already typed as native `Stub`
- only a bare single-class `@var` (skips union/intersection, and `Stub`/`MockObject` short names)

Registered in `PHPUNIT_MOCK_TO_STUB` and `PHPUNIT_CODE_QUALITY` sets. Complements `MockObjectVarToStubRector`, which deliberately skips this bare-var case.