### PR TITLE
[PHPUnit 13] Add PHPUnit 13 config set

### DIFF
--- a/config/sets/phpunit130.php
+++ b/config/sets/phpunit130.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        // @see https://github.com/sebastianbergmann/phpunit/issues/6560
+        new MethodCallRename('PHPUnit\Framework\TestClass', 'expectExceptionMessage', 'expectExceptionMessageIsOrContains'),
+    ]);
+};

--- a/src/Set/PHPUnitSetList.php
+++ b/src/Set/PHPUnitSetList.php
@@ -27,6 +27,8 @@ final class PHPUnitSetList
 
     public const string PHPUNIT_120 = __DIR__ . '/../../config/sets/phpunit120.php';
 
+    public const string PHPUNIT_130 = __DIR__ . '/../../config/sets/phpunit130.php';
+
     public const string PHPUNIT_MOCK_TO_STUB = __DIR__ . '/../../config/sets/phpunit-mock-to-stub.php';
 
     public const string PHPUNIT_CODE_QUALITY = __DIR__ . '/../../config/sets/phpunit-code-quality.php';

--- a/src/Set/SetProvider/PHPUnitSetProvider.php
+++ b/src/Set/SetProvider/PHPUnitSetProvider.php
@@ -82,6 +82,13 @@ final class PHPUnitSetProvider implements SetProviderInterface
                 __DIR__ . '/../../../config/sets/phpunit125.php'
             ),
 
+            new ComposerTriggeredSet(
+                SetGroup::PHPUNIT,
+                'phpunit/phpunit',
+                '13.0',
+                __DIR__ . '/../../../config/sets/phpunit130.php'
+            ),
+
             new Set(SetGroup::PHPUNIT, 'Code Quality', __DIR__ . '/../../../config/sets/phpunit-code-quality.php'),
 
             new Set(


### PR DESCRIPTION
Start adding PHPUnit 13 config set, start with rename deprecated `expectExceptionMessage` to `expectExceptionMessageIsOrContains`. 

The `expectExceptionMessage` behaviour is using `str_contains` so direct replacement is using `expectExceptionMessageIsOrContains`.

https://github.com/sebastianbergmann/phpunit/issues/6560