### PR TITLE
[CodeQuality] Move AssertClassToThisAssertRector hook from Class_ to ClassMethod

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/AssertClassToThisAssertRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/AssertClassToThisAssertRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/basic.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/basic.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +17,7 @@ final class BasicTest extends TestCase
 -----
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/fully_qualified.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/fully_qualified.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\TestCase;
 
@@ -16,7 +16,7 @@ final class FullyQualifiedTest extends TestCase
 -----
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\TestCase;
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/inside_foreach.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/inside_foreach.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class InsideForeach extends TestCase
+{
+    public function testOriginalKeyOrderingForFullAssociativeArray(): void
+    {
+        $entityMock = $this->createMock(SomeEntity::class);
+        $entityMock->method('getId')
+            ->willReturn(1);
+        $entities = [$entityMock];
+
+        $parameters = [
+            ['id' => 1, 'foo' => 'bar'],
+        ];
+
+        $helper = new SomeHelper($parameters);
+        $orderedEntities = $helper->orderByOriginalKey($entities);
+
+        $this->assertSame([0], array_keys($orderedEntities));
+
+        foreach ($parameters as $key => $contact) {
+            Assert::assertEquals($orderedEntities[$key]->getId(), $entities[$key]->getId());
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class InsideForeach extends TestCase
+{
+    public function testOriginalKeyOrderingForFullAssociativeArray(): void
+    {
+        $entityMock = $this->createMock(SomeEntity::class);
+        $entityMock->method('getId')
+            ->willReturn(1);
+        $entities = [$entityMock];
+
+        $parameters = [
+            ['id' => 1, 'foo' => 'bar'],
+        ];
+
+        $helper = new SomeHelper($parameters);
+        $orderedEntities = $helper->orderByOriginalKey($entities);
+
+        $this->assertSame([0], array_keys($orderedEntities));
+
+        foreach ($parameters as $key => $contact) {
+            $this->assertEquals($orderedEntities[$key]->getId(), $entities[$key]->getId());
+        }
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_non_test_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\Assert;
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_self_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_self_call.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\TestCase;
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_static_closure.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_static_closure.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_static_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_static_method.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\Fixture;
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\CodeQuality\Rector\Class_\AssertClassToThisAssertRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(AssertClassToThisAssertRector::class);

--- a/rules/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
+namespace Rector\PHPUnit\CodeQuality\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeVisitor;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
@@ -19,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AssertClassToThisAssertRector\AssertClassToThisAssertRectorTest
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\AssertClassToThisAssertRectorTest
  */
 final class AssertClassToThisAssertRector extends AbstractRector
 {
@@ -66,14 +65,18 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Class_::class];
+        return [ClassMethod::class];
     }
 
     /**
-     * @param Class_ $node
+     * @param ClassMethod $node
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->isStatic()) {
+            return null;
+        }
+
         if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
             return null;
         }
@@ -81,8 +84,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         $this->traverseNodesWithCallable($node, function (Node $node) use (&$hasChanged): int|null|MethodCall {
-            $isInsideStaticFunctionLike = ($node instanceof ClassMethod && $node->isStatic()) || (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static);
-            if ($isInsideStaticFunctionLike) {
+            if (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static) {
                 return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 


### PR DESCRIPTION
The rule only ever rewrote `Assert::assert*()` calls inside class methods, so hooking on `ClassMethod` is more precise than hooking on the whole `Class_` and re-traversing it.

Behavior is unchanged:

```diff
 final class SomeTest extends TestCase
 {
     public function testMe()
     {
-        Assert::assertSame(1, 1);
+        $this->assertSame(1, 1);
     }
 }
```

Static methods are now skipped with an early return instead of a `DONT_TRAVERSE_CURRENT_AND_CHILDREN` check inside the traversal callback:

```php
public function refactor(Node $node): ?Node
{
    if ($node->isStatic()) {
        return null;
    }
    // ...
}
```

Static closures and arrow functions are still skipped during traversal.

The rule and its tests move from `Rector/Class_/` to `Rector/ClassMethod/` to match the hooked node type.