### PR TITLE
[PHPUnit 11.5] Add AssertContainsOnlyMethodCallRector, bond deprecated generic asserts to phpunit >=11.5

### DIFF
--- a/config/sets/phpunit110.php
+++ b/config/sets/phpunit110.php
@@ -3,8 +3,15 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
 use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(NamedArgumentForDataProviderRector::class);
+    $rectorConfig->rules([
+        NamedArgumentForDataProviderRector::class,
+        // deprecated in PHPUnit 11.5, guarded by composer package constraint
+        AssertContainsOnlyMethodCallRector::class,
+        AssertIsTypeMethodCallRector::class,
+    ]);
 };

--- a/config/sets/phpunit120.php
+++ b/config/sets/phpunit120.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
@@ -12,6 +13,8 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rules([
         RemoveOverrideFinalConstructTestCaseRector::class,
+        // deprecated in PHPUnit 11.5, repeated here for a direct 11.4 → 12.0 upgrade
+        AssertContainsOnlyMethodCallRector::class,
         AssertIsTypeMethodCallRector::class,
     ]);
 };

--- a/config/sets/phpunit130.php
+++ b/config/sets/phpunit130.php
@@ -3,10 +3,18 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        // deprecated in PHPUnit 11.5, repeated here for a direct upgrade from an older version
+        AssertContainsOnlyMethodCallRector::class,
+        AssertIsTypeMethodCallRector::class,
+    ]);
+
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
         // @see https://github.com/sebastianbergmann/phpunit/issues/6560
         new MethodCallRename('PHPUnit\Framework\TestCase', 'expectExceptionMessage', 'expectExceptionMessageIsOrContains'),

--- a/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/AssertContainsOnlyMethodCallRectorTest.php
+++ b/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/AssertContainsOnlyMethodCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertContainsOnlyMethodCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/Fixture/fixture.php.inc
+++ b/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/Fixture/fixture.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    public function testMethod(): void
+    {
+        $this->assertContainsOnly('array', [[]]);
+        $this->assertContainsOnly('bool', [true]);
+        $this->assertContainsOnly('boolean', [true]);
+        $this->assertContainsOnly('callable', [fn () => 0]);
+        $this->assertContainsOnly('double', [1.0]);
+        $this->assertContainsOnly('float', [1.0]);
+        $this->assertContainsOnly('int', [1]);
+        $this->assertContainsOnly('integer', [1]);
+        $this->assertContainsOnly('iterable', [[]]);
+        $this->assertContainsOnly('null', [null]);
+        $this->assertContainsOnly('numeric', [12]);
+        $this->assertContainsOnly('object', [new \stdClass()]);
+        $this->assertContainsOnly('real', [1.0]);
+        $this->assertContainsOnly('resource', [$resource]);
+        $this->assertContainsOnly('resource (closed)', [$closedResource]);
+        $this->assertContainsOnly('scalar', ['']);
+        $this->assertContainsOnly('string', ['']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    public function testMethod(): void
+    {
+        $this->assertContainsOnlyArray([[]]);
+        $this->assertContainsOnlyBool([true]);
+        $this->assertContainsOnlyBool([true]);
+        $this->assertContainsOnlyCallable([fn () => 0]);
+        $this->assertContainsOnlyFloat([1.0]);
+        $this->assertContainsOnlyFloat([1.0]);
+        $this->assertContainsOnlyInt([1]);
+        $this->assertContainsOnlyInt([1]);
+        $this->assertContainsOnlyIterable([[]]);
+        $this->assertContainsOnlyNull([null]);
+        $this->assertContainsOnlyNumeric([12]);
+        $this->assertContainsOnlyObject([new \stdClass()]);
+        $this->assertContainsOnlyFloat([1.0]);
+        $this->assertContainsOnlyResource([$resource]);
+        $this->assertContainsOnlyClosedResource([$closedResource]);
+        $this->assertContainsOnlyScalar(['']);
+        $this->assertContainsOnlyString(['']);
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/Fixture/skip_class_name_type.php.inc
+++ b/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/Fixture/skip_class_name_type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipClassNameType extends TestCase
+{
+    public function testMethod(): void
+    {
+        $this->assertContainsOnly(\stdClass::class, [new \stdClass()]);
+        $this->assertContainsOnly('string', ['a'], false);
+        $this->assertContainsOnly('string', ['a'], $isNativeType);
+        $this->assertContainsOnly($type, ['a']);
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/Fixture/static_fixture.php.inc
+++ b/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/Fixture/static_fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class StaticFixture extends TestCase
+{
+    public function testMethod(): void
+    {
+        self::assertContainsOnly('string', ['a'], null, 'some message');
+        self::assertContainsOnly('int', [1], true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class StaticFixture extends TestCase
+{
+    public function testMethod(): void
+    {
+        self::assertContainsOnlyString(['a'], 'some message');
+        self::assertContainsOnlyInt([1]);
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AssertContainsOnlyMethodCallRector::class);
+};

--- a/rules/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector.php
+++ b/rules/PHPUnit110/Rector/CallLike/AssertContainsOnlyMethodCallRector.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit110\Rector\CallLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * The assertContainsOnly*() methods were added and assertContainsOnly() deprecated in PHPUnit 11.5
+ *
+ * @see https://github.com/sebastianbergmann/phpunit/issues/6055
+ * @see https://github.com/sebastianbergmann/phpunit/blob/11.5.0/ChangeLog-11.5.md
+ *
+ * @see \Rector\PHPUnit\Tests\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector\AssertContainsOnlyMethodCallRectorTest
+ */
+final class AssertContainsOnlyMethodCallRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private const array TYPE_VALUE_TO_METHOD = [
+        'array' => 'assertContainsOnlyArray',
+        'bool' => 'assertContainsOnlyBool',
+        'boolean' => 'assertContainsOnlyBool',
+        'callable' => 'assertContainsOnlyCallable',
+        'double' => 'assertContainsOnlyFloat',
+        'float' => 'assertContainsOnlyFloat',
+        'int' => 'assertContainsOnlyInt',
+        'integer' => 'assertContainsOnlyInt',
+        'iterable' => 'assertContainsOnlyIterable',
+        'null' => 'assertContainsOnlyNull',
+        'numeric' => 'assertContainsOnlyNumeric',
+        'object' => 'assertContainsOnlyObject',
+        'real' => 'assertContainsOnlyFloat',
+        'resource' => 'assertContainsOnlyResource',
+        'resource (closed)' => 'assertContainsOnlyClosedResource',
+        'scalar' => 'assertContainsOnlyScalar',
+        'string' => 'assertContainsOnlyString',
+    ];
+
+    public function __construct(
+        private readonly ValueResolver $valueResolver,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+    ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.5');
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replaces `Assert::assertContainsOnly()` calls with type-specific `Assert::assertContainsOnly*()` calls',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    use PHPUnit\Framework\TestCase;
+
+                    final class SomeClass extends TestCase
+                    {
+                        public function testMethod(): void
+                        {
+                            $this->assertContainsOnly('string', ['a', 'b']);
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                    use PHPUnit\Framework\TestCase;
+
+                    final class SomeClass extends TestCase
+                    {
+                        public function testMethod(): void
+                        {
+                            $this->assertContainsOnlyString(['a', 'b']);
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): Node|null
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->testsNodeAnalyzer->isPHPUnitTestCaseCall($node) || ! $this->isName(
+            $node->name,
+            'assertContainsOnly'
+        )) {
+            return null;
+        }
+
+        $typeArg = $node->getArg('type', 0);
+        $haystackArg = $node->getArg('haystack', 1);
+        if (! $typeArg instanceof Arg || ! $haystackArg instanceof Arg) {
+            return null;
+        }
+
+        $typeValue = $this->valueResolver->getValue($typeArg);
+        if (! is_string($typeValue)) {
+            return null;
+        }
+
+        $newMethodName = self::TYPE_VALUE_TO_METHOD[$typeValue] ?? null;
+        if ($newMethodName === null) {
+            return null;
+        }
+
+        // the $isNativeType argument can turn the type into a class name, that has no type-specific method
+        $isNativeTypeArg = $node->getArg('isNativeType', 2);
+        if ($isNativeTypeArg instanceof Arg && ! $this->valueResolver->isTrue(
+            $isNativeTypeArg->value
+        ) && ! $this->valueResolver->isNull($isNativeTypeArg->value)) {
+            return null;
+        }
+
+        $newArgs = [new Arg($haystackArg->value)];
+
+        $messageArg = $node->getArg('message', 3);
+        if ($messageArg instanceof Arg) {
+            $newArgs[] = new Arg($messageArg->value);
+        }
+
+        if ($node instanceof MethodCall) {
+            return new MethodCall($node->var, $newMethodName, $newArgs);
+        }
+
+        return new StaticCall($node->class, $newMethodName, $newArgs);
+    }
+}

--- a/rules/PHPUnit120/Rector/Class_/AssertIsTypeMethodCallRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AssertIsTypeMethodCallRector.php
@@ -11,16 +11,20 @@ use PhpParser\Node\Expr\StaticCall;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see https://github.com/sebastianbergmann/phpunit/issues/6053
- * @see https://github.com/sebastianbergmann/phpunit/blob/12.0.0/ChangeLog-12.0.md
+ * The is*() methods were added and isType() deprecated in PHPUnit 11.5
+ *
+ * @see https://github.com/sebastianbergmann/phpunit/issues/6052
+ * @see https://github.com/sebastianbergmann/phpunit/blob/11.5.0/ChangeLog-11.5.md
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector\AssertIsTypeMethodCallRectorTest
  */
-final class AssertIsTypeMethodCallRector extends AbstractRector
+final class AssertIsTypeMethodCallRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     /**
      * @var array<string, string>
@@ -49,6 +53,11 @@ final class AssertIsTypeMethodCallRector extends AbstractRector
         private readonly ValueResolver $valueResolver,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.5');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
PHPUnit 11.5 deprecated the generic `assertContainsOnly()` and `isType()` assertions and added type-specific replacements for both ([#6055](https://github.com/sebastianbergmann/phpunit/issues/6055), [#6052](https://github.com/sebastianbergmann/phpunit/issues/6052)).

Neither was handled for projects actually running PHPUnit 11.5:

* there was no rule for `assertContainsOnly()` at all
* `AssertIsTypeMethodCallRector` existed, but only in the `phpunit120.php` set. `ComposerTriggeredSet` matches with `^` + version, so on `phpunit/phpunit 11.5.x` only `phpunit110.php` is loaded and the rule never ran — despite the deprecation landing in 11.5.

## New rule: `AssertContainsOnlyMethodCallRector`

```diff
 final class SomeTest extends TestCase
 {
     public function test(): void
     {
-        $this->assertContainsOnly('string', ['a', 'b']);
+        $this->assertContainsOnlyString(['a', 'b']);
-        self::assertContainsOnly('int', [1], null, 'some message');
+        self::assertContainsOnlyInt([1], 'some message');
     }
 }
```

The `$isNativeType` argument is dropped when it is absent, `null` or `true`. When it is `false` or an unresolvable expression the type may be a class name, so the call is skipped.

## Version bonding

Both rules now implement `ComposerPackageConstraintInterface` (rectorphp/rector-src#7877):

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    return new ComposerPackageConstraint('phpunit/phpunit', '>=11.5');
}
```

`ComposerTriggeredSet` matches with `^` + version and is not cumulative, so a project on PHPUnit 12 never loads `phpunit110.php`. Both rules are therefore registered in the `phpunit110.php`, `phpunit120.php` and `phpunit130.php` sets — someone upgrading straight from 11.4 to 12.0 still gets them. `AssertIsTypeMethodCallRector` keeps its current class name, so nothing breaks for existing PHPUnit 12 users.

The `>=11.5` constraint is what keeps both rules from firing on 11.0–11.4, where the type-specific methods do not exist yet.

Needed rectorphp/rector-src#8237 (merged) — the autowired `InstalledPackageResolver` behind `ComposerPackageConstraintFilter` lost its cwd fallback, so every rule implementing `ComposerPackageConstraintInterface` threw `The installed package json not found`.