### PR TITLE
Register composer-based set in PHPUnitSetProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^13.2",
         "rector/jack": "^1.0",
-        "rector/rector-src": "dev-main",
+        "rector/rector-src": "dev-composer-triggered-set-version-constraint as dev-main",
         "rector/swiss-knife": "^2.4",
         "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",

--- a/src/Set/SetProvider/PHPUnitSetProvider.php
+++ b/src/Set/SetProvider/PHPUnitSetProvider.php
@@ -89,6 +89,15 @@ final class PHPUnitSetProvider implements SetProviderInterface
                 __DIR__ . '/../../../config/sets/phpunit130.php'
             ),
 
+            // applies to any installed PHPUnit version, the rules and configuration inside are bound
+            // to the exact version they are available from
+            new ComposerTriggeredSet(
+                SetGroup::PHPUNIT,
+                'phpunit/phpunit',
+                '>=4.0',
+                __DIR__ . '/../../../config/sets/composer-based.php'
+            ),
+
             new Set(SetGroup::PHPUNIT, 'Code Quality', __DIR__ . '/../../../config/sets/phpunit-code-quality.php'),
 
             new Set(


### PR DESCRIPTION
`withComposerBased(phpunit: true)` resolves `SetGroup::PHPUNIT` through `PHPUnitSetProvider`, which only lists the per-version upgrade sets. The new `composer-based.php` set was not among them, so it was only reachable by naming `PHPUnitSetList::COMPOSER_BASED` explicitly, or indirectly through `phpunit110.php` and newer.

It is registered now, for any installed PHPUnit version:

```php
// applies to any installed PHPUnit version, the rules and configuration inside are bound
// to the exact version they are available from
new ComposerTriggeredSet(
    SetGroup::PHPUNIT,
    'phpunit/phpunit',
    '>=4.0',
    __DIR__ . '/../../../config/sets/composer-based.php'
),
```

The set does its own gating - every rule in it declares a `ComposerPackageConstraint`, and the configuration goes through `ruleWithConfigurationComposerVersionBound()` - so loading it on any version is safe; nothing inside applies below the version it belongs to.

Verified against this package (PHPUnit ^13.2 installed):

```
$setManager->matchBySetGroups([SetGroup::PHPUNIT]);

phpunit130.php
composer-based.php
```

Requires rectorphp/rector-src#8245, which allows a version constraint instead of only a bare major version in `ComposerTriggeredSet`. `composer.json` points at that branch so CI can run; to be reverted to `dev-main` once it is merged.
