### PR TITLE
[CodeQuality] Skip AddIntersectionVarToMockObjectPropertyRector when @var already has intersection type

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/skip_existing_intersection_var.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector/Fixture/skip_existing_intersection_var.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipExistingIntersectionVarTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject&\stdClass
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $someServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->someServiceMock = $this->createMock(\stdClass::class);
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector.php
@@ -10,7 +10,9 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
@@ -85,6 +87,13 @@ final class AddIntersectionVarToMockObjectPropertyRector extends AbstractRector
             ]);
 
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+
+            // already has an intersection @var, skip
+            $varTagValueNode = $phpDocInfo->getVarTagValueNode();
+            if ($varTagValueNode instanceof VarTagValueNode && $varTagValueNode->type instanceof IntersectionTypeNode) {
+                continue;
+            }
+
             $this->phpDocTypeChanger->changeVarTypeNode($property, $phpDocInfo, $intersectionTypeNode);
 
             $hasChanged = true;


### PR DESCRIPTION
Skip adding the `@var` docblock when the property already has an intersection `@var` type — no need to overwrite an existing intersection.

Added fixture `skip_existing_intersection_var.php.inc`. Tests pass (5/5), PHPStan clean.