### PR TITLE
[PHPUnit 13] Fix class in expectExceptionMessage() rename to TestCase

### DIFF
--- a/config/sets/phpunit130.php
+++ b/config/sets/phpunit130.php
@@ -9,6 +9,6 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
         // @see https://github.com/sebastianbergmann/phpunit/issues/6560
-        new MethodCallRename('PHPUnit\Framework\TestClass', 'expectExceptionMessage', 'expectExceptionMessageIsOrContains'),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectExceptionMessage', 'expectExceptionMessageIsOrContains'),
     ]);
 };

--- a/rules/CodeQuality/Rector/MethodCall/AssertComparisonToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertComparisonToSpecificMethodRector.php
@@ -35,7 +35,7 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
     /**
      * @var BinaryOpWithAssertMethod[]
      */
-    private array $binaryOpWithAssertMethods = [];
+    private readonly array $binaryOpWithAssertMethods;
 
     public function __construct(
         private readonly IdentifierManipulator $identifierManipulator,

--- a/rules/CodeQuality/Rector/MethodCall/AssertSameBoolNullToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertSameBoolNullToSpecificMethodRector.php
@@ -24,7 +24,7 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
     /**
      * @var ConstantWithAssertMethods[]
      */
-    private array $constantWithAssertMethods = [];
+    private readonly array $constantWithAssertMethods;
 
     public function __construct(
         private readonly IdentifierManipulator $identifierManipulator,


### PR DESCRIPTION
The `PHPUNIT_130` set renamed `expectExceptionMessage()` on `PHPUnit\Framework\TestClass` — a class that does not exist. The rename never applied.

Fixed to `PHPUnit\Framework\TestCase`, so the set now handles the [phpunit#6560](https://github.com/sebastianbergmann/phpunit/issues/6560) soft deprecation (PHPUnit 13.2):

```diff
 final class SomeTest extends TestCase
 {
     public function test(): void
     {
-        $this->expectExceptionMessage('some message');
+        $this->expectExceptionMessageIsOrContains('some message');
     }
 }
```