### PR TITLE
Add MockObjectArgCreateStubToCreateMockRector

### DIFF
--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
+use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
@@ -23,5 +24,8 @@ return static function (RectorConfig $rectorConfig): void {
         AddIntersectionVarToMockObjectPropertyRector::class,
         AddStubIntersectionVarToStubPropertyRector::class,
         BareCreateMockAssignToDirectUseRector::class,
+
+        // mocks back over stubs, where mock object is required
+        MockObjectArgCreateStubToCreateMockRector::class,
     ]);
 };

--- a/config/sets/phpunit110.php
+++ b/config/sets/phpunit110.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
 use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
+use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         NamedArgumentForDataProviderRector::class,
+        MockObjectArgCreateStubToCreateMockRector::class,
         // deprecated in PHPUnit 11.5, guarded by composer package constraint
         AssertContainsOnlyMethodCallRector::class,
         AssertIsTypeMethodCallRector::class,

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/fixture.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/fixture.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class PassedToMockObjectParam extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createStub(SomeUser::class);
+        $this->prepareUserMock($user);
+    }
+
+    private function prepareUserMock(MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class PassedToMockObjectParam extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createMock(SomeUser::class);
+        $this->prepareUserMock($user);
+    }
+
+    private function prepareUserMock(MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/intersection_docblock_param.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/intersection_docblock_param.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class IntersectionDocblockParam extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createStub(SomeUser::class);
+        $this->prepareCommonMocks('some_event', $user);
+    }
+
+    /**
+     * @param MockObject&SomeUser $user
+     */
+    private function prepareCommonMocks(string $event, MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class IntersectionDocblockParam extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createMock(SomeUser::class);
+        $this->prepareCommonMocks('some_event', $user);
+    }
+
+    /**
+     * @param MockObject&SomeUser $user
+     */
+    private function prepareCommonMocks(string $event, MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/named_arg.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/named_arg.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class NamedArg extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createStub(SomeUser::class);
+        $this->prepareUserMock(user: $user);
+    }
+
+    private function prepareUserMock(MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class NamedArg extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createMock(SomeUser::class);
+        $this->prepareUserMock(user: $user);
+    }
+
+    private function prepareUserMock(MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/skip_plain_param_type.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/skip_plain_param_type.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class SkipPlainParamType extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createStub(SomeUser::class);
+        $this->useUser($user);
+    }
+
+    private function useUser(SomeUser $user): void
+    {
+        $user->getId();
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/skip_stub_only_usage.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Fixture/skip_stub_only_usage.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source\SomeUser;
+
+final class SkipStubOnlyUsage extends TestCase
+{
+    public function test()
+    {
+        $user = $this->createStub(SomeUser::class);
+        $user->method('getId')->willReturn(1);
+
+        $this->assertSame(1, $user->getId());
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/MockObjectArgCreateStubToCreateMockRectorTest.php
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/MockObjectArgCreateStubToCreateMockRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MockObjectArgCreateStubToCreateMockRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Source/SomeUser.php
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/Source/SomeUser.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\Source;
+
+final class SomeUser
+{
+    public function getId(): int
+    {
+        return 1;
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(MockObjectArgCreateStubToCreateMockRector::class);
+};

--- a/rules/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector.php
+++ b/rules/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector.php
@@ -19,19 +19,26 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\MockObjectArgCreateStubToCreateMockRectorTest
  */
-final class MockObjectArgCreateStubToCreateMockRector extends AbstractRector
+final class MockObjectArgCreateStubToCreateMockRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly ReflectionResolver $reflectionResolver,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector.php
+++ b/rules/PHPUnit110/Rector/ClassMethod/MockObjectArgCreateStubToCreateMockRector.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit110\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector\MockObjectArgCreateStubToCreateMockRectorTest
+ */
+final class MockObjectArgCreateStubToCreateMockRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change createStub() to createMock(), when the created variable is passed to a method that requires MockObject type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $someMock = $this->createStub(SomeClass::class);
+        $this->prepareMock($someMock);
+    }
+
+    private function prepareMock(MockObject $someMock): void
+    {
+        $someMock->expects($this->once())
+            ->method('someMethod');
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $someMock = $this->createMock(SomeClass::class);
+        $this->prepareMock($someMock);
+    }
+
+    private function prepareMock(MockObject $someMock): void
+    {
+        $someMock->expects($this->once())
+            ->method('someMethod');
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?ClassMethod
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $createStubMethodCallsByVariableName = $this->collectCreateStubAssigns($node);
+        if ($createStubMethodCallsByVariableName === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($createStubMethodCallsByVariableName as $variableName => $createStubMethodCall) {
+            if (! $this->isPassedAsMockObjectArg($node, (string) $variableName)) {
+                continue;
+            }
+
+            $createStubMethodCall->name = new Identifier('createMock');
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, MethodCall>
+     */
+    private function collectCreateStubAssigns(ClassMethod $classMethod): array
+    {
+        $createStubMethodCallsByVariableName = [];
+
+        foreach ((array) $classMethod->stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $stmt->expr instanceof Assign) {
+                continue;
+            }
+
+            $assign = $stmt->expr;
+            if (! $assign->var instanceof Variable) {
+                continue;
+            }
+
+            if (! $assign->expr instanceof MethodCall) {
+                continue;
+            }
+
+            $methodCall = $assign->expr;
+            if (! $this->isName($methodCall->name, 'createStub')) {
+                continue;
+            }
+
+            $variableName = $this->getName($assign->var);
+            if ($variableName === null) {
+                continue;
+            }
+
+            $createStubMethodCallsByVariableName[$variableName] = $methodCall;
+        }
+
+        return $createStubMethodCallsByVariableName;
+    }
+
+    private function isPassedAsMockObjectArg(ClassMethod $classMethod, string $variableName): bool
+    {
+        /** @var array<MethodCall|StaticCall> $callLikes */
+        $callLikes = $this->betterNodeFinder->findInstancesOfScoped(
+            (array) $classMethod->stmts,
+            [MethodCall::class, StaticCall::class]
+        );
+
+        foreach ($callLikes as $callLike) {
+            if ($callLike->isFirstClassCallable()) {
+                continue;
+            }
+
+            foreach ($callLike->getArgs() as $argIndex => $arg) {
+                if (! $arg->value instanceof Variable) {
+                    continue;
+                }
+
+                if (! $this->isName($arg->value, $variableName)) {
+                    continue;
+                }
+
+                if ($this->isMockObjectParam($callLike, $arg->name, $argIndex)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isMockObjectParam(
+        MethodCall|StaticCall $callLike,
+        ?Identifier $identifier,
+        int $argIndex
+    ): bool {
+        $methodReflection = $callLike instanceof MethodCall
+            ? $this->reflectionResolver->resolveMethodReflectionFromMethodCall($callLike)
+            : $this->reflectionResolver->resolveMethodReflectionFromStaticCall($callLike);
+
+        if (! $methodReflection instanceof MethodReflection) {
+            return false;
+        }
+
+        $mockObjectType = new ObjectType(PHPUnitClassName::MOCK_OBJECT);
+
+        foreach ($methodReflection->getVariants() as $parametersAcceptor) {
+            $parameters = $parametersAcceptor->getParameters();
+
+            if ($identifier instanceof Identifier) {
+                foreach ($parameters as $parameter) {
+                    if ($parameter->getName() !== $identifier->toString()) {
+                        continue;
+                    }
+
+                    if ($mockObjectType->isSuperTypeOf($parameter->getType())->yes()) {
+                        return true;
+                    }
+                }
+
+                continue;
+            }
+
+            if (! isset($parameters[$argIndex])) {
+                continue;
+            }
+
+            if ($mockObjectType->isSuperTypeOf($parameters[$argIndex]->getType())->yes()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Stub/mock rules move `createMock()` → `createStub()` when a mock has no expectations. But a variable can be passed to a local helper method that requires `MockObject` and calls `expects()` on it — there a stub is a type error.

This rule fixes those spots back:

```diff
 public function testNotificationOfUnpublishToAuthor(): void
 {
     $event = new Event();
-    $user  = $this->createStub(User::class);
+    $user  = $this->createMock(User::class);
     $this->prepareCommonMocks($event, $user);
 }

 /**
  * @param MockObject&User $user
  */
 private function prepareCommonMocks(Event $event, MockObject $user): void
 {
     $user->expects($this->once())
         ->method('getId')
         ->willReturn(1);
 }
```

Real-world case: [mautic/mautic NotificationHelperTest](https://github.com/mautic/mautic/blob/95ab79cbf3b5771bf9d6c48482243810ff20f37a/app/bundles/CampaignBundle/Tests/Helper/NotificationHelperTest.php#L234-L247)

Only triggers when the variable is passed as an argument to a method/static call whose parameter type is `MockObject` — native type, docblock intersection, positional or named argument. A stub used only for `method()`/`willReturn()` is left alone.

Registered in `phpunit110.php` and `phpunit-mock-to-stub.php` sets. No ping-pong with `ExpressionCreateMockToCreateStubRector`, which already skips variables passed to `MockObject` params.
