### PR TITLE
[CodeQuality] Add AddIntersectionVarToMockObjectPropertyRector

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector;
-use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddParamTypeFromDependsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddReturnTypeToDependedRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
@@ -93,7 +92,6 @@ return static function (RectorConfig $rectorConfig): void {
         AddParamTypeFromDependsRector::class,
         AddReturnTypeToDependedRector::class,
         ScalarArgumentToExpectedParamTypeRector::class,
-        AddIntersectionVarToMockObjectPropertyRector::class,
 
         NarrowUnusedSetUpDefinedPropertyRector::class,
 

--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddParamTypeFromDependsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddReturnTypeToDependedRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
@@ -92,6 +93,7 @@ return static function (RectorConfig $rectorConfig): void {
         AddParamTypeFromDependsRector::class,
         AddReturnTypeToDependedRector::class,
         ScalarArgumentToExpectedParamTypeRector::class,
+        AddIntersectionVarToMockObjectPropertyRector::class,
 
         NarrowUnusedSetUpDefinedPropertyRector::class,
 

--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
@@ -19,5 +20,6 @@ return static function (RectorConfig $rectorConfig): void {
         PropertyCreateMockToCreateStubRector::class,
         MockObjectVarToStubRector::class,
         BareVarToStubIntersectionRector::class,
+        AddIntersectionVarToMockObjectPropertyRector::class,
     ]);
 };

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/AddIntersectionVarToMockObjectPropertyRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/AddIntersectionVarToMockObjectPropertyRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddIntersectionVarToMockObjectPropertyRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/fixture.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject&\stdClass
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/overwrite_existing_var.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/overwrite_existing_var.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class OverwriteExistingVarTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class OverwriteExistingVarTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject&\stdClass
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+final class SkipNonTestClass
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/skip_stub_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/skip_stub_property.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipStubPropertyTest extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\Stub $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
+
+return RectorConfig::configure()
+    ->withRules([AddIntersectionVarToMockObjectPropertyRector::class]);

--- a/rules/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
+use Rector\PHPUnit\CodeQuality\NodeAnalyser\MockObjectPropertyDetector;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\MethodName;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\AddIntersectionVarToMockObjectPropertyRectorTest
+ */
+final class AddIntersectionVarToMockObjectPropertyRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly MockObjectPropertyDetector $mockObjectPropertyDetector,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $setUpClassMethod = $node->getMethod(MethodName::SET_UP);
+        if (! $setUpClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $propertyNamesToCreateMockMethodCalls = $this->mockObjectPropertyDetector->collectFromClassMethod(
+            $setUpClassMethod
+        );
+        if ($propertyNamesToCreateMockMethodCalls === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($propertyNamesToCreateMockMethodCalls as $propertyName => $createMockMethodCall) {
+            $property = $node->getProperty($propertyName);
+            if (! $property instanceof Property) {
+                continue;
+            }
+
+            // only properties typed as a bare native MockObject
+            if (! $this->mockObjectPropertyDetector->detect($property)) {
+                continue;
+            }
+
+            $mockedClass = $this->resolveMockedClass($createMockMethodCall);
+            if ($mockedClass === null) {
+                continue;
+            }
+
+            $intersectionTypeNode = new BracketsAwareIntersectionTypeNode([
+                new IdentifierTypeNode('\\' . PHPUnitClassName::MOCK_OBJECT),
+                new IdentifierTypeNode('\\' . $mockedClass),
+            ]);
+
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+            $this->phpDocTypeChanger->changeVarTypeNode($property, $phpDocInfo, $intersectionTypeNode);
+
+            $hasChanged = true;
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add a MockObject intersection @var docblock with the mocked class to a native MockObject property',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(SomeService::class);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject&\SomeService
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(SomeService::class);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    private function resolveMockedClass(MethodCall $methodCall): ?string
+    {
+        $firstArg = $methodCall->getArgs()[0] ?? null;
+        if ($firstArg === null) {
+            return null;
+        }
+
+        if (! $firstArg->value instanceof ClassConstFetch) {
+            return null;
+        }
+
+        $className = $this->getName($firstArg->value->class);
+        if (! is_string($className)) {
+            return null;
+        }
+
+        return $className;
+    }
+}


### PR DESCRIPTION
Adds new rule `AddIntersectionVarToMockObjectPropertyRector`.

For a native `MockObject` property assigned via `createMock(X::class)` in `setUp()`, adds a `@var \PHPUnit\Framework\MockObject\MockObject&\X` docblock so the property carries both the MockObject and the mocked class type.

```php
 private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+/**
+ * @var \PHPUnit\Framework\MockObject\MockObject&\SomeService
+ */
+private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;

 protected function setUp(): void
 {
     $this->someServiceMock = $this->createMock(SomeService::class);
 }
```

Registered in `phpunit-code-quality` set. Overwrites any existing `@var`. Covered with tests (basic, overwrite-existing, skip non-MockObject type, skip non-test class).