### PR TITLE
Handle test traits in DataProviderAnnotationToAttributeRector

### DIFF
--- a/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/in_test_trait.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/in_test_trait.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+trait SomeTestTrait
+{
+    /**
+     * @dataProvider someMethod()
+     */
+    public function test(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+trait SomeTestTrait
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('someMethod')]
+    public function test(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/skip_non_public_trait_method.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/skip_non_public_trait_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+trait SkipNonPublicTraitMethod
+{
+    /**
+     * @dataProvider someMethod()
+     */
+    protected function test(): void
+    {
+    }
+}

--- a/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/skip_static_trait_method.php.inc
+++ b/rules-tests/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector/Fixture/skip_static_trait_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector\Fixture;
+
+trait SkipStaticTraitMethod
+{
+    /**
+     * @dataProvider someMethod()
+     */
+    public static function test(): void
+    {
+    }
+}

--- a/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
+++ b/rules/AnnotationsToAttributes/Rector/ClassMethod/DataProviderAnnotationToAttributeRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -20,7 +19,6 @@ use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPUnit\Enum\PHPUnitAttribute;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
-use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersion;
 use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -37,7 +35,6 @@ final class DataProviderAnnotationToAttributeRector extends AbstractRector imple
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly PhpDocTagRemover $phpDocTagRemover,
-        private readonly ReflectionResolver $reflectionResolver,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly ReflectionProvider $reflectionProvider
@@ -123,15 +120,6 @@ CODE_SAMPLE
         /** @var PhpDocTagNode[] $desiredTagValueNodes */
         $desiredTagValueNodes = $phpDocInfo->getTagsByName('dataProvider');
         if ($desiredTagValueNodes === []) {
-            return null;
-        }
-
-        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
-        if (! $classReflection instanceof ClassReflection) {
-            return null;
-        }
-
-        if (! $classReflection->isClass()) {
             return null;
         }
 

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -35,6 +35,12 @@ final readonly class TestsNodeAnalyzer
             return false;
         }
 
+        // traits have no parent, so the test case check below can never match them;
+        // fall back to the namespace, as test traits live next to the test cases that use them
+        if ($classReflection->isTrait()) {
+            return $this->isInTestsNamespace($classReflection);
+        }
+
         return array_any(
             PHPUnitClassName::TEST_CLASSES,
             fn (string $testCaseObjectClass): bool => $classReflection->is($testCaseObjectClass)
@@ -81,6 +87,19 @@ final readonly class TestsNodeAnalyzer
 
         /** @var StaticCall|MethodCall $node */
         return $this->nodeNameResolver->isName($node->name, $name);
+    }
+
+    private function isInTestsNamespace(ClassReflection $classReflection): bool
+    {
+        $nameParts = explode('\\', $classReflection->getName());
+
+        // drop the short trait name, only the namespace matters here
+        array_pop($nameParts);
+
+        return array_any(
+            $nameParts,
+            static fn (string $namePart): bool => in_array($namePart, ['Test', 'Tests'], true)
+        );
     }
 
     /**

--- a/src/NodeAnalyzer/TestsNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TestsNodeAnalyzer.php
@@ -35,10 +35,9 @@ final readonly class TestsNodeAnalyzer
             return false;
         }
 
-        // traits have no parent, so the test case check below can never match them;
-        // fall back to the namespace, as test traits live next to the test cases that use them
+        // traits have no parent, so the test case check below can never match them
         if ($classReflection->isTrait()) {
-            return $this->isInTestsNamespace($classReflection);
+            return $this->isInTestTrait($classReflection, $node);
         }
 
         return array_any(
@@ -87,6 +86,32 @@ final readonly class TestsNodeAnalyzer
 
         /** @var StaticCall|MethodCall $node */
         return $this->nodeNameResolver->isName($node->name, $name);
+    }
+
+    /**
+     * Test traits live next to the test cases that use them, so the namespace is the main hint.
+     * Only public non-static methods can be test methods, and a "test" prefixed one is a test
+     * method even outside a tests namespace.
+     */
+    private function isInTestTrait(ClassReflection $classReflection, Node $node): bool
+    {
+        if (! $node instanceof ClassMethod) {
+            return $this->isInTestsNamespace($classReflection);
+        }
+
+        if (! $node->isPublic()) {
+            return false;
+        }
+
+        if ($node->isStatic()) {
+            return false;
+        }
+
+        if ($this->isInTestsNamespace($classReflection)) {
+            return true;
+        }
+
+        return str_starts_with($node->name->toString(), 'test');
     }
 
     private function isInTestsNamespace(ClassReflection $classReflection): bool


### PR DESCRIPTION
`@dataProvider` annotations inside test traits were never converted, because `TestsNodeAnalyzer::isInTestClass()` only checks `$classReflection->is(TestCase::class)`. A trait has no parent, so that check can never match — the whole file is skipped.

Real-world case in Mautic:

```php
namespace Mautic\CoreBundle\Tests\Twig;

trait TwigIntegrationTestTrait
{
    public static function integrationTestDataProvider(): iterable
    {
        return static::getIntegrationTestData();
    }

    /**
     * @dataProvider integrationTestDataProvider
     */
    public function testIntegration($file, $message): void
    {
        // ...
    }
}
```

Left untouched by the PHPUnit 10 set, so the upgrade silently misses it.

## Change

Traits are now detected by a `Test`/`Tests` namespace part, since test traits live next to the test cases that use them:

```diff
+        // traits have no parent, so the test case check below can never match them;
+        // fall back to the namespace, as test traits live next to the test cases that use them
+        if ($classReflection->isTrait()) {
+            return $this->isInTestsNamespace($classReflection);
+        }
+
         return array_any(
             PHPUnitClassName::TEST_CLASSES,
             fn (string $testCaseObjectClass): bool => $classReflection->is($testCaseObjectClass)
         );
```

`DataProviderAnnotationToAttributeRector` also carried its own `! $classReflection->isClass()` guard, which blocked traits even once the analyzer accepted them. Dropped — `isInTestClass()` already rejects interfaces and enums, so the guard was redundant.

Result:

```diff
 trait SomeTestTrait
 {
-    /**
-     * @dataProvider someMethod()
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('someMethod')]
     public function test(): void
     {
     }
 }
```

## Note

`isInTestClass()` is used by ~74 rules, so this widens all of them to test traits — which is the intended behaviour, but worth a second look.
