### PR TITLE
[CodeQuality] Add BareCreateMockAssignToDirectUseRector to phpunit-mock-to-stub set

### DIFF
--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
@@ -21,5 +22,6 @@ return static function (RectorConfig $rectorConfig): void {
         MockObjectVarToStubRector::class,
         AddIntersectionVarToMockObjectPropertyRector::class,
         AddStubIntersectionVarToStubPropertyRector::class,
+        BareCreateMockAssignToDirectUseRector::class,
     ]);
 };


### PR DESCRIPTION
Adds `BareCreateMockAssignToDirectUseRector` to the `phpunit-mock-to-stub` set.

Inlines a bare `createMock()` assign directly into the single call that uses it:

```diff
 public function test()
 {
-    $someObject = $this->createMock(SomeClass::class);
-    $this->process($someObject);
+    $this->process($this->createMock(SomeClass::class));
 }
```
