### PR TITLE
[composer-based] Bond version-specific rules to composer package constraints

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -20,11 +20,17 @@ use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWhereParentClassRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\AssertIsTypeMethodCallRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
 use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 
 /**
  * Rules and configuration bound to the PHPUnit version installed in the analysed project,
@@ -61,6 +67,14 @@ return static function (RectorConfig $rectorConfig): void {
         // deprecated in PHPUnit 11.5
         AssertContainsOnlyMethodCallRector::class,
         AssertIsTypeMethodCallRector::class,
+
+        // the TestCase::__construct() is final since PHPUnit 12.0.3
+        RemoveOverrideFinalConstructTestCaseRector::class,
+
+        // the AllowMockObjectsWithoutExpectations attribute exists since PHPUnit 12.5.2
+        AllowMockObjectsWhereParentClassRector::class,
+        AllowMockObjectsForDataProviderRector::class,
+        AllowMockObjectsWithoutExpectationsAttributeRector::class,
     ]);
 
     // both attributes were added in PHPUnit 10.0
@@ -87,4 +101,69 @@ return static function (RectorConfig $rectorConfig): void {
             'PHPUnit\Framework\Attributes\RunClassInSeparateProcess'
         ),
     ], 'phpunit/phpunit', '>=10.0 <13.0');
+
+    // the MockBuilder::onlyMethods() method was added in PHPUnit 8.3
+    // @see https://github.com/sebastianbergmann/phpunit/pull/3687
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('PHPUnit\Framework\MockObject\MockBuilder', 'setMethods', 'onlyMethods'),
+    ], 'phpunit/phpunit', '>=8.3');
+
+    // the expectExceptionMessageMatches() method was added in PHPUnit 8.4
+    // @see https://github.com/sebastianbergmann/phpunit/issues/3957
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectExceptionMessageRegExp',
+            'expectExceptionMessageMatches'
+        ),
+    ], 'phpunit/phpunit', '>=8.4');
+
+    // all these assert methods were added in PHPUnit 9.1
+    // @see https://github.com/sebastianbergmann/phpunit/blob/9.1.0/ChangeLog-9.1.md
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertRegExp', 'assertMatchesRegularExpression'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotRegExp', 'assertDoesNotMatchRegularExpression'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotExists', 'assertFileDoesNotExist'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertFileNotIsReadable', 'assertFileIsNotReadable'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertDirectoryNotExists', 'assertDirectoryDoesNotExist'),
+        new MethodCallRename(
+            'PHPUnit\Framework\Assert',
+            'assertDirectoryNotIsReadable',
+            'assertDirectoryIsNotReadable'
+        ),
+        new MethodCallRename(
+            'PHPUnit\Framework\Assert',
+            'assertDirectoryNotIsWritable',
+            'assertDirectoryIsNotWritable'
+        ),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsReadable', 'assertIsNotReadable'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertNotIsWritable', 'assertIsNotWritable'),
+    ], 'phpunit/phpunit', '>=9.1');
+
+    // the numberOfInvocations() method was added in PHPUnit 10.0
+    // @see https://github.com/sebastianbergmann/phpunit/commit/2ba8b7fded44a1a75cf5712a3b7310a8de0b6bb8
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename(
+            'PHPUnit\Framework\MockObject\Rule\InvocationOrder',
+            'getInvocationCount',
+            'numberOfInvocations'
+        ),
+    ], 'phpunit/phpunit', '>=10.0');
+
+    // the assertObjectHasProperty() and assertObjectNotHasProperty() methods were added in PHPUnit 10.1
+    // @see https://github.com/sebastianbergmann/phpunit/issues/5220
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertObjectHasAttribute', 'assertObjectHasProperty'),
+        new MethodCallRename('PHPUnit\Framework\Assert', 'assertObjectNotHasAttribute', 'assertObjectNotHasProperty'),
+    ], 'phpunit/phpunit', '>=10.1');
+
+    // the expectExceptionMessageIsOrContains() method was added in PHPUnit 13.2
+    // @see https://github.com/sebastianbergmann/phpunit/issues/6560
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectExceptionMessage',
+            'expectExceptionMessageIsOrContains'
+        ),
+    ], 'phpunit/phpunit', '>=13.2');
 };

--- a/rules/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ChangeMockObjectReturnUnionToIntersectionRector.php
@@ -17,19 +17,26 @@ use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector\ChangeMockObjectReturnUnionToIntersectionRectorTest
  */
-final class ChangeMockObjectReturnUnionToIntersectionRector extends AbstractRector
+final class ChangeMockObjectReturnUnionToIntersectionRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getNodeTypes(): array

--- a/rules/CodeQuality/Rector/Class_/InlineStubPropertyToCreateStubMethodCallRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineStubPropertyToCreateStubMethodCallRector.php
@@ -27,13 +27,15 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector\InlineStubPropertyToCreateStubMethodCallRectorTest
  */
-final class InlineStubPropertyToCreateStubMethodCallRector extends AbstractRector
+final class InlineStubPropertyToCreateStubMethodCallRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -42,6 +44,11 @@ final class InlineStubPropertyToCreateStubMethodCallRector extends AbstractRecto
         private readonly StubPropertyResolver $stubPropertyResolver,
         private readonly BetterNodeFinder $betterNodeFinder,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/CodeQuality/Rector/Class_/SingleMockPropertyTypeRector.php
+++ b/rules/CodeQuality/Rector/Class_/SingleMockPropertyTypeRector.php
@@ -11,17 +11,24 @@ use PhpParser\Node\UnionType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\SingleMockPropertyTypeRector\SingleMockPropertyTypeRectorTest
  */
-final class SingleMockPropertyTypeRector extends AbstractRector
+final class SingleMockPropertyTypeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsForDataProviderRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsForDataProviderRector.php
@@ -16,14 +16,20 @@ use Rector\PHPUnit\Enum\PHPUnitAttribute;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * The AllowMockObjectsWithoutExpectations attribute was added in PHPUnit 12.5.2
+ *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector\AllowMockObjectsForDataProviderRectorTest
+ *
+ * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43
  */
-final class AllowMockObjectsForDataProviderRector extends AbstractRector implements MinPhpVersionInterface
+final class AllowMockObjectsForDataProviderRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -31,6 +37,11 @@ final class AllowMockObjectsForDataProviderRector extends AbstractRector impleme
         private readonly ReflectionProvider $reflectionProvider,
         private readonly MockObjectExprDetector $mockObjectExprDetector,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=12.5.2');
     }
 
     public function getNodeTypes(): array

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWhereParentClassRector.php
@@ -18,16 +18,20 @@ use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * The AllowMockObjectsWithoutExpectations attribute was added in PHPUnit 12.5.2
+ *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsWhereParentClassRector\AllowMockObjectsWhereParentClassRectorTest
  *
  * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43
  */
-final class AllowMockObjectsWhereParentClassRector extends AbstractRector implements MinPhpVersionInterface
+final class AllowMockObjectsWhereParentClassRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     /**
      * @var string[]
@@ -39,6 +43,11 @@ final class AllowMockObjectsWhereParentClassRector extends AbstractRector implem
         private readonly AttributeFinder $attributeFinder,
         private readonly ReflectionProvider $reflectionProvider,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=12.5.2');
     }
 
     public function getNodeTypes(): array

--- a/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
+++ b/rules/PHPUnit120/Rector/Class_/AllowMockObjectsWithoutExpectationsAttributeRector.php
@@ -25,16 +25,20 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * The AllowMockObjectsWithoutExpectations attribute was added in PHPUnit 12.5.2
+ *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector\AllowMockObjectsWithoutExpectationsAttributeRectorTest
  *
  * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43
  */
-final class AllowMockObjectsWithoutExpectationsAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class AllowMockObjectsWithoutExpectationsAttributeRector extends AbstractRector implements MinPhpVersionInterface, ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
@@ -42,6 +46,11 @@ final class AllowMockObjectsWithoutExpectationsAttributeRector extends AbstractR
         private readonly ReflectionProvider $reflectionProvider,
         private readonly BetterNodeFinder $betterNodeFinder,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=12.5.2');
     }
 
     public function getNodeTypes(): array

--- a/rules/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector.php
+++ b/rules/PHPUnit120/Rector/Class_/RemoveOverrideFinalConstructTestCaseRector.php
@@ -10,17 +10,28 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * The TestCase::__construct() was declared final in PHPUnit 12.0.3, overriding it is a fatal error since then
+ *
  * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector\RemoveOverrideFinalConstructTestCaseRectorTest
+ *
+ * @see https://github.com/sebastianbergmann/phpunit/commit/3263f4c62d4af44777ff1c81d093ee88eafccdad
  */
-final class RemoveOverrideFinalConstructTestCaseRector extends AbstractRector
+final class RemoveOverrideFinalConstructTestCaseRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=12.0.3');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/tests/ComposerBased/Fixture/remove_override_final_construct.php.inc
+++ b/tests/ComposerBased/Fixture/remove_override_final_construct.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class RemoveOverrideFinalConstructTest extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct(static::class);
+    }
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class RemoveOverrideFinalConstructTest extends TestCase
+{
+}
+
+?>

--- a/tests/ComposerBased/Fixture/version_bound_method_renames.php.inc
+++ b/tests/ComposerBased/Fixture/version_bound_method_renames.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class VersionBoundMethodRenamesTest extends TestCase
+{
+    public function testSomething()
+    {
+        $this->assertObjectHasAttribute('someProperty', new stdClass());
+        $this->expectExceptionMessage('some message');
+    }
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class VersionBoundMethodRenamesTest extends TestCase
+{
+    public function testSomething()
+    {
+        $this->assertObjectHasProperty('someProperty', new stdClass());
+        $this->expectExceptionMessageIsOrContains('some message');
+    }
+}
+
+?>


### PR DESCRIPTION
Some rules and configurations emit APIs that only exist since a specific PHPUnit version, but carry no version bond. Applied to an older PHPUnit, they produce code that fatals.

Every version below was resolved from the `sebastianbergmann/phpunit` git history (`git tag --contains <commit>`), not from memory.

## Rules

| rule | bond | what breaks without it |
| --- | --- | --- |
| `AllowMockObjectsWhereParentClassRector` | `>=12.5.2` | `#[AllowMockObjectsWithoutExpectations]` does not exist yet ([24c208d](https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43)) |
| `AllowMockObjectsForDataProviderRector` | `>=12.5.2` | same attribute |
| `AllowMockObjectsWithoutExpectationsAttributeRector` | `>=12.5.2` | same attribute |
| `RemoveOverrideFinalConstructTestCaseRector` | `>=12.0.3` | `TestCase::__construct()` is only final since then ([3263f4c](https://github.com/sebastianbergmann/phpunit/commit/3263f4c62d4af44777ff1c81d093ee88eafccdad)) |
| `InlineStubPropertyToCreateStubMethodCallRector` | `>=11.0` | stub/mock split, matches the already bonded siblings |
| `SingleMockPropertyTypeRector` | `>=11.0` | same |
| `ChangeMockObjectReturnUnionToIntersectionRector` | `>=11.0` | same |

```diff
 use Symfony\Component\Form\Test\TypeTestCase;

+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SomeTest extends TypeTestCase
 {
 }
```

On PHPUnit 12.5.1 and below that attribute class does not exist, so the test class fatals. With the bond, the rule is skipped instead of producing broken code.

## Method renames

The generic `RenameMethodRector` configurations get the same treatment, each bound to the version that added the **target** method:

| rename | target method added in |
| --- | --- |
| `setMethods()` → `onlyMethods()` | 8.3 |
| `expectExceptionMessageRegExp()` → `expectExceptionMessageMatches()` | 8.4 |
| `assertRegExp()`, `assertNotRegExp()`, `assertFileNotExists()`, `assertFileNotIsReadable()`, `assertDirectoryNotExists()`, `assertDirectoryNotIsReadable()`, `assertDirectoryNotIsWritable()`, `assertNotIsReadable()`, `assertNotIsWritable()` | 9.1 |
| `getInvocationCount()` → `numberOfInvocations()` | 10.0 |
| `assertObjectHasAttribute()` → `assertObjectHasProperty()` | 10.1 |
| `expectExceptionMessage()` → `expectExceptionMessageIsOrContains()` | 13.2 |

```diff
-$this->assertObjectHasAttribute('someProperty', new stdClass());
-$this->expectExceptionMessage('some message');
+$this->assertObjectHasProperty('someProperty', new stdClass());
+$this->expectExceptionMessageIsOrContains('some message');
```

Two versions worth calling out, as they are a minor later than one would assume: `assertObjectHasProperty()` is 10.1, not 10.0, and `expectExceptionMessageIsOrContains()` is 13.2. The latter is the sharpest edge - rewriting `expectExceptionMessage()` on a project still on PHPUnit 11 or 12 points every call at a method that does not exist there.

## Set registration

Everything is registered in `composer-based.php`, so it applies to any project whose installed PHPUnit matches, not only through the single upgrade set that used to carry it.

The per-version sets keep their current registrations untouched, so nothing changes for anyone already using them - a rule registered by both a version set and the composer-based set is tagged only once by `RectorConfig::rule()`, and rule configurations are merged.

Two `tests/ComposerBased` fixtures cover the constructor rule and the bounded renames arriving through the composer-based set.
