### PR TITLE
Move composer version bound rules to composer-based set

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -12,11 +12,17 @@ use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\TicketAnnotationToAttri
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector;
+use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
+use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 
 /**
- * Annotation to attribute pairs bound to the PHPUnit version installed in the analysed project,
- * as not every attribute exists in every PHPUnit version.
+ * Rules and configuration bound to the PHPUnit version installed in the analysed project,
+ * as not every attribute and method exists in every PHPUnit version.
+ *
+ * Thanks to the composer package constraint, these rules can be registered once here, instead of being
+ * repeated in every PHPUnit version set to cover a direct upgrade from an older version.
  */
 return static function (RectorConfig $rectorConfig): void {
     // each of these rules declares the "phpunit/phpunit" version its attributes were added in,
@@ -28,6 +34,13 @@ return static function (RectorConfig $rectorConfig): void {
         CoversAnnotationWithValueToAttributeRector::class,
         RequiresAnnotationWithValueToAttributeRector::class,
         DependsAnnotationWithValueToAttributeRector::class,
+
+        // stubs are required over mocks since PHPUnit 11.0
+        MockObjectArgCreateStubToCreateMockRector::class,
+
+        // deprecated in PHPUnit 11.5
+        AssertContainsOnlyMethodCallRector::class,
+        AssertIsTypeMethodCallRector::class,
     ]);
 
     // both attributes were added in PHPUnit 10.0

--- a/config/sets/phpunit110.php
+++ b/config/sets/phpunit110.php
@@ -3,17 +3,13 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
 use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
-use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
-use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        NamedArgumentForDataProviderRector::class,
-        MockObjectArgCreateStubToCreateMockRector::class,
-        // deprecated in PHPUnit 11.5, guarded by composer package constraint
-        AssertContainsOnlyMethodCallRector::class,
-        AssertIsTypeMethodCallRector::class,
-    ]);
+    // MockObjectArgCreateStubToCreateMockRector, AssertContainsOnlyMethodCallRector
+    // and AssertIsTypeMethodCallRector are registered there, guarded by composer package constraint
+    $rectorConfig->sets([PHPUnitSetList::COMPOSER_BASED]);
+
+    $rectorConfig->rules([NamedArgumentForDataProviderRector::class]);
 };

--- a/config/sets/phpunit120.php
+++ b/config/sets/phpunit120.php
@@ -3,18 +3,11 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
-use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([PHPUnitSetList::PHPUNIT_MOCK_TO_STUB]);
+    $rectorConfig->sets([PHPUnitSetList::PHPUNIT_MOCK_TO_STUB, PHPUnitSetList::COMPOSER_BASED]);
 
-    $rectorConfig->rules([
-        RemoveOverrideFinalConstructTestCaseRector::class,
-        // deprecated in PHPUnit 11.5, repeated here for a direct 11.4 → 12.0 upgrade
-        AssertContainsOnlyMethodCallRector::class,
-        AssertIsTypeMethodCallRector::class,
-    ]);
+    $rectorConfig->rules([RemoveOverrideFinalConstructTestCaseRector::class]);
 };

--- a/config/sets/phpunit130.php
+++ b/config/sets/phpunit130.php
@@ -3,17 +3,14 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
-use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        // deprecated in PHPUnit 11.5, repeated here for a direct upgrade from an older version
-        AssertContainsOnlyMethodCallRector::class,
-        AssertIsTypeMethodCallRector::class,
-    ]);
+    // AssertContainsOnlyMethodCallRector and AssertIsTypeMethodCallRector are registered there,
+    // guarded by composer package constraint
+    $rectorConfig->sets([PHPUnitSetList::COMPOSER_BASED]);
 
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
         // @see https://github.com/sebastianbergmann/phpunit/issues/6560


### PR DESCRIPTION
The three remaining rules that declare a `ComposerPackageConstraint` were registered in several PHPUnit version sets, repeated so that a direct upgrade from an older version still picks them up:

```php
// config/sets/phpunit120.php
// deprecated in PHPUnit 11.5, repeated here for a direct 11.4 → 12.0 upgrade
AssertContainsOnlyMethodCallRector::class,
AssertIsTypeMethodCallRector::class,
```

The composer package constraint already handles that, so the repetition is not needed. They move into `composer-based.php`, which the version sets import:

```php
$rectorConfig->rules([
    // ...

    // stubs are required over mocks since PHPUnit 11.0
    MockObjectArgCreateStubToCreateMockRector::class,

    // deprecated in PHPUnit 11.5
    AssertContainsOnlyMethodCallRector::class,
    AssertIsTypeMethodCallRector::class,
]);
```

| Rule | Constraint |
|---|---|
| `MockObjectArgCreateStubToCreateMockRector` | `>=11.0` |
| `AssertContainsOnlyMethodCallRector` | `>=11.5` |
| `AssertIsTypeMethodCallRector` | `>=11.5` |

```diff
 // config/sets/phpunit130.php
-    $rectorConfig->rules([
-        // deprecated in PHPUnit 11.5, repeated here for a direct upgrade from an older version
-        AssertContainsOnlyMethodCallRector::class,
-        AssertIsTypeMethodCallRector::class,
-    ]);
+    // AssertContainsOnlyMethodCallRector and AssertIsTypeMethodCallRector are registered there,
+    // guarded by composer package constraint
+    $rectorConfig->sets([PHPUnitSetList::COMPOSER_BASED]);
```

`phpunit110.php`, `phpunit120.php` and `phpunit130.php` now import `PHPUnitSetList::COMPOSER_BASED` instead of listing the rules, so no set loses a rule.

Side effect worth a look: importing `COMPOSER_BASED` also brings its annotation to attribute rules into those three version sets. Those rules are bound to `phpunit/phpunit >=10.0`, so they are active for any project on 11 or newer - which is what a direct upgrade from a pre-attribute version needs anyway.

`phpunit-mock-to-stub.php` keeps its own `MockObjectArgCreateStubToCreateMockRector` registration - that one is thematic, not a version repetition.
