### PR TITLE
[PHPUnit120] Use Stub FQN in @var docblock

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/bare_var.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector/Fixture/bare_var.php.inc
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 final class BareVarTest extends TestCase
 {
     /**
-     * @var FormBuilderInterface&Stub
+     * @var FormBuilderInterface&\PHPUnit\Framework\MockObject\Stub
      */
     private \PHPUnit\Framework\MockObject\Stub $formBuilder;
 }

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/intersection_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/intersection_type.php.inc
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 final class IntersectionTypeTest extends TestCase
 {
     /**
-     * @var FieldModel&Stub
+     * @var FieldModel&\PHPUnit\Framework\MockObject\Stub
      */
     private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
 }

--- a/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/union_type.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Property/MockObjectVarToStubRector/Fixture/union_type.php.inc
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 final class UnionTypeTest extends TestCase
 {
     /**
-     * @var FieldModel|Stub
+     * @var FieldModel|\PHPUnit\Framework\MockObject\Stub
      */
     private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
 }

--- a/rules/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector.php
+++ b/rules/PHPUnit120/Rector/Property/BareVarToStubIntersectionRector.php
@@ -87,7 +87,7 @@ CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
 /**
- * @var FormBuilderInterface&Stub
+ * @var FormBuilderInterface&\PHPUnit\Framework\MockObject\Stub
  */
 private \PHPUnit\Framework\MockObject\Stub $formBuilder;
 CODE_SAMPLE
@@ -128,7 +128,10 @@ CODE_SAMPLE
             return false;
         }
 
-        $varTagValueNode->type = new BracketsAwareIntersectionTypeNode([$typeNode, new IdentifierTypeNode('Stub')]);
+        $varTagValueNode->type = new BracketsAwareIntersectionTypeNode([
+            $typeNode,
+            new IdentifierTypeNode('\\' . PHPUnitClassName::STUB),
+        ]);
 
         return true;
     }

--- a/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
+++ b/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
 /**
- * @var FieldModel|Stub
+ * @var FieldModel|\PHPUnit\Framework\MockObject\Stub
  */
 private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
 CODE_SAMPLE
@@ -120,7 +120,7 @@ CODE_SAMPLE
             $hasChanged = false;
             foreach ($typeNode->types as $key => $innerType) {
                 if ($innerType instanceof IdentifierTypeNode && $this->isMockObjectIdentifier($innerType)) {
-                    $typeNode->types[$key] = new IdentifierTypeNode($this->resolveStubName($innerType->name));
+                    $typeNode->types[$key] = new IdentifierTypeNode('\\' . PHPUnitClassName::STUB);
                     $hasChanged = true;
                 }
             }
@@ -129,7 +129,7 @@ CODE_SAMPLE
         }
 
         if ($typeNode instanceof IdentifierTypeNode && $this->isMockObjectIdentifier($typeNode)) {
-            $varTagValueNode->type = new IdentifierTypeNode($this->resolveStubName($typeNode->name));
+            $varTagValueNode->type = new IdentifierTypeNode('\\' . PHPUnitClassName::STUB);
             return true;
         }
 
@@ -144,14 +144,5 @@ CODE_SAMPLE
             : substr($identifierTypeNode->name, $lastBackslashPosition + 1);
 
         return $shortName === 'MockObject';
-    }
-
-    private function resolveStubName(string $name): string
-    {
-        $lastBackslashPosition = strrpos($name, '\\');
-
-        return $lastBackslashPosition === false
-            ? 'Stub'
-            : substr($name, 0, $lastBackslashPosition + 1) . 'Stub';
     }
 }


### PR DESCRIPTION
Both `MockObjectVarToStubRector` (#689) and `BareVarToStubIntersectionRector` (#690) wrote the short `Stub` name into the `@var` docblock, which requires a `use` import to resolve.

This always emits the FQN `\PHPUnit\Framework\MockObject\Stub` instead, so no import check is needed and the type resolves regardless of imports.

```diff
 /**
- * @var FieldModel|Stub
+ * @var FieldModel|\PHPUnit\Framework\MockObject\Stub
  */
 private \PHPUnit\Framework\MockObject\Stub $leadFieldModel;
```

Fixtures and code samples updated. Tests, ECS, PHPStan, Rector all pass.