### PR TITLE
[CodeQuality] Reuse local stub variable when property used 2+ times in single method

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineStubPropertyToCreateStubMethodCallRector/Fixture/reuse_variable_on_multiple_uses.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineStubPropertyToCreateStubMethodCallRector/Fixture/reuse_variable_on_multiple_uses.php.inc
@@ -6,24 +6,20 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\Stub;
 use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector\Source\NotRelevantClass;
 
-final class InlineUsedInCalls extends TestCase
+final class ReuseVariableOnMultipleUses extends TestCase
 {
-    private Stub $someStub;
+    private Stub $formatter;
 
     protected function setUp(): void
     {
-        $this->someStub = $this->createStub(NotRelevantClass::class);
+        $this->formatter = $this->createStub(NotRelevantClass::class);
     }
 
     public function testAnother()
     {
-        $anotherObject = new NotRelevantClass($this->someStub);
+        $handler = new NotRelevantClass($this->formatter);
 
-        $this->runThis($this->someStub);
-    }
-
-    private function runThis($object)
-    {
+        $this->assertSame(spl_object_id($this->formatter), spl_object_id($handler));
     }
 }
 
@@ -37,7 +33,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\Stub;
 use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector\Source\NotRelevantClass;
 
-final class InlineUsedInCalls extends TestCase
+final class ReuseVariableOnMultipleUses extends TestCase
 {
     protected function setUp(): void
     {
@@ -45,14 +41,10 @@ final class InlineUsedInCalls extends TestCase
 
     public function testAnother()
     {
-        $someStub = $this->createStub(\Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector\Source\NotRelevantClass::class);
-        $anotherObject = new NotRelevantClass($someStub);
+        $formatterStub = $this->createStub(\Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector\Source\NotRelevantClass::class);
+        $handler = new NotRelevantClass($formatterStub);
 
-        $this->runThis($someStub);
-    }
-
-    private function runThis($object)
-    {
+        $this->assertSame(spl_object_id($formatterStub), spl_object_id($handler));
     }
 }
 

--- a/rules/CodeQuality/Rector/Class_/InlineStubPropertyToCreateStubMethodCallRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineStubPropertyToCreateStubMethodCallRector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\ObjectType;
+use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\PHPUnit\CodeQuality\NodeAnalyser\StubPropertyResolver;
 use Rector\PHPUnit\CodeQuality\NodeFinder\PropertyFetchUsageFinder;
@@ -39,6 +40,7 @@ final class InlineStubPropertyToCreateStubMethodCallRector extends AbstractRecto
         private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly PropertyFetchUsageFinder $propertyFetchUsageFinder,
         private readonly StubPropertyResolver $stubPropertyResolver,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 
@@ -149,7 +151,32 @@ CODE_SAMPLE
 
             // 3. replace property fetch calls, with createStub()
             $stubClassName = $propertyNamesToStubClasses[$propertyName];
-            $this->traverseNodesWithCallable($node->getMethods(), function (Node $node) use (
+            foreach ($node->getMethods() as $classMethod) {
+                $this->refactorClassMethod($classMethod, $propertyName, $stubClassName);
+            }
+        }
+
+        if ($hasChanged === false) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function refactorClassMethod(ClassMethod $classMethod, string $propertyName, string $stubClassName): void
+    {
+        $propertyFetches = $this->betterNodeFinder->find(
+            (array) $classMethod->stmts,
+            fn (Node $node): bool => $node instanceof PropertyFetch && $this->isName($node->name, $propertyName)
+        );
+
+        if ($propertyFetches === []) {
+            return;
+        }
+
+        // single use → inline directly
+        if (count($propertyFetches) === 1) {
+            $this->traverseNodesWithCallable($classMethod, function (Node $node) use (
                 $propertyName,
                 $stubClassName
             ): ?MethodCall {
@@ -161,19 +188,74 @@ CODE_SAMPLE
                     return null;
                 }
 
-                $classConstFetch = new ClassConstFetch(new FullyQualified($stubClassName), 'class');
-
-                return new MethodCall(new Variable('this'), new Identifier('createStub'), [
-                    new Arg($classConstFetch),
-                ]);
+                return $this->createCreateStubMethodCall($stubClassName);
             });
+
+            return;
         }
 
-        if ($hasChanged === false) {
-            return null;
+        // multiple uses → assign to a local variable above first use and reuse it
+        $variableName = $this->resolveVariableName($propertyName);
+
+        $this->traverseNodesWithCallable($classMethod, function (Node $node) use (
+            $propertyName,
+            $variableName
+        ): ?Variable {
+            if (! $node instanceof PropertyFetch) {
+                return null;
+            }
+
+            if (! $this->isName($node->name, $propertyName)) {
+                return null;
+            }
+
+            return new Variable($variableName);
+        });
+
+        $assignExpression = new Expression(
+            new Assign(new Variable($variableName), $this->createCreateStubMethodCall($stubClassName))
+        );
+
+        $this->insertBeforeFirstVariableUse($classMethod, $variableName, $assignExpression);
+    }
+
+    private function insertBeforeFirstVariableUse(
+        ClassMethod $classMethod,
+        string $variableName,
+        Expression $assignExpression
+    ): void {
+        $stmts = (array) $classMethod->stmts;
+
+        foreach ($stmts as $key => $stmt) {
+            $firstVariable = $this->betterNodeFinder->findFirst(
+                $stmt,
+                fn (Node $node): bool => $node instanceof Variable && $this->isName($node, $variableName)
+            );
+
+            if (! $firstVariable instanceof Variable) {
+                continue;
+            }
+
+            array_splice($stmts, $key, 0, [$assignExpression]);
+            $classMethod->stmts = $stmts;
+            return;
+        }
+    }
+
+    private function createCreateStubMethodCall(string $stubClassName): MethodCall
+    {
+        $classConstFetch = new ClassConstFetch(new FullyQualified($stubClassName), 'class');
+
+        return new MethodCall(new Variable('this'), new Identifier('createStub'), [new Arg($classConstFetch)]);
+    }
+
+    private function resolveVariableName(string $propertyName): string
+    {
+        if (str_ends_with(strtolower($propertyName), 'stub')) {
+            return $propertyName;
         }
 
-        return $node;
+        return $propertyName . 'Stub';
     }
 
     private function removeSetupPropertyFetchByPropertyName(ClassMethod $setUpClassMethod, string $propertyName): void


### PR DESCRIPTION
## Why

`InlineStubPropertyToCreateStubMethodCallRector` inlined `$this->createStub(...)` at **every** property fetch. When a stub property is used 2+ times in a single method, that produced multiple distinct stub instances — breaking identity checks like `spl_object_id($this->formatter)`.

## What

Per-method handling in `refactorClassMethod()`:

- **1 use** in a method → inline directly (unchanged).
- **2+ uses** in a method → declare a local variable assigned to `$this->createStub(...)` above the first use, then reuse the variable.

Variable name via `resolveVariableName()`: `formatter` → `$formatterStub`; a name already ending in `Stub` is kept as-is (`someStub` → `$someStub`).

### Before
```php
public function testAnother()
{
    $handler = new FileLogHandler($this->createStub(FormatterInterface::class));
    $this->assertSame(spl_object_id($this->createStub(FormatterInterface::class)), spl_object_id($handler->getFormatter()));
}
```

### After
```php
public function testAnother()
{
    $formatterStub = $this->createStub(FormatterInterface::class);
    $handler = new FileLogHandler($formatterStub);
    $this->assertSame(spl_object_id($formatterStub), spl_object_id($handler->getFormatter()));
}
```

Only `Stub` properties are touched; `MockObject` (`createMock`) is left untouched.

## Tests

- Updated `inline_used_in_calls.php.inc` (2 uses → reuses local var).
- Added `reuse_variable_on_multiple_uses.php.inc`.

ECS, PHPStan, Rector, and the rule tests all pass.