### PR TITLE
[CodeQuality] Produce void callbacks with bare return in WithCallbackIdenticalToStandaloneAssertsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/array_key_exists.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/array_key_exists.php.inc
@@ -32,10 +32,10 @@ final class ArrayKeyExists extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function (array $args): bool {
+            ->with($this->callback(function (array $args): void {
                 $this->assertArrayHasKey(5, $args);
                 $this->assertInstanceOf(\stdClass::class, $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/arrow_with_class_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/arrow_with_class_variable.php.inc
@@ -32,10 +32,10 @@ final class ArrowWithClassVariable extends TestCase
         $this->createMock('SomeType')
             ->method('someMethod')
             ->with($this->callback(
-                function ($item) use ($type): bool {
+                function ($item) use ($type): void {
                     $this->assertInstanceOf($type, $item);
                     $this->assertSame('name', $item->getName());
-                    return true;
+                    return;
                 }
                 ));
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/assert_method_call_true.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/assert_method_call_true.php.inc
@@ -38,10 +38,10 @@ final class AssertMethodCallTrue extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function ($arg): bool {
+            ->with($this->callback(function ($arg): void {
                 $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\WithCallbackIdenticalToStandaloneAssertsRector\Source\SomeClassWithMethodCall::class, $arg);
                 $this->assertTrue($arg->isReady());
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/closure_instance_of.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/closure_instance_of.php.inc
@@ -34,10 +34,10 @@ final class ClosureInstanceOf extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function ($args): bool {
+            ->with($this->callback(function ($args): void {
                 $this->assertCount(5, $args);
                 $this->assertInstanceOf(\stdClass::class, $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/cover_equal.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/cover_equal.php.inc
@@ -32,10 +32,10 @@ final class CoverEqual extends TestCase
         $this->createMock('SomeType')
             ->method('someMethod')
             ->with($this->callback(
-                function ($item) use ($type): bool {
+                function ($item) use ($type): void {
                     $this->assertInstanceOf($type, $item);
                     $this->assertEquals('name', $item->getName());
-                    return true;
+                    return;
                 }
                 ));
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/extra_stmt.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/extra_stmt.php.inc
@@ -35,12 +35,12 @@ final class ExtraStmt extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function ($args): bool {
+            ->with($this->callback(function ($args): void {
                 $item = 100;
                 $this->assertCount(5, $args);
                 $this->assertArrayHasKey(0, $args);
                 $this->assertSame('some_value', $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/handle_solo_compare.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/handle_solo_compare.php.inc
@@ -36,9 +36,9 @@ final class HandleSoloCompare extends TestCase
             ->method('trans')
             ->with(
                 $this->callback(
-                    function ($args): bool {
+                    function ($args): void {
                         $this->assertCount(5, $args);
-                        return true;
+                        return;
                     }
                 )
             );

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/handle_solo_instance.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/handle_solo_instance.php.inc
@@ -36,9 +36,9 @@ final class HandleSoloInstance extends TestCase
             ->method('trans')
             ->with(
                 $this->callback(
-                    function ($arg): bool {
+                    function ($arg): void {
                         $this->assertInstanceOf(\stdClass::class, $arg);
-                        return true;
+                        return;
                     }
                 )
             );

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/handle_solo_isset.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/handle_solo_isset.php.inc
@@ -36,9 +36,9 @@ final class HandleSoloIsset extends TestCase
             ->method('trans')
             ->with(
                 $this->callback(
-                    function ($args): bool {
+                    function ($args): void {
                         $this->assertArrayHasKey('key', $args);
-                        return true;
+                        return;
                     }
                 )
             );

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/include_no_args.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/include_no_args.php.inc
@@ -39,11 +39,11 @@ final class IncludeNoArgs extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function (): bool {
+            ->with($this->callback(function (): void {
                 $args= [1, 2, 3];
                 $this->assertCount(5, $args);
                 $this->assertSame('some_value', $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/isset_array_keys.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/isset_array_keys.php.inc
@@ -34,11 +34,11 @@ final class IssetArrayKeys extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function ($args): bool {
+            ->with($this->callback(function ($args): void {
                 $this->assertCount(5, $args);
                 $this->assertArrayHasKey(0, $args);
                 $this->assertSame('some_value', $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/multi_callbacks.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/multi_callbacks.php.inc
@@ -36,13 +36,13 @@ final class MultiCallbacks extends TestCase
         $someMock->expects($this->any())
             ->method('trans')
             ->with(
-                    $this->callback(function (array $args): bool {
+                    $this->callback(function (array $args): void {
                         $this->assertArrayHasKey(5, $args);
-                        return true;
+                        return;
                     }),
-                    $this->callback(function (array $args): bool {
+                    $this->callback(function (array $args): void {
                         $this->assertArrayHasKey(50, $args);
-                        return true;
+                        return;
                     }),
             );
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/on_self.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/on_self.php.inc
@@ -36,10 +36,10 @@ final class OnSelf extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function ($arg): bool {
+            ->with($this->callback(function ($arg): void {
                 $this->assertInstanceOf(self::class, $arg);
                 $this->assertTrue($arg->isReady());
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/on_static_closure.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/on_static_closure.php.inc
@@ -36,10 +36,10 @@ final class OnStaticClosure extends TestCase
         $this->createMock('SomeClass')
             ->expects($this->once())
             ->method('someMethod')
-            ->with($this->callback(static function (array $args): bool {
+            ->with($this->callback(static function (array $args): void {
                 self::assertCount(2, $args);
                 self::assertSame('correct', $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/skip_this.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/skip_this.php.inc
@@ -41,10 +41,10 @@ final class SkipThis extends TestCase
         $someMock->expects($this->any())
             ->method('trans')
             ->with(
-                $this->callback(function ($args): bool {
+                $this->callback(function ($args): void {
                     $this->assertCount(5, $args);
                     $this->assertSame($this->expectedValue, $args[0]);
-                    return true;
+                    return;
                 })
             );
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/use_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/use_variable.php.inc
@@ -37,10 +37,10 @@ final class UseVariable extends TestCase
         $someMock->expects($this->any())
             ->method('trans')
             ->with(
-                $this->callback(function ($args) use ($expectedValue): bool {
+                $this->callback(function ($args) use ($expectedValue): void {
                     $this->assertCount(5, $args);
                     $this->assertSame($expectedValue, $args[0]);
-                    return true;
+                    return;
                 })
             );
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/use_variable_require_once.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/use_variable_require_once.php.inc
@@ -37,11 +37,11 @@ final class UseVariableRequireOnce extends TestCase
         $someMock->expects($this->any())
             ->method('trans')
             ->with(
-                $this->callback(function ($args) use ($expectedValue): bool {
+                $this->callback(function ($args) use ($expectedValue): void {
                     $this->assertCount(5, $args);
                     $this->assertSame($expectedValue, $args[0]);
                     $this->assertSame($expectedValue, $args[2]);
-                    return true;
+                    return;
                 })
             );
     }

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/with_arrow_function.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/with_arrow_function.php.inc
@@ -38,10 +38,10 @@ final class WithArrowFunction extends TestCase
             ->method('trans')
             ->with(
                 $this->callback(
-                    function ($args): bool {
+                    function ($args): void {
                         $this->assertCount(5, $args);
                         $this->assertInstanceOf(\stdClass::class, $args[0]);
-                        return true;
+                        return;
                     }
                 )
             );

--- a/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/with_callback_assert.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector/Fixture/with_callback_assert.php.inc
@@ -34,10 +34,10 @@ final class WithCallbackAssert extends TestCase
 
         $someMock->expects($this->any())
             ->method('trans')
-            ->with($this->callback(function ($args): bool {
+            ->with($this->callback(function ($args): void {
                 $this->assertCount(5, $args);
                 $this->assertSame('some_value', $args[0]);
-                return true;
+                return;
             }));
     }
 }

--- a/rules/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/WithCallbackIdenticalToStandaloneAssertsRector.php
@@ -73,11 +73,11 @@ final class SomeTest extends TestCase
         $this->createMock('SomeClass')
             ->expects($this->once())
             ->method('someMethod')
-            ->with($this->callback(function (array $args): bool {
+            ->with($this->callback(function (array $args): void {
                 $this->assertCount(2, $args);
                 $this->assertSame('correct', $args[0]);
 
-                return true;
+                return;
             }));
     }
 }
@@ -135,11 +135,12 @@ CODE_SAMPLE
 
             $nonReturnCallbackStmts = $this->resolveNonReturnCallbackStmts($argAndFunctionLike);
 
-            // last si return true;
-            $assertExprStmts[] = new Return_($this->nodeFactory->createTrue());
+            // last is a bare "return;"
+            $assertExprStmts[] = new Return_();
 
             if ($innerFunctionLike instanceof Closure) {
                 $innerFunctionLike->stmts = array_merge($nonReturnCallbackStmts, $assertExprStmts);
+                $innerFunctionLike->returnType = new Identifier('void');
             } else {
                 // arrow function -> flip to closure
                 $functionLikeInArg = $argAndFunctionLike->getArg();
@@ -280,7 +281,7 @@ CODE_SAMPLE
             'params' => $argAndFunctionLike->getFunctionLike()
                 ->params,
             'stmts' => $assertExprStmts,
-            'returnType' => new Identifier('bool'),
+            'returnType' => new Identifier('void'),
             'uses' => $externalVariables,
         ]);
     }


### PR DESCRIPTION
Change `WithCallbackIdenticalToStandaloneAssertsRector` output: the generated `$this->callback(...)` closure now has a `void` return type and a bare `return;` instead of `: bool` / `return true;`.

```diff
 ->with($this->callback(function (array $args): bool {
-    return count($args) === 2 && $args[0] === 'correct';
+ ->with($this->callback(function (array $args): void {
+    $this->assertCount(2, $args);
+    $this->assertSame('correct', $args[0]);
+
+    return;
 }));
```