### PR TITLE
[CodeQuality] Skip mock property removal when used in a trait

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector/Fixture/skip_if_used_in_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector/Fixture/skip_if_used_in_trait.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveNeverUsedMockPropertyRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveNeverUsedMockPropertyRector\Source\UsesMockPropertyTrait;
+
+final class SkipIfUsedInTrait extends TestCase
+{
+    use UsesMockPropertyTrait;
+
+    private MockObject $mockProperty;
+
+    protected function setUp(): void
+    {
+        $this->mockProperty = $this->createMock(\stdClass::class);
+        $this->mockProperty->expects($this->once())
+            ->method('someMethod')
+            ->willReturn('someValue');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector/Source/UsesMockPropertyTrait.php
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector/Source/UsesMockPropertyTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\RemoveNeverUsedMockPropertyRector\Source;
+
+trait UsesMockPropertyTrait
+{
+    public function useMock(): void
+    {
+        $this->mockProperty->someMethod();
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/RemoveNeverUsedMockPropertyRector.php
@@ -13,6 +13,8 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Trait_;
+use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\PHPUnit\CodeQuality\NodeAnalyser\MockObjectPropertyDetector;
@@ -32,6 +34,7 @@ final class RemoveNeverUsedMockPropertyRector extends AbstractRector
         private readonly MockObjectPropertyDetector $mockObjectPropertyDetector,
         private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly AstResolver $astResolver,
     ) {
     }
 
@@ -235,9 +238,35 @@ CODE_SAMPLE
                 continue;
             }
 
+            // the property might be used in a used trait, skip removal to stay safe
+            if ($this->isPropertyUsedInTrait($class, $propertyName)) {
+                continue;
+            }
+
             $propertyNamesToRemove[] = $propertyName;
         }
 
         return $propertyNamesToRemove;
+    }
+
+    private function isPropertyUsedInTrait(Class_ $class, string $propertyName): bool
+    {
+        foreach ($class->getTraitUses() as $traitUse) {
+            foreach ($traitUse->traits as $traitName) {
+                $trait = $this->astResolver->resolveClassFromName($traitName->toString());
+                if (! $trait instanceof Trait_) {
+                    continue;
+                }
+
+                $propertyFetches = $this->betterNodeFinder->findInstancesOf($trait, [PropertyFetch::class]);
+                foreach ($propertyFetches as $propertyFetch) {
+                    if ($this->isName($propertyFetch->name, $propertyName)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
`RemoveNeverUsedMockPropertyRector` removed a mock property when it saw no local uses. But a used **trait** can reference that property, so removal broke the code.

Now resolves each used trait's AST and skips removal if the trait fetches the property.

### Skipped case

```php
trait UsesMockPropertyTrait
{
    public function useMock(): void
    {
        $this->mockProperty->someMethod();
    }
}

final class SkipIfUsedInTrait extends TestCase
{
    use UsesMockPropertyTrait;

    private MockObject $mockProperty;

    protected function setUp(): void
    {
        $this->mockProperty = $this->createMock(\stdClass::class);
        $this->mockProperty->expects($this->once())
            ->method('someMethod')
            ->willReturn('someValue');
    }
}
```

Before this change the `$mockProperty` (and its `setUp()` assignment) got removed, breaking `UsesMockPropertyTrait`. Now it is kept.