### PR TITLE
[PHPUnit120] Skip PropertyCreateMockToCreateStubRector for property with expects() nested in closure

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_property_used_in_closure.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector/Fixture/skip_property_used_in_closure.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipPropertyUsedInClosure extends TestCase
+{
+    private \PHPUnit\Framework\MockObject\MockObject $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(\stdClass::class);
+    }
+
+    public function testThis()
+    {
+        $builder = $this->createMock(\stdClass::class);
+        $builder->method('addEventListener')->willReturnCallback(function () {
+            $this->someMock->expects($this->once())->method('something');
+        });
+    }
+}

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -141,9 +141,10 @@ final readonly class MockObjectExprDetector
             return true;
         }
 
-        // find out, how many are used in call likes as args
+        // find out, how many are used in call likes as args;
+        // not scoped on purpose, as expects() can be nested in closures, e.g. willReturnCallback()
         /** @var array<Expr\MethodCall> $methodCalls */
-        $methodCalls = $this->betterNodeFinder->findInstancesOfScoped($class->getMethods(), [MethodCall::class]);
+        $methodCalls = $this->betterNodeFinder->findInstancesOf($class->getMethods(), [MethodCall::class]);
 
         foreach ($methodCalls as $methodCall) {
             if (! $methodCall->var instanceof PropertyFetch) {


### PR DESCRIPTION
## Bug

`PropertyCreateMockToCreateStubRector` had false positive: converted a mock property to `createStub()` even though the property had `expects()` calls — when those calls were nested inside a closure (e.g. `willReturnCallback(function () { ... })`).

Cause: `MockObjectExprDetector::isPropertyUsedForMocking()` used `findInstancesOfScoped()`, which stops traversal at closure boundaries, so `$this->someMock->expects()->method()` inside a callback went undetected.

## Fix

Switched to non-scoped `findInstancesOf()` so usage inside closures is detected.

Added `skip_property_used_in_closure.php.inc` fixture.