### PR TITLE
[CodeQuality] Verify assert method name exists on Assert class via reflection

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/file_exists.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/file_exists.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class FileExists extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(file_exists($file));
+        $this->assertFalse(file_exists($file));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class FileExists extends TestCase
+{
+    public function test()
+    {
+        $this->assertFileExists($file);
+        $this->assertFileDoesNotExist($file);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/fixture.php.inc
@@ -46,7 +46,7 @@ final class MyTest extends Testing
 
         $this->assertNotIsReadable('...');
         $this->assertEmpty('...');
-        $this->assertFileNotExists('...');
+        $this->assertFileDoesNotExist('...');
         $this->assertDirectoryExists('...');
         $this->assertFinite('...');
         $this->assertNan('...');

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/is_dir.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/is_dir.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IsDir extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(is_dir($directory));
+        $this->assertFalse(is_dir($directory));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IsDir extends TestCase
+{
+    public function test()
+    {
+        $this->assertDirectoryExists($directory);
+        $this->assertDirectoryDoesNotExist($directory);
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -11,7 +11,9 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\StringType;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\ValueObject\FunctionNameWithAssertMethods;
 use Rector\Rector\AbstractRector;
@@ -42,8 +44,18 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
         'str_contains' => ['str_contains', 'assertStringContainsString', 'assertStringNotContainsString'],
     ];
 
+    /**
+     * Some assert methods were renamed in newer PHPUnit versions
+     * @var array<string, string>
+     */
+    private const array RENAMED_ASSERT_METHOD_NAMES = [
+        'assertFileNotExists' => 'assertFileDoesNotExist',
+        'assertDirectoryNotExists' => 'assertDirectoryDoesNotExist',
+    ];
+
     public function __construct(
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -145,7 +157,9 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
         $oldMethodName = $identifierNode->toString();
 
         if (in_array($oldMethodName, ['assertTrue', 'assertNotFalse'], true)) {
-            $node->name = new Identifier($functionNameWithAssertMethods->getAssetMethodName());
+            $node->name = new Identifier(
+                $this->resolveExistingAssertMethodName($functionNameWithAssertMethods->getAssetMethodName())
+            );
         }
 
         if ($functionNameWithAssertMethods->getNotAssertMethodName() === '') {
@@ -156,7 +170,27 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
             return;
         }
 
-        $node->name = new Identifier($functionNameWithAssertMethods->getNotAssertMethodName());
+        $node->name = new Identifier(
+            $this->resolveExistingAssertMethodName($functionNameWithAssertMethods->getNotAssertMethodName())
+        );
+    }
+
+    /**
+     * Verify the assert method exists on the PHPUnit Assert class,
+     * as some methods were renamed in newer PHPUnit versions
+     */
+    private function resolveExistingAssertMethodName(string $methodName): string
+    {
+        if (! $this->reflectionProvider->hasClass(PHPUnitClassName::ASSERT)) {
+            return $methodName;
+        }
+
+        $assertClassReflection = $this->reflectionProvider->getClass(PHPUnitClassName::ASSERT);
+        if ($assertClassReflection->hasNativeMethod($methodName)) {
+            return $methodName;
+        }
+
+        return self::RENAMED_ASSERT_METHOD_NAMES[$methodName] ?? $methodName;
     }
 
     /**


### PR DESCRIPTION
`AssertTrueFalseToSpecificMethodRector` mapped `file_exists`/`is_dir` to `assertFileNotExists()`/`assertDirectoryNotExists()`. These were **renamed** in newer PHPUnit versions — the produced call no longer exists on the `Assert` class, breaking the test.

Now the rule verifies the target method exists on `PHPUnit\Framework\Assert` via reflection, and falls back to the current name when the legacy one is gone.

## Before

```php
$this->assertFalse(file_exists($file));
```

on PHPUnit 12 became:

```diff
-$this->assertFalse(file_exists($file));
+$this->assertFileNotExists($file); // method removed → fatal
```

## After

```diff
-$this->assertFalse(file_exists($file));
+$this->assertFileDoesNotExist($file);
```

Renames covered:

| legacy | current |
| --- | --- |
| `assertFileNotExists` | `assertFileDoesNotExist` |
| `assertDirectoryNotExists` | `assertDirectoryDoesNotExist` |

When the legacy method still exists (older PHPUnit), it is kept as-is.