### PR TITLE
Fix swapped preCondition and postCondition attribute mapping

### DIFF
--- a/config/sets/annotations-to-attributes.php
+++ b/config/sets/annotations-to-attributes.php
@@ -69,8 +69,8 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
         new AnnotationToAttribute('large', 'PHPUnit\Framework\Attributes\Large'),
         new AnnotationToAttribute('medium', 'PHPUnit\Framework\Attributes\Medium'),
-        new AnnotationToAttribute('preCondition', 'PHPUnit\Framework\Attributes\PostCondition'),
-        new AnnotationToAttribute('postCondition', 'PHPUnit\Framework\Attributes\PreCondition'),
+        new AnnotationToAttribute('preCondition', 'PHPUnit\Framework\Attributes\PreCondition'),
+        new AnnotationToAttribute('postCondition', 'PHPUnit\Framework\Attributes\PostCondition'),
         new AnnotationToAttribute('runInSeparateProcess', 'PHPUnit\Framework\Attributes\RunInSeparateProcess'),
         new AnnotationToAttribute(
             'runTestsInSeparateProcesses',

--- a/tests/AnnotationsToAttributes/Fixture/pre_post_condition.php.inc
+++ b/tests/AnnotationsToAttributes/Fixture/pre_post_condition.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class PrePostConditionTest extends TestCase
+{
+    /**
+     * @preCondition
+     */
+    protected function setUpSomething()
+    {
+    }
+
+    /**
+     * @postCondition
+     */
+    protected function tearDownSomething()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class PrePostConditionTest extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\PreCondition]
+    protected function setUpSomething()
+    {
+    }
+
+    #[\PHPUnit\Framework\Attributes\PostCondition]
+    protected function tearDownSomething()
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
`@preCondition` was converted to `#[PostCondition]` and `@postCondition` to `#[PreCondition]` - the two mappings are swapped, so the hooks end up running at the wrong point of the test lifecycle.

```diff
-        new AnnotationToAttribute('preCondition', 'PHPUnit\Framework\Attributes\PostCondition'),
-        new AnnotationToAttribute('postCondition', 'PHPUnit\Framework\Attributes\PreCondition'),
+        new AnnotationToAttribute('preCondition', 'PHPUnit\Framework\Attributes\PreCondition'),
+        new AnnotationToAttribute('postCondition', 'PHPUnit\Framework\Attributes\PostCondition'),
```

Before:

```php
/**
 * @preCondition
 */
protected function setUpSomething()
{
}
```

was turned into:

```php
#[\PHPUnit\Framework\Attributes\PostCondition]
protected function setUpSomething()
{
}
```

There was no fixture covering these two annotations, which is how the swap went unnoticed. Added `pre_post_condition.php.inc`.
