### PR TITLE
[CodeQuality] Add PHPUNIT_NARROW_ASSERTS set focused on narrowing broad asserts to specific methods

### DIFF
--- a/config/sets/phpunit-narrow-asserts.php
+++ b/config/sets/phpunit-narrow-asserts.php
@@ -18,7 +18,6 @@ use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameBoolNullToSpecificMet
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameTrueFalseToAssertTrueFalseRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\MatchAssertSameExpectedTypeRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWithMethodRector;
 
 /**
@@ -37,7 +36,6 @@ return static function (RectorConfig $rectorConfig): void {
         AssertInstanceOfComparisonRector::class,
         AssertFuncCallToPHPUnitAssertRector::class,
         SimplifyForeachInstanceOfRector::class,
-        UseSpecificWillMethodRector::class,
         UseSpecificWithMethodRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
 

--- a/config/sets/phpunit-narrow-asserts.php
+++ b/config/sets/phpunit-narrow-asserts.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Expression\AssertArrayCastedObjectToAssertSameRector;
-use Rector\PHPUnit\CodeQuality\Rector\Foreach_\SimplifyForeachInstanceOfRector;
 use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMethodRector;
@@ -35,7 +34,6 @@ return static function (RectorConfig $rectorConfig): void {
         AssertIssetToSpecificMethodRector::class,
         AssertInstanceOfComparisonRector::class,
         AssertFuncCallToPHPUnitAssertRector::class,
-        SimplifyForeachInstanceOfRector::class,
         UseSpecificWithMethodRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
 

--- a/config/sets/phpunit-narrow-asserts.php
+++ b/config/sets/phpunit-narrow-asserts.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Expression\AssertArrayCastedObjectToAssertSameRector;
+use Rector\PHPUnit\CodeQuality\Rector\Foreach_\SimplifyForeachInstanceOfRector;
+use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertFalseStrposToContainsRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertNotOperatorRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameBoolNullToSpecificMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameTrueFalseToAssertTrueFalseRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\MatchAssertSameExpectedTypeRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWithMethodRector;
+
+/**
+ * Narrow broad asserts to their specific, more descriptive method calls,
+ * e.g. assertTrue(isset($a['b'])) => assertArrayHasKey('b', $a).
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        AssertCompareOnCountableWithMethodToAssertCountRector::class,
+        AssertComparisonToSpecificMethodRector::class,
+        AssertNotOperatorRector::class,
+        AssertTrueFalseToSpecificMethodRector::class,
+        AssertSameBoolNullToSpecificMethodRector::class,
+        AssertFalseStrposToContainsRector::class,
+        AssertIssetToSpecificMethodRector::class,
+        AssertInstanceOfComparisonRector::class,
+        AssertFuncCallToPHPUnitAssertRector::class,
+        SimplifyForeachInstanceOfRector::class,
+        UseSpecificWillMethodRector::class,
+        UseSpecificWithMethodRector::class,
+        AssertEmptyNullableObjectToAssertInstanceofRector::class,
+
+        AssertEqualsToSameRector::class,
+        AssertSameTrueFalseToAssertTrueFalseRector::class,
+        MatchAssertSameExpectedTypeRector::class,
+        AssertArrayCastedObjectToAssertSameRector::class,
+    ]);
+};

--- a/config/sets/phpunit-narrow-asserts.php
+++ b/config/sets/phpunit-narrow-asserts.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Expression\AssertArrayCastedObjectToAssertSameRector;
-use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
@@ -17,7 +16,6 @@ use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameBoolNullToSpecificMet
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameTrueFalseToAssertTrueFalseRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\MatchAssertSameExpectedTypeRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWithMethodRector;
 
 /**
  * Narrow broad asserts to their specific, more descriptive method calls,
@@ -33,8 +31,6 @@ return static function (RectorConfig $rectorConfig): void {
         AssertFalseStrposToContainsRector::class,
         AssertIssetToSpecificMethodRector::class,
         AssertInstanceOfComparisonRector::class,
-        AssertFuncCallToPHPUnitAssertRector::class,
-        UseSpecificWithMethodRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
 
         AssertEqualsToSameRector::class,

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -31,5 +31,7 @@ final class PHPUnitSetList
 
     public const string PHPUNIT_CODE_QUALITY = __DIR__ . '/../../config/sets/phpunit-code-quality.php';
 
+    public const string PHPUNIT_NARROW_ASSERTS = __DIR__ . '/../../config/sets/phpunit-narrow-asserts.php';
+
     public const string ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/annotations-to-attributes.php';
 }


### PR DESCRIPTION
Adds a focused `PHPUNIT_NARROW_ASSERTS` set that groups only the rules narrowing broad asserts into specific, more descriptive PHPUnit methods.

Handy when you want the assert-narrowing cleanups without adopting the full `PHPUNIT_CODE_QUALITY` set (mock/stub rewrites, type declarations, etc). All rules stay in `PHPUNIT_CODE_QUALITY` too.

```php
use Rector\Config\RectorConfig;
use Rector\PHPUnit\Set\PHPUnitSetList;

return RectorConfig::configure()
    ->withSets([
        PHPUnitSetList::PHPUNIT_NARROW_ASSERTS,
    ]);
```

Example changes the set produces:

```diff
-$this->assertTrue(isset($array['key']));
+$this->assertArrayHasKey('key', $array);
```

```diff
-$this->assertSame(10, count($items));
+$this->assertCount(10, $items);
```

```diff
-$this->assertEquals('value', $result);
+$this->assertSame('value', $result);
```

```diff
-$this->assertSame(null, $value);
+$this->assertNull($value);
```

Rules included (13): AssertCompareOnCountableWithMethodToAssertCount, AssertComparisonToSpecificMethod, AssertNotOperator, AssertTrueFalseToSpecificMethod, AssertSameBoolNullToSpecificMethod, AssertFalseStrposToContains, AssertIssetToSpecificMethod, AssertInstanceOfComparison, AssertEmptyNullableObjectToAssertInstanceof, AssertEqualsToSame, AssertSameTrueFalseToAssertTrueFalse, MatchAssertSameExpectedType, AssertArrayCastedObjectToAssertSame.
