### PR TITLE
[CodeQuality] Detect Behat context by interface, not class name suffix

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_compare_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_compare_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertCompareContext implements Context
 {
     public function some($response)
     {
@@ -17,7 +19,9 @@ final class AssertCompareContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertCompareContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_null_compare_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/assert_null_compare_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertNullCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertNullCompareContext implements Context
 {
     public function some($response)
     {
@@ -16,7 +18,9 @@ final class AssertNullCompareContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class AssertNullCompareContext
+use Behat\Behat\Context\Context;
+
+final class AssertNullCompareContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/method_exists_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/method_exists_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class MethodExistsContext
+use Behat\Behat\Context\Context;
+
+final class MethodExistsContext implements Context
 {
     public function some($response)
     {
@@ -16,7 +18,9 @@ final class MethodExistsContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class MethodExistsContext
+use Behat\Behat\Context\Context;
+
+final class MethodExistsContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/simple_context.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/simple_context.php.inc
@@ -2,7 +2,9 @@
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class SimpleContext
+use Behat\Behat\Context\Context;
+
+final class SimpleContext implements Context
 {
     public function some($response)
     {
@@ -18,7 +20,9 @@ final class SimpleContext
 
 namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
 
-final class SimpleContext
+use Behat\Behat\Context\Context;
+
+final class SimpleContext implements Context
 {
     public function some($response)
     {

--- a/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/skip_non_behat_context_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector/Fixture/skip_non_behat_context_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector\Fixture;
+
+final class SchemaValidationContext
+{
+    public function some($response)
+    {
+        assert($response instanceof \DateTime, 'only remaining option');
+    }
+}

--- a/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/AssertFuncCallToPHPUnitAssertRector.php
@@ -24,6 +24,7 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\PHPUnit\Enum\AssertMethod;
+use Rector\PHPUnit\Enum\BehatClassName;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -195,15 +196,13 @@ CODE_SAMPLE
     private function isBehatContext(Class_ $class): bool
     {
         $scope = ScopeFetcher::fetch($class);
-        if (! $scope->getClassReflection() instanceof ClassReflection) {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
             return false;
         }
 
-        $className = $scope->getClassReflection()
-            ->getName();
-
         // special case with static call
-        return str_ends_with($className, 'Context');
+        return $classReflection->is(BehatClassName::CONTEXT);
     }
 
     /**


### PR DESCRIPTION
## Bug

`AssertFuncCallToPHPUnitAssertRector` decided a class was a Behat context with:

```php
return str_ends_with($className, 'Context');
```

Any class whose name ends with `Context` matched — including ordinary
production classes that have nothing to do with Behat. The rule then rewrote
their `assert()` calls into `\PHPUnit\Framework\Assert::` calls, pulling PHPUnit
into non-test source.

Found in [webonyx/graphql-php](https://github.com/webonyx/graphql-php), whose
`rector.php` skips this rule on `src` for exactly this reason. `SchemaValidationContext`
(a plain production class) was rewritten:

```diff
-assert($type instanceof ScalarType, 'only remaining option');
+\PHPUnit\Framework\Assert::assertInstanceOf(ScalarType::class, $type, 'only remaining option');
```

## Fix

Detect a real Behat context by whether it implements `Behat\Behat\Context\Context`
(the existing `BehatClassName::CONTEXT` constant, already used the same way in
`ScalarArgumentToExpectedParamTypeRector`), instead of matching the class name.

Existing `*Context` fixtures updated to implement the interface; added
`skip_non_behat_context_class.php.inc` covering a non-Behat `*Context` class.
