### PR TITLE
[CodeQuality] Skip NarrowUnusedSetUpDefinedPropertyRector for property used in nested closure

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_property_used_in_closure.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_property_used_in_closure.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipPropertyUsedInClosure extends TestCase
+{
+    private array $dataSource;
+
+    protected function setUp(): void
+    {
+        $this->dataSource = [1, 2, 3];
+
+        $this->resolver = function () {
+            return $this->dataSource;
+        };
+    }
+
+    public function test()
+    {
+        $resolver = $this->resolver;
+        $this->assertSame([1, 2, 3], $resolver());
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
@@ -6,6 +6,8 @@ namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
@@ -121,6 +123,12 @@ CODE_SAMPLE
                 continue;
             }
 
+            // referenced inside a nested closure that may run after setUp() - turning it into a local
+            // variable would leave it out of the closure scope, as there is no "use" binding to add it
+            if ($this->isPropertyUsedInNestedClosure($setUpClassMethod, $propertyName)) {
+                continue;
+            }
+
             $hasChanged = true;
 
             unset($node->stmts[$key]);
@@ -187,6 +195,36 @@ CODE_SAMPLE
         }
 
         return $isPropertyUsed;
+    }
+
+    private function isPropertyUsedInNestedClosure(ClassMethod $setUpClassMethod, string $propertyName): bool
+    {
+        $closures = $this->nodeFinder->find(
+            $setUpClassMethod,
+            static fn (Node $node): bool => $node instanceof Closure || $node instanceof ArrowFunction
+        );
+
+        foreach ($closures as $closure) {
+            $usedPropertyFetch = $this->nodeFinder->findFirst($closure, function (Node $node) use (
+                $propertyName
+            ): bool {
+                if (! $node instanceof PropertyFetch) {
+                    return false;
+                }
+
+                if (! $this->isName($node->var, 'this')) {
+                    return false;
+                }
+
+                return $this->isName($node->name, $propertyName);
+            });
+
+            if ($usedPropertyFetch instanceof PropertyFetch) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function shouldSkipProperty(

--- a/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
@@ -6,7 +6,6 @@ namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -199,10 +198,9 @@ CODE_SAMPLE
 
     private function isPropertyUsedInNestedClosure(ClassMethod $setUpClassMethod, string $propertyName): bool
     {
-        $closures = $this->nodeFinder->find(
-            $setUpClassMethod,
-            static fn (Node $node): bool => $node instanceof Closure || $node instanceof ArrowFunction
-        );
+        // only regular closures are unsafe: they do not capture outer variables without an
+        // explicit "use" binding. Arrow functions auto-capture by value, so narrowing is safe there.
+        $closures = $this->nodeFinder->findInstanceOf($setUpClassMethod, Closure::class);
 
         foreach ($closures as $closure) {
             $usedPropertyFetch = $this->nodeFinder->findFirst($closure, function (Node $node) use (


### PR DESCRIPTION
## Bug

`NarrowUnusedSetUpDefinedPropertyRector` turns a property only used in `setUp()`
into a local variable. While doing so it rewrites **every** `$this->property`
reference inside `setUp()` to a bare `$property` variable — including references
inside nested closures stored for later execution (resolver callbacks, deferred
factories, etc.).

A closure does not capture that local variable (the rule adds no `use ($property)`
binding), so when the closure runs *after* `setUp()` the variable is undefined and
the closure silently returns `null`.

Found in [webonyx/graphql-php](https://github.com/webonyx/graphql-php)
(`DeferredFieldsTest`), whose `rector.php` skips this rule. A resolver closure:

```php
$this->categoryDataSource = [/* ... */];
// ...
'resolve' => function () {
    return $this->categoryDataSource; // -> $categoryDataSource (undefined in closure) -> null
}
```

The rewrite made the deferred resolvers return `null`, breaking the tests
(verified: 3 failures with `zend.assertions=1`, gone after the fix, full suite
otherwise unchanged).

## Fix

Skip narrowing a property when it is referenced inside a `Closure` or
`ArrowFunction` within `setUp()`. Added `skip_property_used_in_closure.php.inc`.
