### PR TITLE
[CodeQuality] Skip by-ref use() closures in CallbackSingleAssertToSimplerRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/skip_referenced_use.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/skip_referenced_use.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipReferencedUse extends TestCase
+{
+    public function test()
+    {
+        $download = null;
+
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->once())
+            ->method('detach')
+            ->with($this->callback(function ($downloadDetach) use (&$download): bool {
+                $this->assertSame($downloadDetach, $download);
+
+                return true;
+            }));
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
@@ -125,6 +125,13 @@ CODE_SAMPLE
             return null;
         }
 
+        // skip closures capturing by reference, as the referenced value is likely modified above
+        foreach ($innerClosure->uses as $use) {
+            if ($use->byRef) {
+                return null;
+            }
+        }
+
         // exactly assertSame() expression + "return true;"
         $closureStmts = $innerClosure->getStmts();
         if (count($closureStmts) !== 2) {


### PR DESCRIPTION
`CallbackSingleAssertToSimplerRector` wrongly rewrote callbacks that capture a variable **by reference** in `use`. Such a variable is typically mutated in an earlier callback, so freezing it into an `equalTo()` matcher captures the wrong value.

Now the rule skips any callback closure with a by-reference `use`.

```php
$download = null;

$this->entityManager->expects($this->once())
    ->method('persist')
    ->with($this->callback(function ($downloadPersist) use (&$download): bool {
        $download = $downloadPersist;
        $this->assertInstanceOf(Download::class, $download);

        return true;
    }));

// referenced value modified above, must NOT be collapsed
$this->entityManager->expects($this->once())
    ->method('detach')
    ->with($this->callback(function ($downloadDetach) use (&$download): bool {
        $this->assertSame($downloadDetach, $download);

        return true;
    }));
```

Previously the second callback was rewritten to `->with($this->equalTo($downloadDetach))`, which is wrong. Now it is left untouched.
