### PR TITLE
Bond stub and mock rules to phpunit/phpunit >=11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^13.2",
         "rector/jack": "^1.0",
-        "rector/rector-src": "dev-composer-triggered-set-version-constraint as dev-main",
+        "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.4",
         "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",

--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -12,9 +12,17 @@ use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\TicketAnnotationToAttri
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
 use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
+use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
+use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
 
 /**
@@ -35,7 +43,17 @@ return static function (RectorConfig $rectorConfig): void {
         RequiresAnnotationWithValueToAttributeRector::class,
         DependsAnnotationWithValueToAttributeRector::class,
 
-        // stubs are required over mocks since PHPUnit 11.0
+        // stubs over mocks, where no expectations are set, since PHPUnit 11.0
+        CreateStubOverCreateMockArgRector::class,
+        CreateStubInCoalesceArgRector::class,
+        ExpressionCreateMockToCreateStubRector::class,
+        PropertyCreateMockToCreateStubRector::class,
+        MockObjectVarToStubRector::class,
+        AddIntersectionVarToMockObjectPropertyRector::class,
+        AddStubIntersectionVarToStubPropertyRector::class,
+        BareCreateMockAssignToDirectUseRector::class,
+
+        // mocks back over stubs, where a mock object is required
         MockObjectArgCreateStubToCreateMockRector::class,
 
         // deprecated in PHPUnit 11.5

--- a/rules/CodeQuality/Rector/ClassMethod/BareCreateMockAssignToDirectUseRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/BareCreateMockAssignToDirectUseRector.php
@@ -23,13 +23,15 @@ use Rector\PHPUnit\CodeQuality\NodeAnalyser\AssignedMocksCollector;
 use Rector\PHPUnit\CodeQuality\NodeFinder\VariableFinder;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector\BareCreateMockAssignToDirectUseRectorTest
  */
-final class BareCreateMockAssignToDirectUseRector extends AbstractRector
+final class BareCreateMockAssignToDirectUseRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -38,6 +40,11 @@ final class BareCreateMockAssignToDirectUseRector extends AbstractRector
         private readonly VariableFinder $variableFinder,
         private readonly AssertMethodAnalyzer $assertMethodAnalyzer,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddIntersectionVarToMockObjectPropertyRector.php
@@ -22,13 +22,15 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector\AddIntersectionVarToMockObjectPropertyRectorTest
  */
-final class AddIntersectionVarToMockObjectPropertyRector extends AbstractRector
+final class AddIntersectionVarToMockObjectPropertyRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -105,6 +107,11 @@ final class AddIntersectionVarToMockObjectPropertyRector extends AbstractRector
         }
 
         return $node;
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/CodeQuality/Rector/Class_/AddStubIntersectionVarToStubPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddStubIntersectionVarToStubPropertyRector.php
@@ -22,13 +22,15 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector\AddStubIntersectionVarToStubPropertyRectorTest
  */
-final class AddStubIntersectionVarToStubPropertyRector extends AbstractRector
+final class AddStubIntersectionVarToStubPropertyRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -92,6 +94,11 @@ final class AddStubIntersectionVarToStubPropertyRector extends AbstractRector
         }
 
         return $node;
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit120/Rector/CallLike/CreateStubInCoalesceArgRector.php
+++ b/rules/PHPUnit120/Rector/CallLike/CreateStubInCoalesceArgRector.php
@@ -13,6 +13,8 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,11 +23,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector\CreateStubInCoalesceArgRectorTest
  */
-final class CreateStubInCoalesceArgRector extends AbstractRector
+final class CreateStubInCoalesceArgRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit120/Rector/CallLike/CreateStubOverCreateMockArgRector.php
+++ b/rules/PHPUnit120/Rector/CallLike/CreateStubOverCreateMockArgRector.php
@@ -29,6 +29,8 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -37,13 +39,18 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector\CreateStubOverCreateMockArgRectorTest
  */
-final class CreateStubOverCreateMockArgRector extends AbstractRector
+final class CreateStubOverCreateMockArgRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly MockObjectExprDetector $mockObjectExprDetector,
         private readonly ReflectionResolver $reflectionResolver
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector.php
+++ b/rules/PHPUnit120/Rector/ClassMethod/ExpressionCreateMockToCreateStubRector.php
@@ -16,19 +16,26 @@ use Rector\PHPUnit\CodeQuality\NodeAnalyser\AssignedMocksCollector;
 use Rector\PHPUnit\CodeQuality\NodeAnalyser\MockObjectExprDetector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector\ExpressionCreateMockToCreateStubRectorTest
  */
-final class ExpressionCreateMockToCreateStubRector extends AbstractRector
+final class ExpressionCreateMockToCreateStubRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly AssignedMocksCollector $assignedMocksCollector,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly MockObjectExprDetector $mockObjectExprDetector,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector.php
+++ b/rules/PHPUnit120/Rector/Class_/PropertyCreateMockToCreateStubRector.php
@@ -17,6 +17,8 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43
  */
-final class PropertyCreateMockToCreateStubRector extends AbstractRector
+final class PropertyCreateMockToCreateStubRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -80,6 +82,11 @@ final class PropertyCreateMockToCreateStubRector extends AbstractRector
         }
 
         return $node;
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
+++ b/rules/PHPUnit120/Rector/Property/MockObjectVarToStubRector.php
@@ -19,13 +19,15 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Property\MockObjectVarToStubRector\MockObjectVarToStubRectorTest
  */
-final class MockObjectVarToStubRector extends AbstractRector
+final class MockObjectVarToStubRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
@@ -71,6 +73,11 @@ final class MockObjectVarToStubRector extends AbstractRector
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
         return $node;
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
The stub and mock rules were only reachable through `PHPUnitSetList::PHPUNIT_MOCK_TO_STUB`, with nothing tying them to a PHPUnit version. They now declare the constraint themselves and are registered in the composer-based set, so `withComposerBased(phpunit: true)` picks them up on any project with PHPUnit 11 or newer.

```diff
-final class BareCreateMockAssignToDirectUseRector extends AbstractRector
+final class BareCreateMockAssignToDirectUseRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
+    }
```

Rules bound to `>=11.0`:

* `CreateStubOverCreateMockArgRector`
* `CreateStubInCoalesceArgRector`
* `ExpressionCreateMockToCreateStubRector`
* `PropertyCreateMockToCreateStubRector`
* `MockObjectVarToStubRector`
* `AddIntersectionVarToMockObjectPropertyRector`
* `AddStubIntersectionVarToStubPropertyRector`
* `BareCreateMockAssignToDirectUseRector`

`MockObjectArgCreateStubToCreateMockRector` already declared `>=11.0` and was already in the set.

And registered in `composer-based.php`:

```php
// stubs over mocks, where no expectations are set, since PHPUnit 11.0
CreateStubOverCreateMockArgRector::class,
CreateStubInCoalesceArgRector::class,
ExpressionCreateMockToCreateStubRector::class,
PropertyCreateMockToCreateStubRector::class,
MockObjectVarToStubRector::class,
AddIntersectionVarToMockObjectPropertyRector::class,
AddStubIntersectionVarToStubPropertyRector::class,
BareCreateMockAssignToDirectUseRector::class,

// mocks back over stubs, where a mock object is required
MockObjectArgCreateStubToCreateMockRector::class,
```

`phpunit-mock-to-stub.php` is left as is - the rules now self-gate wherever they are registered, so a PHPUnit 10 project including that set no longer gets stub conversions it cannot use.

Based on #749, which restores `rector/rector-src` to `dev-main`; without it `composer install` fails on `main`.
