### PR TITLE
[CodeQuality] Skip AssertIssetToSpecificMethodRector on ArrayAccess objects

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector/Fixture/skip_array_access_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector/Fixture/skip_array_access_object.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector\Source\SomeArrayAccessStore;
+
+final class SkipArrayAccessObject extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $store = new SomeArrayAccessStore();
+
+        $this->assertTrue(isset($store[$key]), 'message');
+        $this->assertFalse(isset($store[$key]));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector/Source/SomeArrayAccessStore.php
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector/Source/SomeArrayAccessStore.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector\Source;
+
+final class SomeArrayAccessStore implements \ArrayAccess
+{
+    public function offsetExists($offset): bool
+    {
+        return true;
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+    }
+
+    public function offsetUnset($offset): void
+    {
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Type\ObjectType;
 use Rector\PHPUnit\Enum\AssertMethod;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -74,6 +75,13 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
 
         $issetExpr = $firstArgumentValue->vars[0];
         if (! $issetExpr instanceof ArrayDimFetch) {
+            return null;
+        }
+
+        // isset() on an ArrayAccess object is not equivalent to assertArrayHasKey():
+        // the key may be any type (assertArrayHasKey() requires int|string) and offsetExists()
+        // semantics can differ from array_key_exists()
+        if ($this->isObjectType($issetExpr->var, new ObjectType('ArrayAccess'))) {
             return null;
         }
 


### PR DESCRIPTION
## Bug

`AssertIssetToSpecificMethodRector` turns `isset($x[$key])` inside an assert into
`assertArrayHasKey($key, $x)`. That is correct for native arrays, but **not** for
`ArrayAccess` objects:

- `assertArrayHasKey()` requires the key to be `int|string`; `isset($obj[$key])`
  (i.e. `offsetExists()`) accepts any key type.
- `offsetExists()` semantics can differ from `array_key_exists()`.

Found in [webonyx/graphql-php](https://github.com/webonyx/graphql-php). Its
`MixedStoreTest` exercises an `ArrayAccess` store with keys of every type
(`null`, `bool`, `float`, array, object). The conversion produces code that
throws for those keys, which is why `rector.php` skips the rule on that file:

```diff
-self::assertTrue(isset($this->mixedStore[$key]), $err);
+self::assertArrayHasKey($key, $this->mixedStore, $err);
```

## Fix

Skip the rule when the array-dim subject is an `ArrayAccess` object. Native
arrays (the intended target) are unaffected. Added `skip_array_access_object.php.inc`
+ an `ArrayAccess` source stub.
