### PR TITLE
[CodeQuality] Skip union types in AssertEqualsToSameRector to preserve loose type comparison

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_union_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_union_type.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipUnionType extends TestCase
+{
+    public function test(string|int|bool|\DateTime $expected)
+    {
+        $this->assertEquals('value', $this->normalizeStringValue($expected));
+    }
+
+    private function normalizeStringValue(string|int|bool|\DateTime $input): string|int|bool|\DateTime
+    {
+        return $input;
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -23,6 +23,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -125,6 +126,11 @@ final class AssertEqualsToSameRector extends AbstractRector
     {
         $firstArgType = $this->nodeTypeResolver->getNativeType($args[0]->value);
         $secondArgType = TypeCombinator::removeNull($this->nodeTypeResolver->getNativeType($args[1]->value));
+
+        // union type can hold different types that assertEquals() compares loosely, keep it safe
+        if ($secondArgType instanceof UnionType) {
+            return true;
+        }
 
         // loose comparison
         if ($firstArgType instanceof IntegerType && ($secondArgType instanceof FloatType || $secondArgType instanceof StringType)) {


### PR DESCRIPTION
`assertEquals()` compares loosely, so it accepts values of different types across a union. Converting to strict `assertSame()` would break such tests.

Now skip when the actual (second) argument resolves to a union type.

```php
#[DataProvider('stringProvider')]
public function testNormalizeStringValue(string|int|bool|\DateTime $input, string|int|bool|\DateTime $expected): void
{
    // union return type - values may differ in type between runs
    $this->assertEquals($expected, $this->formatterHelper->normalizeStringValue($input));
}
```

```diff
-$this->assertEquals($expected, $this->normalizeStringValue($input));
+$this->assertEquals($expected, $this->normalizeStringValue($input)); // unchanged
```

Before this change the rule wrongly narrowed it to `assertSame()`.
