### PR TITLE
[CodeQuality] Skip anonymous classes in AssertClassToThisAssertRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector/Fixture/skip_anonymous_class.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector\Fixture;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class SkipAnonymousClass extends TestCase
+{
+    public function testMe()
+    {
+        $repository = new class() {
+            public function getEntities(array $args = []): array
+            {
+                Assert::assertSame(['key' => 'value'], $args);
+
+                return [];
+            }
+        };
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/AssertClassToThisAssertRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeVisitor;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
@@ -85,6 +86,11 @@ CODE_SAMPLE
 
         $this->traverseNodesWithCallable($node, function (Node $node) use (&$hasChanged): int|null|MethodCall {
             if (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static) {
+                return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            // anonymous class has its own $this scope, that is not a test case
+            if ($node instanceof Class_) {
                 return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 


### PR DESCRIPTION
An anonymous class defined inside a test method has its own `$this` scope, which is not the `TestCase`. Rewriting `Assert::assertSame()` to `$this->assertSame()` there produces a call to a method that does not exist.

```diff
 final class SomeTest extends TestCase
 {
     public function testMe()
     {
         $repository = new class() {
             public function getEntities(array $args = []): array
             {
-                Assert::assertSame(['key' => 'value'], $args);
+                Assert::assertSame(['key' => 'value'], $args); // kept as is

                 return [];
             }
         };
     }
 }
```

The rule now stops traversing when it enters a `Class_` node, same way it already stops on static closures.