### PR TITLE
[CodeQuality] Skip new object instances in NarrowIdenticalWithConsecutiveRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/NarrowIdenticalWithConsecutiveRector/Fixture/skip_new_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/NarrowIdenticalWithConsecutiveRector/Fixture/skip_new_object.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\NarrowIdenticalWithConsecutiveRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\NarrowIdenticalWithConsecutiveRector\Source\SomeMockedClass;
+
+final class SkipNewObject extends TestCase
+{
+    public function test()
+    {
+        $someServiceMock = $this->createMock(SomeMockedClass::class);
+        $someServiceMock->expects($this->exactly(3))
+            ->method('prepare')
+            ->withConsecutive(
+                [new \stdClass()],
+                [new \stdClass()],
+                [new \stdClass()],
+            );
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/NarrowIdenticalWithConsecutiveRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/NarrowIdenticalWithConsecutiveRector.php
@@ -7,8 +7,10 @@ namespace Rector\PHPUnit\CodeQuality\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Identifier;
 use PhpParser\PrettyPrinter\Standard;
+use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -20,7 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class NarrowIdenticalWithConsecutiveRector extends AbstractRector
 {
     public function __construct(
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder
     ) {
     }
 
@@ -101,6 +104,11 @@ CODE_SAMPLE
 
         // skip as most likely nested array of unique values
         if ($firstArg->unpack) {
+            return null;
+        }
+
+        // skip new object instances, as each creates a fresh instance with possible property dependency
+        if ($this->betterNodeFinder->hasInstancesOf($node->getArgs(), [New_::class])) {
             return null;
         }
 


### PR DESCRIPTION
Skip narrowing `withConsecutive()` / `willReturnOnConsecutiveCalls()` when any consecutive arg builds a `new` object.

Each `new` call creates a fresh instance, possibly with a property/constructor dependency, so collapsing them to a single `with()` / `willReturn()` changes intent.

```diff
 $someServiceMock->expects($this->exactly(3))
     ->method('prepare')
-    ->withConsecutive(
-        [new \stdClass()],
-        [new \stdClass()],
-        [new \stdClass()],
-    );
+    ->withConsecutive(
+        [new \stdClass()],
+        [new \stdClass()],
+        [new \stdClass()],
+    ); // now skipped, left as-is
```

Plain scalar repeats still narrow as before:

```diff
 $someServiceMock->expects($this->exactly(3))
-    ->method('prepare')
-    ->withConsecutive([1], [1], [1]);
+    ->method('prepare')->with([1]);
```
