### PR TITLE
[CodeQuality] Skip super global variables on AssertIssetToSpecificMethodRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector/Fixture/skip_superglobals.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector/Fixture/skip_superglobals.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipSuperglobals extends TestCase
+{
+    public function test(): void
+    {
+        self::assertFalse(isset($GLOBALS['userconfig']));
+        self::assertFalse(isset($_SERVER['userconfig']));
+        self::assertFalse(isset($_GET['userconfig']));
+        self::assertFalse(isset($_POST['userconfig']));
+        self::assertFalse(isset($_FILES['userconfig']));
+        self::assertFalse(isset($_COOKIE['userconfig']));
+        self::assertFalse(isset($_SESSION['userconfig']));
+        self::assertFalse(isset($_REQUEST['userconfig']));
+        self::assertFalse(isset($_ENV['userconfig']));
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertIssetToSpecificMethodRector.php
@@ -22,6 +22,21 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class AssertIssetToSpecificMethodRector extends AbstractRector
 {
+    /**
+     * @var string[]
+     */
+    private const array SUPER_GLOBAL_VARIABLE_NAMES = [
+        'GLOBALS',
+        '_SERVER',
+        '_GET',
+        '_POST',
+        '_FILES',
+        '_COOKIE',
+        '_SESSION',
+        '_REQUEST',
+        '_ENV',
+    ];
+
     public function __construct(
         private readonly IdentifierManipulator $identifierManipulator,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -75,6 +90,12 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
 
         $issetExpr = $firstArgumentValue->vars[0];
         if (! $issetExpr instanceof ArrayDimFetch) {
+            return null;
+        }
+
+        // Keep the non-evaluating behavior of isset() for global state. A superglobal
+        // may be unavailable or unset, while passing it directly evaluates the variable.
+        if ($this->isNames($issetExpr->var, self::SUPER_GLOBAL_VARIABLE_NAMES)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9812