### PR TITLE
Bump dev dependencies, PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,21 +8,21 @@
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.1.38",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^12.5",
-        "rector/jack": "^0.5",
+        "phpunit/phpunit": "^13.2",
+        "rector/jack": "^1.0",
         "rector/rector-src": "dev-main",
-        "rector/swiss-knife": "^2.3",
-        "symplify/easy-coding-standard": "^13.0",
+        "rector/swiss-knife": "^2.4",
+        "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",
-        "symplify/phpstan-rules": "^14.9.11",
+        "symplify/phpstan-rules": "^14.12",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",
         "tomasvotruba/type-coverage": "^2.3",
         "tomasvotruba/unused-public": "^2.2",
-        "tracy/tracy": "^2.11"
+        "tracy/tracy": "^2.12"
     },
     "autoload": {
         "psr-4": {

--- a/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
+++ b/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
@@ -170,7 +170,11 @@ CODE_SAMPLE
 
             if ($callerType instanceof ObjectType && in_array(
                 $callerType->getClassName(),
-                [PHPUnitClassName::INVOCATION_MOCKER, PHPUnitClassName::INVOCATION_STUBBER],
+                [
+                    PHPUnitClassName::INVOCATION_MOCKER,
+                    PHPUnitClassName::INVOCATION_MOCKER_INTERFACE,
+                    PHPUnitClassName::INVOCATION_STUBBER,
+                ],
                 true
             )) {
                 $parentMethodCall = $parentMethodCall->var;

--- a/rules/CodeQuality/Rector/Class_/VoidMethodWithCallbackToWillReturnCallbackRector.php
+++ b/rules/CodeQuality/Rector/Class_/VoidMethodWithCallbackToWillReturnCallbackRector.php
@@ -237,7 +237,11 @@ CODE_SAMPLE
 
         if ($callerType instanceof ObjectType && in_array(
             $callerType->getClassName(),
-            [PHPUnitClassName::INVOCATION_MOCKER, PHPUnitClassName::INVOCATION_STUBBER],
+            [
+                PHPUnitClassName::INVOCATION_MOCKER,
+                PHPUnitClassName::INVOCATION_MOCKER_INTERFACE,
+                PHPUnitClassName::INVOCATION_STUBBER,
+            ],
             true
         )) {
             $parentMethodCall = $parentMethodCall->var;

--- a/src/Enum/PHPUnitClassName.php
+++ b/src/Enum/PHPUnitClassName.php
@@ -19,6 +19,11 @@ final class PHPUnitClassName
 
     public const string INVOCATION_MOCKER = 'PHPUnit\Framework\MockObject\Builder\InvocationMocker';
 
+    /**
+     * PHPUnit 13 moved the interface out of the Builder namespace
+     */
+    public const string INVOCATION_MOCKER_INTERFACE = 'PHPUnit\Framework\MockObject\InvocationMocker';
+
     public const string INVOCATION_STUBBER = 'PHPUnit\Framework\MockObject\InvocationStubber';
 
     public const string TEST_LISTENER = 'PHPUnit\Framework\TestListener';


### PR DESCRIPTION
`composer update` + `vendor/bin/jack raise-to-installed`, with PHPUnit taken to 13.

```diff
 "require-dev": {
-    "phpstan/phpstan": "^2.1.38",
+    "phpstan/phpstan": "^2.2",
-    "phpunit/phpunit": "^12.5",
+    "phpunit/phpunit": "^13.2",
-    "rector/jack": "^0.5",
+    "rector/jack": "^1.0",
-    "rector/swiss-knife": "^2.3",
+    "rector/swiss-knife": "^2.4",
-    "symplify/easy-coding-standard": "^13.0",
+    "symplify/easy-coding-standard": "^13.2",
-    "symplify/phpstan-rules": "^14.9.11",
+    "symplify/phpstan-rules": "^14.12",
-    "tracy/tracy": "^2.11"
+    "tracy/tracy": "^2.12"
 }
```

PHPUnit 13 pulls `sebastian/diff` 9, which needs rector-src `04b18f6` or newer (rectorphp/rector-src#8220).

### PHPUnit 13 moved InvocationMocker

`PHPUnit\Framework\MockObject\Builder\InvocationMocker` became `PHPUnit\Framework\MockObject\InvocationMocker`. Two rules match that class name to see through an `->expects(...)` link in a mock chain, so on PHPUnit 13 they silently stopped firing:

```diff
 $this->createMock(SomeMockedClass::class)
     ->expects($this->any())
     ->method('someMethod')
-    ->willReturnCallback(fn ($name) => $value);
+    ->willReturnCallback(fn (string $name): int => $value);
```

Both names are matched now, so PHPUnit 12 and 13 codebases keep working:

```diff
     public const string INVOCATION_MOCKER = 'PHPUnit\Framework\MockObject\Builder\InvocationMocker';
+
+    /**
+     * PHPUnit 13 moved the interface out of the Builder namespace
+     */
+    public const string INVOCATION_MOCKER_INTERFACE = 'PHPUnit\Framework\MockObject\InvocationMocker';
```