### PR TITLE
[CodeQuality] Use atLeast() instead of exactly() in DecorateWillReturnMapWithExpectsMockRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Expression/DecorateWillReturnMapWithExpectsMockRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Expression/DecorateWillReturnMapWithExpectsMockRector/Fixture/fixture.php.inc
@@ -26,7 +26,7 @@ final class SomeTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $someMock = $this->createMock(\stdClass::class);
-        $someMock->expects($this->exactly(2))->method('some')->willReturnMap([1, 2]);
+        $someMock->expects($this->atLeast(2))->method('some')->willReturnMap([1, 2]);
     }
 }
 

--- a/rules/CodeQuality/Rector/Expression/DecorateWillReturnMapWithExpectsMockRector.php
+++ b/rules/CodeQuality/Rector/Expression/DecorateWillReturnMapWithExpectsMockRector.php
@@ -70,7 +70,7 @@ final class SomeTest extends TestCase
     {
         $this->someMock = $this->createMock(SomeClass::class);
 
-        $this->someMock->expects($this->exactly(2))
+        $this->someMock->expects($this->atLeast(2))
             ->method("someMethod")
             ->willReturnMap([
                 ["arg1", "arg2", "result1"],
@@ -166,7 +166,7 @@ CODE_SAMPLE
             new Identifier('expects'),
             [new Arg(new MethodCall(
                 new Variable('this'),
-                new Identifier('exactly'),
+                new Identifier('atLeast'),
                 [new Arg(new Int_($mapCount))]
             ))]
         );


### PR DESCRIPTION
`willReturnMap()` only maps argument combinations to return values — it does not enforce a strict call count. Decorating with `expects($this->exactly(N))` forces the mock to be called *exactly* N times (N = map entry count), which produces false test failures when the mocked method is called fewer or more times than there are map entries.

Switching to `atLeast(N)` keeps a lower-bound expectation without over-constraining the call count.

### Before

```php
$someMock->method('some')->willReturnMap([1, 2]);
```

### After

```diff
-$someMock->method('some')->willReturnMap([1, 2]);
+$someMock->expects($this->atLeast(2))->method('some')->willReturnMap([1, 2]);
```