### PR TITLE
Use rector-src dev-main again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^13.2",
         "rector/jack": "^1.0",
-        "rector/rector-src": "dev-composer-triggered-set-version-constraint as dev-main",
+        "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.4",
         "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",


### PR DESCRIPTION
Follow up to #748, which pinned `rector/rector-src` to the branch of rectorphp/rector-src#8245 so CI could run against it.

That PR is merged and its branch is gone, so `composer update` on `main` now fails:

```
Root composer.json requires rector/rector-src dev-composer-triggered-set-version-constraint as dev-main,
found rector/rector-src[...] but these do not match your constraint
```

Back to `dev-main`.