### PR TITLE
[CodeQuality] Skip TestCase suffix classes in RemoveNeverUsedMockPropertyRector

### DIFF
--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
@@ -21,5 +22,6 @@ return static function (RectorConfig $rectorConfig): void {
         MockObjectVarToStubRector::class,
         AddIntersectionVarToMockObjectPropertyRector::class,
         AddStubIntersectionVarToStubPropertyRector::class,
+        BareCreateMockAssignToDirectUseRector::class,
     ]);
 };

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector/Fixture/skip_test_case_suffix.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector/Fixture/skip_test_case_suffix.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveNeverUsedMockPropertyRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class SomeAbstractTestCase extends TestCase
+{
+    private MockObject $mockProperty;
+
+    protected function setUp(): void
+    {
+        $this->mockProperty = $this->createMock(\stdClass::class);
+        $this->mockProperty->expects($this->once())
+            ->method('someMethod')
+            ->willReturn('someValue');
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector.php
@@ -92,6 +92,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // skip abstract test case classes, as most likely extended and mock used in child classes
+        if (str_ends_with((string) $this->getName($node), 'TestCase')) {
+            return null;
+        }
+
         $setUpClassMethod = $node->getMethod(MethodName::SET_UP);
         if (! $setUpClassMethod instanceof ClassMethod) {
             return null;


### PR DESCRIPTION
Abstract `*TestCase` classes are most likely extended, with mock properties used in child test classes. This rule was removing those still-used mocks. Now skips any class whose name ends with `TestCase`.

```diff
-abstract class SomeAbstractTestCase extends TestCase
-{
-    private MockObject $mockProperty;
-
-    protected function setUp(): void
-    {
-        $this->mockProperty = $this->createMock(\stdClass::class);
-        $this->mockProperty->expects($this->once())
-            ->method('someMethod')
-            ->willReturn('someValue');
-    }
-}
```

Above class is now left untouched (`skip_test_case_suffix.php.inc` fixture).