### PR TITLE
[CodeQuality] Add ChangeMockObjectReturnUnionToIntersectionRector

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -19,6 +19,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\NoSetupWithParentCallOverrideRector;
@@ -155,6 +156,7 @@ return static function (RectorConfig $rectorConfig): void {
         EntityDocumentCreateMockToDirectNewRector::class,
         ReplaceAtMethodWithDesiredMatcherRector::class,
         BareCreateMockAssignToDirectUseRector::class,
+        ChangeMockObjectReturnUnionToIntersectionRector::class,
         DecorateWillReturnMapWithExpectsMockRector::class,
 
         // dead code

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/ChangeMockObjectReturnUnionToIntersectionRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/ChangeMockObjectReturnUnionToIntersectionRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeMockObjectReturnUnionToIntersectionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @return Event|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createEvent(): \PHPUnit\Framework\MockObject\MockObject
+    {
+        return $this->createMock(Event::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @return Event&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createEvent(): \PHPUnit\Framework\MockObject\MockObject
+    {
+        return $this->createMock(Event::class);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/short_mock_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/short_mock_object.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ShortMockObjectTest extends TestCase
+{
+    /**
+     * @return Event|MockObject
+     */
+    private function createEvent(): MockObject
+    {
+        return $this->createMock(Event::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ShortMockObjectTest extends TestCase
+{
+    /**
+     * @return Event&MockObject
+     */
+    private function createEvent(): MockObject
+    {
+        return $this->createMock(Event::class);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/skip_non_mock_union.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/skip_non_mock_union.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNonMockUnionTest extends TestCase
+{
+    /**
+     * @return Event|Campaign
+     */
+    private function resolve()
+    {
+        return $this->createEvent();
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+final class SkipNonTestClass
+{
+    /**
+     * @return Event|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createEvent()
+    {
+        return $this->createMock(Event::class);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/stub.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/Fixture/stub.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class StubTest extends TestCase
+{
+    /**
+     * @return Event|Stub
+     */
+    private function createEvent(): Stub
+    {
+        return $this->createStub(Event::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\Fixture;
+
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class StubTest extends TestCase
+{
+    /**
+     * @return Event&Stub
+     */
+    private function createEvent(): Stub
+    {
+        return $this->createStub(Event::class);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector;
+
+return RectorConfig::configure()
+    ->withRules([ChangeMockObjectReturnUnionToIntersectionRector::class]);

--- a/rules/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\ChangeMockObjectReturnUnionToIntersectionRectorTest
+ */
+final class ChangeMockObjectReturnUnionToIntersectionRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?ClassMethod
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        $returnTypeNode = $returnTagValueNode->type;
+        if (! $returnTypeNode instanceof UnionTypeNode) {
+            return null;
+        }
+
+        // must contain a MockObject member to be a mock union
+        if (! $this->hasMockObjectType($returnTypeNode)) {
+            return null;
+        }
+
+        $bracketsAwareIntersectionTypeNode = new BracketsAwareIntersectionTypeNode($returnTypeNode->types);
+        $this->phpDocTypeChanger->changeReturnTypeNode($node, $phpDocInfo, $bracketsAwareIntersectionTypeNode);
+
+        return $node;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change a MockObject @return union docblock to an intersection type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @return Event|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createEvent(): \PHPUnit\Framework\MockObject\MockObject
+    {
+        return $this->createMock(Event::class);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @return Event&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createEvent(): \PHPUnit\Framework\MockObject\MockObject
+    {
+        return $this->createMock(Event::class);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    private function hasMockObjectType(UnionTypeNode $unionTypeNode): bool
+    {
+        return array_any($unionTypeNode->types, fn(TypeNode $typeNode): bool => $this->isMockObjectType($typeNode));
+    }
+
+    private function isMockObjectType(TypeNode $typeNode): bool
+    {
+        if (! $typeNode instanceof IdentifierTypeNode) {
+            return false;
+        }
+
+        $typeName = ltrim($typeNode->name, '\\');
+
+        return $typeName === PHPUnitClassName::MOCK_OBJECT || $typeName === 'MockObject';
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector.php
@@ -61,8 +61,8 @@ final class ChangeMockObjectReturnUnionToIntersectionRector extends AbstractRect
             return null;
         }
 
-        // must contain a MockObject member to be a mock union
-        if (! $this->hasMockObjectType($returnTypeNode)) {
+        // must contain a MockObject or Stub member to be a mock union
+        if (! $this->hasMockObjectOrStubType($returnTypeNode)) {
             return null;
         }
 
@@ -112,12 +112,14 @@ CODE_SAMPLE
         );
     }
 
-    private function hasMockObjectType(UnionTypeNode $unionTypeNode): bool
+    private function hasMockObjectOrStubType(UnionTypeNode $unionTypeNode): bool
     {
-        return array_any($unionTypeNode->types, fn(TypeNode $typeNode): bool => $this->isMockObjectType($typeNode));
+        return array_any($unionTypeNode->types, fn (TypeNode $typeNode): bool => $this->isMockObjectOrStubType(
+            $typeNode
+        ));
     }
 
-    private function isMockObjectType(TypeNode $typeNode): bool
+    private function isMockObjectOrStubType(TypeNode $typeNode): bool
     {
         if (! $typeNode instanceof IdentifierTypeNode) {
             return false;
@@ -125,6 +127,10 @@ CODE_SAMPLE
 
         $typeName = ltrim($typeNode->name, '\\');
 
-        return $typeName === PHPUnitClassName::MOCK_OBJECT || $typeName === 'MockObject';
+        return in_array(
+            $typeName,
+            [PHPUnitClassName::MOCK_OBJECT, 'MockObject', PHPUnitClassName::STUB, 'Stub'],
+            true
+        );
     }
 }


### PR DESCRIPTION
Adds code quality rule that converts a `@return` docblock **union** with `MockObject` into an **intersection** type.

```diff
 /**
- * @return Event|\PHPUnit\Framework\MockObject\MockObject
+ * @return Event&\PHPUnit\Framework\MockObject\MockObject
  */
 private function getEvent(): \PHPUnit\Framework\MockObject\MockObject
 {
     return $this->createMock(Event::class);
 }
```

Mirrors the existing `AddIntersectionVarToMockObjectPropertyRector` (for `@var`), applied to method `@return` tags in test classes.

Registered in the `phpunit-code-quality` set.