### PR TITLE
[CodeQuality] Skip nested value compare in CallbackSingleAssertToSimplerRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/flipped_param_order.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/flipped_param_order.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class FlippedParamOrder extends TestCase
+{
+    public function test()
+    {
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->exactly(2))
+            ->method('add')
+            ->with($this->callback(function ($type): bool {
+                $this->assertSame($type, TextType::class);
+
+                return true;
+            }));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class FlippedParamOrder extends TestCase
+{
+    public function test()
+    {
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->exactly(2))
+            ->method('add')
+            ->with($this->equalTo(TextType::class));
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/skip_nested_compare.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/skip_nested_compare.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNestedCompare extends TestCase
+{
+    public function test()
+    {
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->exactly(2))
+            ->method('add')
+            ->with($this->callback(function (array $args): bool {
+                $this->assertSame($args['label'], 'Test Label');
+
+                return true;
+            }));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/skip_nested_compare_expected_left.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/skip_nested_compare_expected_left.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNestedCompareExpectedLeft extends TestCase
+{
+    public function test()
+    {
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->exactly(2))
+            ->method('add')
+            ->with($this->callback(function (array $args): bool {
+                $this->assertSame('Test Label', $args['label']);
+
+                return true;
+            }));
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
@@ -159,12 +159,20 @@ CODE_SAMPLE
             return null;
         }
 
-        // the actual value must be the whole closure parameter, not a nested access (e.g. $args['label'])
-        if (! $this->isClosureSoleParam($innerClosure, $assertSameArgs[1]->value)) {
-            return null;
+        $firstValue = $assertSameArgs[0]->value;
+        $secondValue = $assertSameArgs[1]->value;
+
+        // one side must be the whole closure parameter; the other side is the expected value
+        // nested access (e.g. $args['label']) is skipped, as equalTo() matches the whole argument
+        if ($this->isClosureSoleParam($innerClosure, $secondValue)) {
+            return $firstValue;
         }
 
-        return $assertSameArgs[0]->value;
+        if ($this->isClosureSoleParam($innerClosure, $firstValue)) {
+            return $secondValue;
+        }
+
+        return null;
     }
 
     private function isClosureSoleParam(Closure $closure, Expr $expr): bool

--- a/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -153,8 +154,35 @@ CODE_SAMPLE
             return null;
         }
 
-        return $firstStmtExpr->getArgs()[0]
-            ->value;
+        $assertSameArgs = $firstStmtExpr->getArgs();
+        if (count($assertSameArgs) !== 2) {
+            return null;
+        }
+
+        // the actual value must be the whole closure parameter, not a nested access (e.g. $args['label'])
+        if (! $this->isClosureSoleParam($innerClosure, $assertSameArgs[1]->value)) {
+            return null;
+        }
+
+        return $assertSameArgs[0]->value;
+    }
+
+    private function isClosureSoleParam(Closure $closure, Expr $expr): bool
+    {
+        if (count($closure->params) !== 1) {
+            return false;
+        }
+
+        if (! $expr instanceof Variable) {
+            return false;
+        }
+
+        $soleParam = $closure->params[0];
+        if (! $soleParam->var instanceof Variable) {
+            return false;
+        }
+
+        return $this->nodeComparator->areNodesEqual($soleParam->var, $expr);
     }
 
     private function isTrueReturn(Return_ $return): bool


### PR DESCRIPTION
`CallbackSingleAssertToSimplerRector` converts a `callback()` closure with a sole `assertSame()` into an `equalTo()` matcher. But `equalTo()` matches against the **whole** closure argument, so the conversion is only correct when the asserted value *is* the plain closure parameter.

When the assert compares a **nested** value (e.g. `$args['label']`), converting to `equalTo()` would wrongly match the entire argument. Now skipped.

```php
->with($this->callback(function (array $args): bool {
    $this->assertSame($args['label'], 'Test Label');

    return true;
}));
```

Stays untouched (previously wrongly collapsed to `->with($this->equalTo('Test Label'))`).

Still converts when the actual value is the whole parameter:

```diff
-->with($this->callback(function ($type): bool {
-    $this->assertSame(TextType::class, $type);
-
-    return true;
-}));
+->with($this->equalTo(TextType::class));
```