### PR TITLE
[CodeQuality] Add AddIntersectionParamToMockObjectParamRector

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -12,6 +12,7 @@ use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\TicketAnnotationToAttri
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
@@ -57,6 +58,7 @@ return static function (RectorConfig $rectorConfig): void {
         // mocks back over stubs, where a mock object is required
         MockObjectArgCreateStubToCreateMockRector::class,
         ExpectsParamToMockObjectRector::class,
+        AddIntersectionParamToMockObjectParamRector::class,
 
         // deprecated in PHPUnit 11.5
         AssertContainsOnlyMethodCallRector::class,

--- a/config/sets/phpunit-mock-to-stub.php
+++ b/config/sets/phpunit-mock-to-stub.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
@@ -27,5 +28,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // mocks back over stubs, where mock object is required
         MockObjectArgCreateStubToCreateMockRector::class,
+        AddIntersectionParamToMockObjectParamRector::class,
     ]);
 };

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/AddIntersectionParamToMockObjectParamRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/AddIntersectionParamToMockObjectParamRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddIntersectionParamToMockObjectParamRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/direct_create_mock_arg.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/direct_create_mock_arg.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DirectCreateMockArgTest extends TestCase
+{
+    public function test(): void
+    {
+        $this->prepareServiceMock($this->createMock(\stdClass::class));
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DirectCreateMockArgTest extends TestCase
+{
+    public function test(): void
+    {
+        $this->prepareServiceMock($this->createMock(\stdClass::class));
+    }
+
+    /**
+     * @param \stdClass&\PHPUnit\Framework\MockObject\MockObject $someService
+     */
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/fixture.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    /**
+     * @param \stdClass&\PHPUnit\Framework\MockObject\MockObject $someService
+     */
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/second_param_only.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/second_param_only.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SecondParamOnlyTest extends TestCase
+{
+    public function test(): void
+    {
+        $builder = self::createMock(\stdClass::class);
+
+        $this->getEventListener(new \DateTime('now'), $builder);
+    }
+
+    private function getEventListener(\DateTime $dateTime, \PHPUnit\Framework\MockObject\MockObject $builder): void
+    {
+        $builder->expects($this->once())
+            ->method('add');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SecondParamOnlyTest extends TestCase
+{
+    public function test(): void
+    {
+        $builder = self::createMock(\stdClass::class);
+
+        $this->getEventListener(new \DateTime('now'), $builder);
+    }
+
+    /**
+     * @param \stdClass&\PHPUnit\Framework\MockObject\MockObject $builder
+     */
+    private function getEventListener(\DateTime $dateTime, \PHPUnit\Framework\MockObject\MockObject $builder): void
+    {
+        $builder->expects($this->once())
+            ->method('add');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_create_stub.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_create_stub.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipCreateStubTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createStub(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_different_mocked_classes.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_different_mocked_classes.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipDifferentMockedClassesTest extends TestCase
+{
+    public function testFirst(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    public function testSecond(): void
+    {
+        $someService = $this->createMock(\DateTime::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_existing_param_doc.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_existing_param_doc.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipExistingParamDocTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    /**
+     * @param MockObject $someService
+     */
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_no_call_site.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_no_call_site.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoCallSiteTest extends TestCase
+{
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class SkipNonTestClass
+{
+    public function run(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_public_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_public_method.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipPublicMethodTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    public function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_reassigned_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/Fixture/skip_reassigned_variable.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipReassignedVariableTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(\stdClass::class);
+        $someService = $this->createMock(\DateTime::class);
+
+        $this->prepareServiceMock($someService);
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector;
+
+return RectorConfig::configure()
+    ->withRules([AddIntersectionParamToMockObjectParamRector::class]);

--- a/rules/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddIntersectionParamToMockObjectParamRector.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectParamRector\AddIntersectionParamToMockObjectParamRectorTest
+ */
+final class AddIntersectionParamToMockObjectParamRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+    ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add a MockObject intersection @param docblock with the mocked class, based on the mock passed in the private method call',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(SomeService::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test(): void
+    {
+        $someService = $this->createMock(SomeService::class);
+        $this->prepareServiceMock($someService);
+    }
+
+    /**
+     * @param \SomeService&\PHPUnit\Framework\MockObject\MockObject $someService
+     */
+    private function prepareServiceMock(MockObject $someService): void
+    {
+        $someService->expects($this->once())
+            ->method('getId');
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $mockObjectParamClassMethods = $this->collectMockObjectParamClassMethods($node);
+        if ($mockObjectParamClassMethods === []) {
+            return null;
+        }
+
+        $mockedClassesByMethodName = $this->resolveMockedClassesFromCallSites(
+            $node,
+            array_keys($mockObjectParamClassMethods)
+        );
+
+        $hasChanged = false;
+
+        foreach ($mockObjectParamClassMethods as $methodName => $classMethod) {
+            $mockedClassesByPosition = $mockedClassesByMethodName[$methodName] ?? [];
+
+            foreach ($classMethod->params as $position => $param) {
+                if (! $this->isBareMockObjectParam($param)) {
+                    continue;
+                }
+
+                $mockedClass = $this->resolveSingleMockedClass($mockedClassesByPosition[$position] ?? []);
+                if ($mockedClass === null) {
+                    continue;
+                }
+
+                $paramName = $this->getName($param->var);
+                if ($paramName === null) {
+                    continue;
+                }
+
+                $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
+
+                // do not contradict an existing docblock type
+                if ($phpDocInfo->getParamTagValueByName($paramName) instanceof ParamTagValueNode) {
+                    continue;
+                }
+
+                $intersectionTypeNode = new BracketsAwareIntersectionTypeNode([
+                    new IdentifierTypeNode('\\' . $mockedClass),
+                    new IdentifierTypeNode('\\' . PHPUnitClassName::MOCK_OBJECT),
+                ]);
+
+                $this->phpDocTypeChanger->changeParamTypeNode(
+                    $classMethod,
+                    $phpDocInfo,
+                    $param,
+                    $paramName,
+                    $intersectionTypeNode
+                );
+
+                $hasChanged = true;
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return array<string, ClassMethod>
+     */
+    private function collectMockObjectParamClassMethods(Class_ $class): array
+    {
+        $mockObjectParamClassMethods = [];
+
+        foreach ($class->getMethods() as $classMethod) {
+            // only private methods, as those can only be called from the very same class
+            if (! $classMethod->isPrivate()) {
+                continue;
+            }
+
+            if ($classMethod->stmts === null) {
+                continue;
+            }
+
+            foreach ($classMethod->params as $param) {
+                if (! $this->isBareMockObjectParam($param)) {
+                    continue;
+                }
+
+                $mockObjectParamClassMethods[$this->getName($classMethod)] = $classMethod;
+                break;
+            }
+        }
+
+        return $mockObjectParamClassMethods;
+    }
+
+    /**
+     * @param string[] $methodNames
+     * @return array<string, array<int, array<string|null>>>
+     */
+    private function resolveMockedClassesFromCallSites(Class_ $class, array $methodNames): array
+    {
+        $mockedClassesByMethodName = [];
+
+        foreach ($class->getMethods() as $classMethod) {
+            if ($classMethod->stmts === null) {
+                continue;
+            }
+
+            $mockedClassesByVariableName = $this->resolveMockedClassesByVariableName($classMethod);
+
+            /** @var MethodCall[] $methodCalls */
+            $methodCalls = $this->betterNodeFinder->findInstancesOfScoped(
+                (array) $classMethod->stmts,
+                MethodCall::class
+            );
+
+            foreach ($methodCalls as $methodCall) {
+                if (! $this->isName($methodCall->var, 'this')) {
+                    continue;
+                }
+
+                $calledMethodName = $this->getName($methodCall->name);
+                if (! in_array($calledMethodName, $methodNames, true)) {
+                    continue;
+                }
+
+                foreach ($methodCall->getArgs() as $position => $arg) {
+                    $mockedClassesByMethodName[$calledMethodName][$position][] = $this->resolveArgMockedClass(
+                        $arg,
+                        $mockedClassesByVariableName
+                    );
+                }
+            }
+        }
+
+        return $mockedClassesByMethodName;
+    }
+
+    /**
+     * @param array<string, string|null> $mockedClassesByVariableName
+     */
+    private function resolveArgMockedClass(Arg $arg, array $mockedClassesByVariableName): ?string
+    {
+        // named args make the position unreliable
+        if ($arg->name instanceof Identifier) {
+            return null;
+        }
+
+        if ($arg->unpack) {
+            return null;
+        }
+
+        if ($arg->value instanceof Variable) {
+            $variableName = $this->getName($arg->value);
+            if ($variableName !== null) {
+                return $mockedClassesByVariableName[$variableName] ?? null;
+            }
+
+            return null;
+        }
+
+        return $this->resolveCreateMockClass($arg->value);
+    }
+
+    /**
+     * Variables assigned exactly once from a createMock() call
+     *
+     * @return array<string, string|null>
+     */
+    private function resolveMockedClassesByVariableName(ClassMethod $classMethod): array
+    {
+        $mockedClassesByVariableName = [];
+
+        /** @var Assign[] $assigns */
+        $assigns = $this->betterNodeFinder->findInstancesOfScoped((array) $classMethod->stmts, Assign::class);
+
+        foreach ($assigns as $assign) {
+            if (! $assign->var instanceof Variable) {
+                continue;
+            }
+
+            $variableName = $this->getName($assign->var);
+            if ($variableName === null) {
+                continue;
+            }
+
+            // re-assigned variable, the type is not reliable
+            if (array_key_exists($variableName, $mockedClassesByVariableName)) {
+                $mockedClassesByVariableName[$variableName] = null;
+                continue;
+            }
+
+            $mockedClassesByVariableName[$variableName] = $this->resolveCreateMockClass($assign->expr);
+        }
+
+        return $mockedClassesByVariableName;
+    }
+
+    private function resolveCreateMockClass(Expr $expr): ?string
+    {
+        // both $this->createMock() and self::createMock()
+        if (! $expr instanceof MethodCall && ! $expr instanceof StaticCall) {
+            return null;
+        }
+
+        if (! $this->isName($expr->name, 'createMock')) {
+            return null;
+        }
+
+        $firstArg = $expr->getArgs()[0] ?? null;
+        if (! $firstArg instanceof Arg) {
+            return null;
+        }
+
+        if (! $firstArg->value instanceof ClassConstFetch) {
+            return null;
+        }
+
+        $className = $this->getName($firstArg->value->class);
+        if (! is_string($className)) {
+            return null;
+        }
+
+        return $className;
+    }
+
+    /**
+     * @param array<string|null> $mockedClasses
+     */
+    private function resolveSingleMockedClass(array $mockedClasses): ?string
+    {
+        if ($mockedClasses === []) {
+            return null;
+        }
+
+        // every call site must pass a mock of the very same class
+        $uniqueMockedClasses = array_unique($mockedClasses, SORT_REGULAR);
+        if (count($uniqueMockedClasses) !== 1) {
+            return null;
+        }
+
+        return array_pop($uniqueMockedClasses);
+    }
+
+    private function isBareMockObjectParam(Param $param): bool
+    {
+        if ($param->variadic) {
+            return false;
+        }
+
+        if (! $param->var instanceof Variable) {
+            return false;
+        }
+
+        if (! $param->type instanceof Name) {
+            return false;
+        }
+
+        return $this->isName($param->type, PHPUnitClassName::MOCK_OBJECT);
+    }
+}


### PR DESCRIPTION
Private test methods that take a mock end up with a bare `MockObject` param type — either handwritten, or produced by `ExpectsParamToMockObjectRector`. The mocked class is then lost for static analysis, which is what forces `@phpstan-ignore-next-line` on every call on that param.

This rule puts the class back into an intersection `@param`, resolved from the mock actually passed at the call sites in the same class.

```diff
 final class SomeTest extends TestCase
 {
     public function testBuildForm(): void
     {
         $builder = $this->createMock(FormBuilderInterface::class);
         $eventListener = $this->getEventListenerFromBuildForm($type, $builder);
     }

+    /**
+     * @param \FormBuilderInterface&\PHPUnit\Framework\MockObject\MockObject $builder
+     */
     private function getEventListenerFromBuildForm(SomeType $type, MockObject $builder): callable
     {
         $builder->expects($this->once())
             ->method('addEventListener');
     }
 }
```

## How the type is resolved

Only private methods are handled, as those can only be called from the very same class, so all call sites are visible.

The mocked class comes from the `$this->createMock(Some::class)` / `self::createMock(Some::class)` assignment of the passed variable, or from a `createMock()` call passed inline as an arg.

Skipped when the type would be a guess:

- call sites disagree on the mocked class
- no call site at all
- the variable is re-assigned, so its type is not certain
- `createStub()` source, that is a `Stub`, not a `MockObject`
- a `@param` tag for that param already exists, to not contradict it
- non-test class, public/protected method, variadic param

## Sets

Registered in the `composer-based` set next to `ExpectsParamToMockObjectRector`, bonded to `phpunit/phpunit >=11.0` to match its stub/mock siblings, and in the `phpunit-mock-to-stub` set.

Note on the intersection order: this prints `\Some&\MockObject`, while the existing `AddIntersectionVarToMockObjectPropertyRector` prints `\MockObject&\Some`. Happy to flip either one for consistency.