### PR TITLE
[CodeQuality] Skip with() multiple arguments in VoidMethodWithCallbackToWillReturnCallbackRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/VoidMethodWithCallbackToWillReturnCallbackRector/Fixture/skip_multiple_with_arguments.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/VoidMethodWithCallbackToWillReturnCallbackRector/Fixture/skip_multiple_with_arguments.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\VoidMethodWithCallbackToWillReturnCallbackRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\VoidMethodWithCallbackToWillReturnCallbackRector\Source\SomeEntityManager;
+
+final class SkipMultipleWithArguments extends TestCase
+{
+    public function test(): void
+    {
+        $this->createMock(SomeEntityManager::class)
+            ->method('persist')
+            ->with(
+                $this->callback(function ($entity): bool {
+                    $this->assertInstanceOf(\stdClass::class, $entity);
+
+                    return true;
+                }),
+                false
+            );
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/VoidMethodWithCallbackToWillReturnCallbackRector.php
+++ b/rules/CodeQuality/Rector/Class_/VoidMethodWithCallbackToWillReturnCallbackRector.php
@@ -180,7 +180,14 @@ CODE_SAMPLE
 
     private function matchCallbackClosure(MethodCall $withMethodCall): ?Closure
     {
-        $withFirstArg = $withMethodCall->getArgs()[0] ?? null;
+        $withArgs = $withMethodCall->getArgs();
+
+        // a 2nd+ ->with() argument matches a further parameter, keep the callback matcher as is
+        if (count($withArgs) > 1) {
+            return null;
+        }
+
+        $withFirstArg = $withArgs[0] ?? null;
         if (! $withFirstArg instanceof Arg) {
             return null;
         }


### PR DESCRIPTION
When `->with()` carries a 2nd+ argument (an extra matcher for a further parameter), the callback matcher no longer covers the whole call, so flipping it to `willReturnCallback()` would drop that matcher and change behavior. Skip these.

```diff
 $this->companyLeadRepo->expects($this->once())
     ->method('saveEntities')
     ->with(
         $this->callback(function (array $companyLeads) use ($winner, $company): bool {
             $this->assertCount(1, $companyLeads);
             return true;
         }),
         false
     );
```

Stays untouched, because `false` is a 2nd matcher argument.

Only a single-argument `->with($this->callback(...))` is still flipped.
