### PR TITLE
[PHPUnit120] Skip PropertyCreateMockToCreateStubRector on abstract/base test classes

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_abstract_class.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_abstract_class.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class SkipAbstractClass extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(\stdClass::class);
+    }
+
+    public function testThis()
+    {
+        $this->assertSame('...', $this->someMock);
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_abstract_name_prefix.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_abstract_name_prefix.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class AbstractSkipSomeClass extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(\stdClass::class);
+    }
+
+    public function testThis()
+    {
+        $this->assertSame('...', $this->someMock);
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_test_case_suffix.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_test_case_suffix.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipSomeTestCase extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(\stdClass::class);
+    }
+
+    public function testThis()
+    {
+        $this->assertSame('...', $this->someMock);
+    }
+}

--- a/rules/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector.php
+++ b/rules/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector.php
@@ -146,6 +146,18 @@ CODE_SAMPLE
             return true;
         }
 
+        // skip abstract/base test classes, as property can be mocked in child classes
+        if ($class->isAbstract()) {
+            return true;
+        }
+
+        if ($class->name instanceof Identifier) {
+            $shortClassName = $class->name->toString();
+            if (str_ends_with($shortClassName, 'TestCase') || str_starts_with($shortClassName, 'Abstract')) {
+                return true;
+            }
+        }
+
         $setUpClassMethod = $class->getMethod(MethodName::SET_UP);
 
         // the setup class method must be here, so we have a place where the createMock() is used


### PR DESCRIPTION
PropertyCreateMockToCreateStubRector incorrectly changed property from Mock to Stub when defined in an abstract/base class.

In abstract classes, the mock property is often used for mocking in **child classes**, so the rule cannot detect the usage and produces a false positive.

## Fix

Skip class in `shouldSkipClass()` when:
- class is `abstract`
- class name ends with `TestCase`
- class name starts with `Abstract`

Added 2 skip fixtures.