### PR TITLE
[CodeQuality] Skip NarrowUnusedSetUpDefinedPropertyRector for property captured by lazy/self-referencing arrow function

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_property_self_referenced_in_arrow_function.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Fixture/skip_property_self_referenced_in_arrow_function.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source\LazyContainer;
+
+final class SkipPropertySelfReferencedInArrowFunction extends TestCase
+{
+    private LazyContainer $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new LazyContainer([
+            'self' => fn (): LazyContainer => $this->container,
+        ]);
+    }
+
+    public function test()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Source/LazyContainer.php
+++ b/rules-tests/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector/Source/LazyContainer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector\Source;
+
+final class LazyContainer
+{
+    /**
+     * @param array<string, callable> $factories
+     */
+    public function __construct(
+        private array $factories
+    ) {
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/NarrowUnusedSetUpDefinedPropertyRector.php
@@ -6,6 +6,8 @@ namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -124,7 +126,7 @@ CODE_SAMPLE
 
             // referenced inside a nested closure that may run after setUp() - turning it into a local
             // variable would leave it out of the closure scope, as there is no "use" binding to add it
-            if ($this->isPropertyUsedInNestedClosure($setUpClassMethod, $propertyName)) {
+            if ($this->isPropertyUsedInUnsafeNestedFunction($setUpClassMethod, $propertyName)) {
                 continue;
             }
 
@@ -196,33 +198,82 @@ CODE_SAMPLE
         return $isPropertyUsed;
     }
 
-    private function isPropertyUsedInNestedClosure(ClassMethod $setUpClassMethod, string $propertyName): bool
+    private function isPropertyUsedInUnsafeNestedFunction(ClassMethod $setUpClassMethod, string $propertyName): bool
     {
-        // only regular closures are unsafe: they do not capture outer variables without an
-        // explicit "use" binding. Arrow functions auto-capture by value, so narrowing is safe there.
-        $closures = $this->nodeFinder->findInstanceOf($setUpClassMethod, Closure::class);
+        // a regular closure does not capture outer variables without an explicit "use" binding,
+        // so turning the property into a local variable always leaves it undefined inside the closure
+        foreach ($this->nodeFinder->findInstanceOf($setUpClassMethod, Closure::class) as $closure) {
+            if ($this->refersToThisProperty($closure, $propertyName)) {
+                return true;
+            }
+        }
 
-        foreach ($closures as $closure) {
-            $usedPropertyFetch = $this->nodeFinder->findFirst($closure, function (Node $node) use (
-                $propertyName
-            ): bool {
-                if (! $node instanceof PropertyFetch) {
-                    return false;
-                }
+        // an arrow function auto-captures by value at definition time; that only matches the original
+        // lazy "$this->property" read when the property assignment is already complete before the arrow
+        // function is defined. A later or wrapping assignment (e.g. a self-referencing type definition)
+        // would capture a not-yet-assigned variable
+        foreach ($this->nodeFinder->findInstanceOf($setUpClassMethod, ArrowFunction::class) as $arrowFunction) {
+            if (! $this->refersToThisProperty($arrowFunction, $propertyName)) {
+                continue;
+            }
 
-                if (! $this->isName($node->var, 'this')) {
-                    return false;
-                }
-
-                return $this->isName($node->name, $propertyName);
-            });
-
-            if ($usedPropertyFetch instanceof PropertyFetch) {
+            if (! $this->isPropertyAssignedBefore($setUpClassMethod, $propertyName, $arrowFunction)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function refersToThisProperty(Node $node, string $propertyName): bool
+    {
+        $propertyFetch = $this->nodeFinder->findFirst($node, function (Node $subNode) use ($propertyName): bool {
+            if (! $subNode instanceof PropertyFetch) {
+                return false;
+            }
+
+            if (! $this->isName($subNode->var, 'this')) {
+                return false;
+            }
+
+            return $this->isName($subNode->name, $propertyName);
+        });
+
+        return $propertyFetch instanceof PropertyFetch;
+    }
+
+    private function isPropertyAssignedBefore(
+        ClassMethod $setUpClassMethod,
+        string $propertyName,
+        ArrowFunction $arrowFunction
+    ): bool {
+        $arrowFunctionStartTokenPos = $arrowFunction->getStartTokenPos();
+
+        $assignBefore = $this->nodeFinder->findFirst($setUpClassMethod, function (Node $node) use (
+            $propertyName,
+            $arrowFunctionStartTokenPos
+        ): bool {
+            if (! $node instanceof Assign) {
+                return false;
+            }
+
+            if (! $node->var instanceof PropertyFetch) {
+                return false;
+            }
+
+            if (! $this->isName($node->var->var, 'this')) {
+                return false;
+            }
+
+            if (! $this->isName($node->var->name, $propertyName)) {
+                return false;
+            }
+
+            // assignment fully completes before the arrow function starts
+            return $node->getEndTokenPos() < $arrowFunctionStartTokenPos;
+        });
+
+        return $assignBefore instanceof Assign;
     }
 
     private function shouldSkipProperty(


### PR DESCRIPTION
Follow-up to #693.

## Why

#693 stopped `NarrowUnusedSetUpDefinedPropertyRector` from narrowing a property
referenced inside a **regular closure** (no `use` binding → undefined local).
But it still narrows properties captured by an **arrow function**, which is only
safe in some cases.

An arrow function auto-captures by value **at definition time**. That matches the
original lazy `$this->property` read only when the property is already fully
assigned *before* the arrow function. When the assignment **wraps or follows**
the arrow function, the captured local is still unset:

```php
// self-referencing type definition - the arrow fn captures $userType before the
// assignment completes, so after narrowing it captures null
$this->userType = new ObjectType([
    'fields' => fn (): array => [
        'bestFriend' => ['type' => $this->userType], // -> $userType (unset at capture) -> null
    ],
]);
```

Found in [webonyx/graphql-php](https://github.com/webonyx/graphql-php)
`DeferredFieldsTest` (verified: breaks the deferred resolvers with
`zend.assertions=1`, fixed after this change, full suite otherwise unchanged).

## Fix

Skip narrowing when the property is referenced inside an arrow function whose
capture happens before its assignment completes (wrapping or later assignment).
Still narrow when the property is assigned first (e.g. a mock yielded from a
generator — `MockToStubSetupCombined` keeps narrowing).

Added `skip_property_self_referenced_in_arrow_function.php.inc`.
