### PR TITLE
Bond annotation to attribute rules to phpunit/phpunit >=10.0

### DIFF
--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
@@ -22,14 +22,16 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersion;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\DataProviderAnnotationToAttributeRectorTest
  */
-final class DataProviderAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class DataProviderAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -82,6 +84,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [ClassMethod::class];
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DependsAnnotationWithValueToAttributeRector.php
@@ -18,14 +18,16 @@ use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector\DependsAnnotationWithValueToAttributeRectorTest
  */
-final class DependsAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class DependsAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     private const string DEPENDS_ATTRIBUTE = 'PHPUnit\Framework\Attributes\Depends';
 
@@ -83,6 +85,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class];
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/TestWithAnnotationToAttributeRector.php
@@ -18,7 +18,9 @@ use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -28,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector\TestWithAnnotationToAttributeRectorTest
  */
-final class TestWithAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class TestWithAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     private const string TEST_WITH_ATTRIBUTE = 'PHPUnit\Framework\Attributes\TestWith';
 
@@ -146,6 +148,11 @@ CODE_SAMPLE
         $node->attrGroups = array_merge($node->attrGroups, $attributeGroups);
 
         return $node;
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/AnnotationWithValueToAttributeRector.php
@@ -19,7 +19,9 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -27,7 +29,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector\AnnotationWithValueToAttributeRectorTest
  */
-final class AnnotationWithValueToAttributeRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
+final class AnnotationWithValueToAttributeRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     /**
      * @var AnnotationWithValueToAttribute[]
@@ -87,6 +89,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class];
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/CoversAnnotationWithValueToAttributeRector.php
@@ -19,14 +19,16 @@ use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector\CoversAnnotationWithValueToAttributeRectorTest
  */
-final class CoversAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class CoversAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     private const string COVERS_FUNCTION_ATTRIBUTE = 'PHPUnit\Framework\Attributes\CoversFunction';
 
@@ -92,6 +94,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class, ClassMethod::class];
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/AnnotationsToAttributes/Rector/Class_/RequiresAnnotationWithValueToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/RequiresAnnotationWithValueToAttributeRector.php
@@ -17,14 +17,16 @@ use Rector\PHPUnit\AnnotationsToAttributes\NodeFactory\RequiresAttributeFactory;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\RequiresAnnotationWithValueToAttributeRector\RequiresAnnotationWithValueToAttributeRectorTest
  */
-final class RequiresAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class RequiresAnnotationWithValueToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly PhpDocTagRemover $phpDocTagRemover,
@@ -82,6 +84,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class, ClassMethod::class];
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/AnnotationsToAttributes/Rector/Class_/TicketAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/Class_/TicketAnnotationToAttributeRector.php
@@ -22,7 +22,9 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -31,7 +33,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\Class_\TicketAnnotationToAttributeRector\TicketAnnotationToAttributeRectorTest
  */
-final class TicketAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class TicketAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     private const string TICKET_CLASS = 'PHPUnit\Framework\Attributes\Ticket';
 
@@ -79,6 +81,11 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class, ClassMethod::class];
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsForDataProviderRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsForDataProviderRector.php
@@ -15,13 +15,15 @@ use Rector\PHPUnit\CodeQuality\NodeAnalyser\MockObjectExprDetector;
 use Rector\PHPUnit\Enum\PHPUnitAttribute;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector\AllowMockObjectsForDataProviderRectorTest
  */
-final class AllowMockObjectsForDataProviderRector extends AbstractRector
+final class AllowMockObjectsForDataProviderRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -34,6 +36,11 @@ final class AllowMockObjectsForDataProviderRector extends AbstractRector
     public function getNodeTypes(): array
     {
         return [Class_::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
     }
 
     /**

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
@@ -17,6 +17,8 @@ use Rector\PHPUnit\Enum\PHPUnitAttribute;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43
  */
-final class AllowMockObjectsWhereParentClassRector extends AbstractRector
+final class AllowMockObjectsWhereParentClassRector extends AbstractRector implements MinPhpVersionInterface
 {
     /**
      * @var string[]
@@ -42,6 +44,11 @@ final class AllowMockObjectsWhereParentClassRector extends AbstractRector
     public function getNodeTypes(): array
     {
         return [Class_::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
     }
 
     /**

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
@@ -24,6 +24,8 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -32,7 +34,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43
  */
-final class AllowMockObjectsWithoutExpectationsAttributeRector extends AbstractRector
+final class AllowMockObjectsWithoutExpectationsAttributeRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -45,6 +47,11 @@ final class AllowMockObjectsWithoutExpectationsAttributeRector extends AbstractR
     public function getNodeTypes(): array
     {
         return [Class_::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
     }
 
     /**


### PR DESCRIPTION
PHPUnit attributes exist since PHPUnit 10.0. Until now these rules converted annotations to attributes regardless of the PHPUnit version installed in the analysed project, so a PHPUnit 9 project ended up with attributes it cannot use.

Each of the 7 annotation to attribute rules now declares the constraint:

```diff
-final class TicketAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class TicketAnnotationToAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
```

Covered rules:

* `TicketAnnotationToAttributeRector`
* `TestWithAnnotationToAttributeRector`
* `DataProviderAnnotationToAttributeRector`
* `CoversAnnotationWithValueToAttributeRector`
* `RequiresAnnotationWithValueToAttributeRector`
* `DependsAnnotationWithValueToAttributeRector`
* `AnnotationWithValueToAttributeRector`

On a project with `phpunit/phpunit: ^9.6`, the rules are now skipped:

```php
// stays as is, PHPUnit 9 has no attributes
final class SomeTest extends TestCase
{
    /**
     * @dataProvider provideData
     */
    public function testSome(): void
    {
    }
}
```

Note: `ComposerPackageConstraintFilter` treats an unresolvable version as "not satisfied", so these rules are also skipped when `phpunit/phpunit` is missing from the analysed project's `installed.json`.

For the generic `AnnotationToAttributeRector` pairs in `annotations-to-attributes.php` no change is needed - the set is pulled in by `phpunit100.php`, and version-specific pairs added later to `phpunit110.php` stack on top, as repeated `ruleWithConfiguration()` calls for the same rule class are merged.

## PHP version bond

Attributes are a PHP 8.0 feature, so a rule that *adds* an attribute must also declare `MinPhpVersionInterface`. The 7 rules above already did. Three more rules add attributes and were missing it:

```diff
-final class AllowMockObjectsForDataProviderRector extends AbstractRector
+final class AllowMockObjectsForDataProviderRector extends AbstractRector implements MinPhpVersionInterface
 {
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
+    }
```

* `AllowMockObjectsForDataProviderRector`
* `AllowMockObjectsWhereParentClassRector`
* `AllowMockObjectsWithoutExpectationsAttributeRector`

On a PHP 7.4 project they no longer produce a parse-error-causing `#[AllowMockObjectsWithoutExpectations]`.
