### PR TITLE
[CodeQuality] Add AssertClassToThisAssertRector

### DIFF
--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -7,7 +7,6 @@ use Rector\PHPUnit\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddParamTypeFromDependsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddReturnTypeToDependedRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
-use Rector\PHPUnit\CodeQuality\Rector\Class_\AssertClassToThisAssertRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector;
@@ -74,7 +73,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         AssertEqualsToSameRector::class,
         PreferPHPUnitThisCallRector::class,
-        AssertClassToThisAssertRector::class,
         YieldDataProviderRector::class,
         RemoveEmptyTestMethodRector::class,
         ReplaceTestAnnotationWithPrefixedFunctionRector::class,

--- a/config/sets/phpunit-code-quality.php
+++ b/config/sets/phpunit-code-quality.php
@@ -7,6 +7,7 @@ use Rector\PHPUnit\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddParamTypeFromDependsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddReturnTypeToDependedRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AssertClassToThisAssertRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector;
@@ -73,6 +74,7 @@ return static function (RectorConfig $rectorConfig): void {
 
         AssertEqualsToSameRector::class,
         PreferPHPUnitThisCallRector::class,
+        AssertClassToThisAssertRector::class,
         YieldDataProviderRector::class,
         RemoveEmptyTestMethodRector::class,
         ReplaceTestAnnotationWithPrefixedFunctionRector::class,

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/AssertClassToThisAssertRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/AssertClassToThisAssertRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertClassToThisAssertRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/basic.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/basic.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class BasicTest extends TestCase
+{
+    public function testMe()
+    {
+        Assert::assertSame(1, 1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class BasicTest extends TestCase
+{
+    public function testMe()
+    {
+        $this->assertSame(1, 1);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/fully_qualified.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/fully_qualified.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class FullyQualifiedTest extends TestCase
+{
+    public function testMe()
+    {
+        \PHPUnit\Framework\Assert::assertEquals('expected', $result);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class FullyQualifiedTest extends TestCase
+{
+    public function testMe()
+    {
+        $this->assertEquals('expected', $result);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+
+final class SkipNonTestClass
+{
+    public function run()
+    {
+        Assert::assertSame(1, 1);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_self_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_self_call.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipSelfCall extends TestCase
+{
+    public function testMe()
+    {
+        self::assertSame(1, 1);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_static_closure.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_static_closure.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class SkipStaticClosure extends TestCase
+{
+    public function testMe()
+    {
+        static fn() => Assert::assertSame(1, 1);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_static_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/Fixture/skip_static_method.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class SkipStaticMethod extends TestCase
+{
+    public static function testMe()
+    {
+        Assert::assertSame(1, 1);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AssertClassToThisAssertRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AssertClassToThisAssertRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AssertClassToThisAssertRector::class);
+};

--- a/rules/CodeQuality/Rector/Class_/AssertClassToThisAssertRector.php
+++ b/rules/CodeQuality/Rector/Class_/AssertClassToThisAssertRector.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeVisitor;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\AssertClassToThisAssertRectorTest
+ */
+final class AssertClassToThisAssertRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Changes PHPUnit calls from Assert::assert*() to $this->assert*()', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class SomeClass extends TestCase
+{
+    public function run()
+    {
+        Assert::assertEquals('expected', $result);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class SomeClass extends TestCase
+{
+    public function run()
+    {
+        $this->assertEquals('expected', $result);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        $this->traverseNodesWithCallable($node, function (Node $node) use (&$hasChanged): int|null|MethodCall {
+            $isInsideStaticFunctionLike = ($node instanceof ClassMethod && $node->isStatic()) || (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static);
+            if ($isInsideStaticFunctionLike) {
+                return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if (! $node instanceof StaticCall) {
+                return null;
+            }
+
+            if ($node->isFirstClassCallable()) {
+                return null;
+            }
+
+            if (! $this->isName($node->class, PHPUnitClassName::ASSERT)) {
+                return null;
+            }
+
+            $methodName = $this->getName($node->name);
+            if ($methodName === null) {
+                return null;
+            }
+
+            $hasChanged = true;
+            return $this->nodeFactory->createMethodCall('this', $methodName, $node->getArgs());
+        });
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Adds `AssertClassToThisAssertRector` to the code quality set.

Converts static `PHPUnit\Framework\Assert::assert*()` calls to `$this->assert*()` inside PHPUnit test classes.

The existing `PreferPHPUnitThisCallRector` only handles `self::`/`static::` calls; fully-qualified `Assert::` calls were not covered.

```diff
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;

 final class SomeTest extends TestCase
 {
     public function test()
     {
-        Assert::assertSame(1, 1);
+        $this->assertSame(1, 1);
     }
 }
```

Only rewrites when `$this` is usable — skips non-test classes, static methods, and static closures/arrow functions.