### PR TITLE
[AnnotationsToAttributes] Avoid partial apply on CoversAnnotationWithValueToAttributeRector

### DIFF
--- a/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -108,7 +108,13 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass(self::COVERS_FUNCTION_ATTRIBUTE)) {
+        // avoid partial apply that may cause error
+        if (
+            ! $this->reflectionProvider->hasClass(self::COVERS_FUNCTION_ATTRIBUTE)
+            || ! $this->reflectionProvider->hasClass(self::COVERTS_CLASS_ATTRIBUTE)
+            || ! $this->reflectionProvider->hasClass(self::COVERTS_TRAIT_ATTRIBUTE)
+            || ! $this->reflectionProvider->hasClass(self::COVERS_METHOD_ATTRIBUTE)
+        ) {
             return null;
         }
 
@@ -140,10 +146,6 @@ CODE_SAMPLE
             $attributeValue = [trim($annotationValue, ':()')];
         } elseif (str_contains($annotationValue, '::')) {
             $attributeClass = self::COVERS_METHOD_ATTRIBUTE;
-            if (! $this->reflectionProvider->hasClass($attributeClass)) {
-                return null;
-            }
-
             $attributeValue = [$this->getClass($annotationValue) . '::class', $this->getMethod($annotationValue)];
         } else {
             $attributeClass = self::COVERTS_CLASS_ATTRIBUTE;
@@ -299,12 +301,6 @@ CODE_SAMPLE
         $desiredTagValueNodes = $phpDocInfo->getTagsByName('covers');
         foreach ($desiredTagValueNodes as $desiredTagValueNode) {
             if (! $desiredTagValueNode->value instanceof GenericTagValueNode) {
-                continue;
-            }
-
-            if (str_contains($desiredTagValueNode->value->value, '::') && ! $this->reflectionProvider->hasClass(
-                self::COVERS_METHOD_ATTRIBUTE
-            )) {
                 continue;
             }
 


### PR DESCRIPTION
When apply partial migration, this rule may cause error:

```
"@covers ::render" is invalid
```

this PR make early check that all possible migration class are there first so no more partial apply due to PHPUnit minor version introduce new attribute classes.