### PR TITLE
[CodeQuality] Handle return throw and return null in void mock callbacks

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReturnFromVoidMethodMockCallbackRector/Fixture/return_throw_and_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReturnFromVoidMethodMockCallbackRector/Fixture/return_throw_and_null.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveReturnFromVoidMethodMockCallbackRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveReturnFromVoidMethodMockCallbackRector\Source\SomeEntityManager;
+
+final class ReturnThrowAndNull extends TestCase
+{
+    public function test($matcher): void
+    {
+        $this->createMock(SomeEntityManager::class)
+            ->method('persist')
+            ->willReturnCallback(function ($entity) use ($matcher) {
+                if (1 === $matcher->numberOfInvocations()) {
+                    return null;
+                }
+
+                if (2 === $matcher->numberOfInvocations()) {
+                    return throw new \RuntimeException('boom');
+                }
+            });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveReturnFromVoidMethodMockCallbackRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveReturnFromVoidMethodMockCallbackRector\Source\SomeEntityManager;
+
+final class ReturnThrowAndNull extends TestCase
+{
+    public function test($matcher): void
+    {
+        $this->createMock(SomeEntityManager::class)
+            ->method('persist')
+            ->willReturnCallback(function ($entity) use ($matcher): void {
+                if (1 === $matcher->numberOfInvocations()) {
+                    return;
+                }
+
+                if (2 === $matcher->numberOfInvocations()) {
+                    throw new \RuntimeException('boom');
+                }
+            });
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/RemoveReturnFromVoidMethodMockCallbackRector.php
+++ b/rules/CodeQuality/Rector/Class_/RemoveReturnFromVoidMethodMockCallbackRector.php
@@ -11,11 +11,13 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeFinder;
@@ -275,10 +277,15 @@ CODE_SAMPLE
             return false;
         }
 
-        // only strip side-effect-free values, to not lose behavior
+        // only strip side-effect-free values or a "return throw", to not lose behavior
         foreach ($valueReturns as $valueReturn) {
             $returnedExpr = $valueReturn->expr;
             if (! $returnedExpr instanceof Expr) {
+                continue;
+            }
+
+            // "return throw new X" becomes a bare "throw new X" statement below
+            if ($returnedExpr instanceof Throw_) {
                 continue;
             }
 
@@ -287,9 +294,22 @@ CODE_SAMPLE
             }
         }
 
-        foreach ($valueReturns as $valueReturn) {
-            $valueReturn->expr = null;
-        }
+        $this->traverseNodesWithCallable($closure->stmts, static function (Node $subNode): ?Expression {
+            if (! $subNode instanceof Return_) {
+                return null;
+            }
+
+            // "return throw new X;" is itself invalid in a void function, unwrap to "throw new X;"
+            if ($subNode->expr instanceof Throw_) {
+                return new Expression($subNode->expr);
+            }
+
+            if ($subNode->expr instanceof Expr) {
+                $subNode->expr = null;
+            }
+
+            return null;
+        });
 
         // drop a now-empty trailing "return;"
         $lastStmt = $closure->stmts[array_key_last($closure->stmts)] ?? null;


### PR DESCRIPTION
When a mocked **void** method's `willReturnCallback()` closure mixes `return null;` with a `return throw new X;`, `RemoveReturnFromVoidMethodMockCallbackRector` bailed out (a `return throw` is not a "pure" value), so it stripped nothing and typed nothing. `TypeWillReturnCallableArrowFunctionRector` then added `: void` on its own, leaving the value returns in place — producing code that fatals:

```
PHP Fatal error: A void function must not return a value
```

Note `return throw new X;` is **also** illegal in a `void` function, so stripping only `return null;` is not enough — the `return` must be dropped from the throw too.

This makes the rule normalize the whole void closure instead of bailing:

- `return null;` (and other pure returns) → `return;`
- `return throw new X;` → `throw new X;`
- closure typed `: void`

Impure, non-throw value returns still bail safely (behavior unchanged).

## Before → After

```diff
             ->method('persist')
-            ->willReturnCallback(function ($entity) use ($matcher) {
+            ->willReturnCallback(function ($entity) use ($matcher): void {
                 if (1 === $matcher->numberOfInvocations()) {
-                    return null;
+                    return;
                 }

                 if (2 === $matcher->numberOfInvocations()) {
-                    return throw new \RuntimeException('boom');
+                    throw new \RuntimeException('boom');
                 }
             });
```
