### PR TITLE
[composer-based] Bond RemoveExpectAnyFromMockRector to PHPUnit 11+

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -16,6 +16,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionParamToMockObjectPar
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveExpectAnyFromMockRector;
 use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
@@ -60,6 +61,7 @@ return static function (RectorConfig $rectorConfig): void {
         AddIntersectionVarToMockObjectPropertyRector::class,
         AddStubIntersectionVarToStubPropertyRector::class,
         BareCreateMockAssignToDirectUseRector::class,
+        RemoveExpectAnyFromMockRector::class,
 
         // mocks back over stubs, where a mock object is required
         MockObjectArgCreateStubToCreateMockRector::class,

--- a/rules/CodeQuality/Rector/MethodCall/RemoveExpectAnyFromMockRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/RemoveExpectAnyFromMockRector.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -16,11 +18,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://github.com/symfony/symfony/pull/30813/files#r270879504
  * @see \Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\RemoveExpectAnyFromMockRector\RemoveExpectAnyFromMockRectorTest
  */
-final class RemoveExpectAnyFromMockRector extends AbstractRector
+final class RemoveExpectAnyFromMockRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
`RemoveExpectAnyFromMockRector` had no version bond at all — it was registered only in the `phpunit-code-quality` set and fired on any PHPUnit version.

The rule really belongs to the PHPUnit 11 mock-to-stub story: stripping `expects($this->any())` leaves the mock with zero expectations, which is exactly what unblocks `ExpressionCreateMockToCreateStubRector`, `PropertyCreateMockToCreateStubRector` and friends.

So it now implements `ComposerPackageConstraintInterface` with `phpunit/phpunit >=11.0`, and is registered in `config/sets/composer-based.php` next to the other mock/stub rules. It stays in the code-quality set as well, same as `BareCreateMockAssignToDirectUseRector`.

What the rule does:

```diff
 use PHPUnit\Framework\TestCase;

 class SomeClass extends TestCase
 {
     public function test()
     {
         $translator = $this->createMock(SomeClass::class);
-        $translator->expects($this->any())
-            ->method('trans')
+        $translator->method('trans')
             ->willReturn('translated max {{ max }}!');
     }
 }
```