### PR TITLE
[Sets] Drop the PHPUnit 12.0, 12.5 and 13.0 triggered sets covered by composer-based

### DIFF
--- a/src/Set/SetProvider/PHPUnitSetProvider.php
+++ b/src/Set/SetProvider/PHPUnitSetProvider.php
@@ -69,26 +69,6 @@ final class PHPUnitSetProvider implements SetProviderInterface
                 '11.0',
                 __DIR__ . '/../../../config/sets/phpunit110.php'
             ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '12.0',
-                __DIR__ . '/../../../config/sets/phpunit120.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '12.5',
-                __DIR__ . '/../../../config/sets/phpunit125.php'
-            ),
-
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '13.0',
-                __DIR__ . '/../../../config/sets/phpunit130.php'
-            ),
-
             // applies to any installed PHPUnit version, the rules and configuration inside are bound
             // to the exact version they are available from
             new ComposerTriggeredSet(


### PR DESCRIPTION
Same cleanup as rectorphp/rector-symfony#1010, but PHPUnit turns out to be a much smaller case — most per-version sets are **not** covered by `composer-based.php` yet, so only three go.

Checked all 11 triggered sets rule by rule against `config/sets/composer-based.php`:

| set | covered | why |
|---|---|---|
| 12.0 | yes | `RemoveOverrideFinalConstructTestCaseRector` (`>=12.0.3`), plus the mock-to-stub and composer-based sets it imports — all 10 mock-to-stub rules are in composer-based |
| 12.5 | yes | the three `AllowMockObjects*` rules (`>=12.5.2`) |
| 13.0 | yes | the `expectExceptionMessage()` → `expectExceptionMessageIsOrContains()` rename (`>=13.2`) |
| 4.0 | no | the `staticExpects()` → `expects()` rename is not in composer-based |
| 5.0–11.0 | no | 5 to 7 rules each still only in their version set |

```diff
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '12.5',
-                __DIR__ . '/../../../config/sets/phpunit125.php'
-            ),
```

The version bond is also **more accurate** than the set trigger it replaces. The set fired on `^13.0`, while the method it renames to only exists from 13.2:

```php
// composer-based.php
$rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
    new MethodCallRename(
        'PHPUnit\Framework\TestCase',
        'expectExceptionMessage',
        'expectExceptionMessageIsOrContains'
    ),
], 'phpunit/phpunit', '>=13.2');
```

Same for 12.0 vs 12.0.3 and 12.5 vs 12.5.2. A project on 13.0 or 13.1 no longer gets a rename to a method it does not have.

`PHPUnitSetProvider` stays — it still carries the 8 uncovered per-version sets, the composer-based trigger, and the Code Quality and PHPUnit Attributes sets. The three set files stay reachable through `PHPUnitSetList::PHPUNIT_120`, `PHPUNIT_125` and `PHPUNIT_130`.

Green locally: 652 tests, PHPStan and ECS clean.
