### PR TITLE
[CodeQuality] Simplify single-statement void callback in CallbackSingleAssertToSimplerRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/single_stmt_void_callback.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector/Fixture/single_stmt_void_callback.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SingleStmtVoidCallback extends TestCase
+{
+    public function test()
+    {
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->once())
+            ->method('queueWebhooksByType')
+            ->with($this->callback(function ($type): void {
+                $this->assertSame($type, 'some_value');
+            }));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SingleStmtVoidCallback extends TestCase
+{
+    public function test()
+    {
+        $builder = $this->getMockBuilder('AnyType')->getMock();
+
+        $builder->expects($this->once())
+            ->method('queueWebhooksByType')
+            ->with($this->equalTo('some_value'));
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/CallbackSingleAssertToSimplerRector.php
@@ -133,13 +133,19 @@ CODE_SAMPLE
             }
         }
 
-        // exactly assertSame() expression + "return true;"
+        // sole assertSame() expression, optionally followed by "return true;"
         $closureStmts = $innerClosure->getStmts();
-        if (count($closureStmts) !== 2) {
+        if (count($closureStmts) === 2) {
+            [$firstStmt, $secondStmt] = $closureStmts;
+
+            if (! $secondStmt instanceof Return_ || ! $this->isTrueReturn($secondStmt)) {
+                return null;
+            }
+        } elseif (count($closureStmts) === 1) {
+            $firstStmt = $closureStmts[0];
+        } else {
             return null;
         }
-
-        [$firstStmt, $secondStmt] = $closureStmts;
 
         if (! $firstStmt instanceof Expression) {
             return null;
@@ -147,10 +153,6 @@ CODE_SAMPLE
 
         $firstStmtExpr = $firstStmt->expr;
         if (! $firstStmtExpr instanceof MethodCall || ! $this->isName($firstStmtExpr->name, 'assertSame')) {
-            return null;
-        }
-
-        if (! $secondStmt instanceof Return_ || ! $this->isTrueReturn($secondStmt)) {
             return null;
         }
 


### PR DESCRIPTION
Extends `CallbackSingleAssertToSimplerRector` to also simplify callbacks that hold a **single** `assertSame()` statement with no `return true;` (a `void` callback), not only the two-statement `assertSame()` + `return true;` shape.

```diff
 $this->mockModel->expects($this->once())
     ->method('queueWebhooksByType')
-    ->with($this->callback(function ($type): void {
-        $this->assertSame($type, 'some_value');
-    }));
+    ->with($this->equalTo('some_value'));
```

Multi-statement callbacks are still skipped.
