### PR TITLE
Add ExpectsParamToMockObjectRector for private test method params

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -16,6 +16,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPrope
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
 use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
+use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
@@ -55,6 +56,7 @@ return static function (RectorConfig $rectorConfig): void {
 
         // mocks back over stubs, where a mock object is required
         MockObjectArgCreateStubToCreateMockRector::class,
+        ExpectsParamToMockObjectRector::class,
 
         // deprecated in PHPUnit 11.5
         AssertContainsOnlyMethodCallRector::class,

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/ExpectsParamToMockObjectRectorTest.php
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/ExpectsParamToMockObjectRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ExpectsParamToMockObjectRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/fixture.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class ExpectsOnParam extends TestCase
+{
+    private function prepareUserMock(SomeUser $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class ExpectsOnParam extends TestCase
+{
+    private function prepareUserMock(\PHPUnit\Framework\MockObject\MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/only_expects_param.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/only_expects_param.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class OnlyExpectsParam extends TestCase
+{
+    private function prepareUserMock(SomeUser $user, SomeUser $anotherUser): void
+    {
+        $anotherUser->getId();
+
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class OnlyExpectsParam extends TestCase
+{
+    private function prepareUserMock(\PHPUnit\Framework\MockObject\MockObject $user, SomeUser $anotherUser): void
+    {
+        $anotherUser->getId();
+
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_docblock_param.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_docblock_param.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class SkipDocblockParam extends TestCase
+{
+    /**
+     * @param SomeUser $user
+     */
+    private function prepareUserMock(SomeUser $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_intersection_param.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_intersection_param.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class SkipIntersectionParam extends TestCase
+{
+    private function prepareUserMock(SomeUser&MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_mock_object_param.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_mock_object_param.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipMockObjectParam extends TestCase
+{
+    private function prepareUserMock(MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_no_expects.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_no_expects.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class SkipNoExpects extends TestCase
+{
+    private function useUser(SomeUser $user): void
+    {
+        $user->getId();
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class SkipNonTestClass
+{
+    private function prepareUserMock(SomeUser $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_public_method.php.inc
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Fixture/skip_public_method.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source\SomeUser;
+
+final class SkipPublicMethod extends TestCase
+{
+    public function prepareUserMock(SomeUser $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Source/SomeUser.php
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/Source/SomeUser.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\Source;
+
+final class SomeUser
+{
+    public function getId(): int
+    {
+        return 1;
+    }
+}

--- a/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ExpectsParamToMockObjectRector::class);
+};

--- a/rules/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector.php
+++ b/rules/PHPUnit110/Rector/ClassMethod/ExpectsParamToMockObjectRector.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit110\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\UnionType;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector\ExpectsParamToMockObjectRectorTest
+ */
+final class ExpectsParamToMockObjectRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+    ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change param type of a private test method to MockObject, when expects() is called on it',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    private function prepareUserMock(SomeUser $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    private function prepareUserMock(MockObject $user): void
+    {
+        $user->expects($this->once())
+            ->method('getId');
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?ClassMethod
+    {
+        if (! $node->isPrivate()) {
+            return null;
+        }
+
+        if ($node->stmts === null || $node->params === []) {
+            return null;
+        }
+
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        $hasChanged = false;
+
+        foreach ($node->params as $param) {
+            if (! $param->var instanceof Variable) {
+                continue;
+            }
+
+            $paramName = $this->getName($param->var);
+            if ($paramName === null) {
+                continue;
+            }
+
+            if ($this->hasMockObjectType($param->type)) {
+                continue;
+            }
+
+            // avoid contradicting the docblock type, that would have to be changed as well
+            if ($phpDocInfo->getParamTagValueByName($paramName) instanceof ParamTagValueNode) {
+                continue;
+            }
+
+            if (! $this->isExpectsCalledOnVariable($node, $paramName)) {
+                continue;
+            }
+
+            $param->type = new FullyQualified(PHPUnitClassName::MOCK_OBJECT);
+            $hasChanged = true;
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function hasMockObjectType(null|Identifier|Name|ComplexType $type): bool
+    {
+        if ($type instanceof Name) {
+            return $this->isName($type, PHPUnitClassName::MOCK_OBJECT);
+        }
+
+        if ($type instanceof NullableType) {
+            return $this->hasMockObjectType($type->type);
+        }
+
+        if ($type instanceof UnionType || $type instanceof IntersectionType) {
+            foreach ($type->types as $singleType) {
+                if ($this->hasMockObjectType($singleType)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isExpectsCalledOnVariable(ClassMethod $classMethod, string $paramName): bool
+    {
+        /** @var MethodCall[] $methodCalls */
+        $methodCalls = $this->betterNodeFinder->findInstancesOfScoped((array) $classMethod->stmts, MethodCall::class);
+
+        foreach ($methodCalls as $methodCall) {
+            if (! $methodCall->var instanceof Variable) {
+                continue;
+            }
+
+            if (! $this->isName($methodCall->var, $paramName)) {
+                continue;
+            }
+
+            if ($this->isName($methodCall->name, 'expects')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Adds `ExpectsParamToMockObjectRector` (PHPUnit 11+), that changes the param type of a **private** test-case method to `MockObject`, when `expects()` is called on that param.

Since PHPUnit 10, `expects()` only exists on `MockObject`, not on the plain class type. Passing a mock into a helper method typed with the original class forces `@phpstan-ignore-next-line` on every `expects()` call:

```diff
 use PHPUnit\Framework\TestCase;

 final class SomeTest extends TestCase
 {
-    private function prepareUserMock(SomeUser $user): void
+    private function prepareUserMock(\PHPUnit\Framework\MockObject\MockObject $user): void
     {
-        // @phpstan-ignore-next-line
         $user->expects($this->once())
             ->method('getId')
             ->willReturn(1);
     }
 }
```

(the rule only changes the type; leftover ignore comments are removed by other tooling)

Only params with an actual `expects()` call are changed:

```diff
-    private function prepareUserMock(SomeUser $user, SomeUser $anotherUser): void
+    private function prepareUserMock(\PHPUnit\Framework\MockObject\MockObject $user, SomeUser $anotherUser): void
     {
         $anotherUser->getId();

         $user->expects($this->once())
             ->method('getId');
     }
```

Skipped:

* non-private methods, as those can be called from outside the test case
* params already typed `MockObject`, incl. intersection types like `SomeUser&MockObject`
* params with a `@param` docblock tag, to avoid a native type contradicting the docblock
* classes that are not test cases

Registered in the composer-based set, bound to `phpunit/phpunit >=11.0`, next to the related `MockObjectArgCreateStubToCreateMockRector`.
