### PR TITLE
[Sets] Move every per-version rule into the composer-based set

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PHPStan\Type\MixedType;
+use PHPStan\Type\VoidType;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
@@ -17,7 +19,14 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\AddIntersectionVarToMockObjectPrope
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddStubIntersectionVarToStubPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveExpectAnyFromMockRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\AddProphecyTraitRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\PHPUnit\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
+use Rector\PHPUnit\PHPUnit100\Rector\StmtsAwareInterface\WithConsecutiveRector;
 use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector;
+use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
@@ -30,9 +39,30 @@ use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\RemoveOverrideFinalConstructTestCaseRector;
 use Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Property\MockObjectVarToStubRector;
+use Rector\PHPUnit\PHPUnit50\Rector\StaticCall\GetMockRector;
+use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector;
+use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\ExceptionAnnotationRector;
+use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector;
+use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
+use Rector\PHPUnit\PHPUnit70\Rector\Class_\RemoveDataProviderTestPrefixRector;
+use Rector\PHPUnit\PHPUnit80\Rector\MethodCall\AssertEqualsParameterToSpecificMethodsTypeRector;
+use Rector\PHPUnit\PHPUnit80\Rector\MethodCall\SpecificAssertContainsRector;
+use Rector\PHPUnit\PHPUnit80\Rector\MethodCall\SpecificAssertInternalTypeRector;
+use Rector\PHPUnit\PHPUnit90\Rector\Class_\TestListenerToHooksRector;
+use Rector\PHPUnit\PHPUnit90\Rector\MethodCall\AssertRegExpRector;
+use Rector\PHPUnit\PHPUnit90\Rector\MethodCall\ExplicitPhpErrorApiRector;
+use Rector\PHPUnit\PHPUnit90\Rector\MethodCall\SpecificAssertContainsWithoutIdentityRector;
 use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
+use Rector\Renaming\Rector\ClassMethod\RenameAnnotationRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameAnnotationByType;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+use Rector\ValueObject\MethodName;
 
 /**
  * Rules and configuration bound to the PHPUnit version installed in the analysed project,
@@ -79,6 +109,49 @@ return static function (RectorConfig $rectorConfig): void {
         AllowMockObjectsWhereParentClassRector::class,
         AllowMockObjectsForDataProviderRector::class,
         AllowMockObjectsWithoutExpectationsAttributeRector::class,
+
+        // the upgrade rules of the per-version sets, each bound to the PHPUnit version
+        // its target API is available from
+
+        // expectException() and friends, PHPUnit 5.2
+        ExceptionAnnotationRector::class,
+        DelegateExceptionArgumentsRector::class,
+
+        // createMock(), PHPUnit 5.4
+        GetMockRector::class,
+        GetMockBuilderGetMockToCreateMockRector::class,
+
+        // PHPUnit 6.0
+        AddDoesNotPerformAssertionToNonAssertingTestRector::class,
+
+        // PHPUnit 7.0
+        RemoveDataProviderTestPrefixRector::class,
+
+        // the assertIsArray(), assertStringContainsString() and assertEqualsWithDelta() families, PHPUnit 7.5
+        SpecificAssertInternalTypeRector::class,
+        SpecificAssertContainsRector::class,
+        AssertEqualsParameterToSpecificMethodsTypeRector::class,
+
+        // the expectDeprecation() family, PHPUnit 8.4 until 10.0
+        ExplicitPhpErrorApiRector::class,
+
+        // PHPUnit 9.0, the hook interfaces until 10.0
+        TestListenerToHooksRector::class,
+        SpecificAssertContainsWithoutIdentityRector::class,
+
+        // assertMatchesRegularExpression(), PHPUnit 9.1
+        AssertRegExpRector::class,
+
+        // PHPUnit 10.0
+        StaticDataProviderClassMethodRector::class,
+        PublicDataProviderClassMethodRector::class,
+        AddProphecyTraitRector::class,
+        WithConsecutiveRector::class,
+        RemoveSetMethodsMethodCallRector::class,
+        ParentTestClassConstructorRector::class,
+
+        // PHPUnit 11.0
+        NamedArgumentForDataProviderRector::class,
     ]);
 
     // both attributes were added in PHPUnit 10.0
@@ -170,4 +243,243 @@ return static function (RectorConfig $rectorConfig): void {
             'expectExceptionMessageIsOrContains'
         ),
     ], 'phpunit/phpunit', '>=13.2');
+    // the staticExpects() method was removed in PHPUnit 4.0
+    // @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/137
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('PHPUnit_Framework_MockObject_MockObject', 'staticExpects', 'expects'),
+    ], 'phpunit/phpunit', '>=4.0');
+
+    // the namespaced class names were introduced in PHPUnit 6.0
+    // @see https://github.com/sebastianbergmann/phpunit/compare/5.7.9...6.0.0
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('PHPUnit\Framework\TestClass', 'setExpectedException', 'expectedException'),
+        new MethodCallRename('PHPUnit\Framework\TestClass', 'setExpectedExceptionRegExp', 'expectedException'),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'createMockBuilder', 'getMockBuilder'),
+    ], 'phpunit/phpunit', '>=6.0');
+
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameClassRector::class, [
+        // ref. https://github.com/sebastianbergmann/phpunit/compare/5.7.9...6.0.0
+        'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
+        'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
+        'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
+        'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
+        'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
+        'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
+        'PHPUnit_Framework_Assert' => 'PHPUnit\Framework\Assert',
+        'PHPUnit_Framework_AssertionFailedError' => 'PHPUnit\Framework\AssertionFailedError',
+        'PHPUnit_Framework_BaseTestListener' => 'PHPUnit\Framework\BaseTestListener',
+        'PHPUnit_Framework_CodeCoverageException' => 'PHPUnit\Framework\CodeCoverageException',
+        'PHPUnit_Exception' => 'PHPUnit\Exception',
+        'PHPUnit_Framework_Exception' => 'PHPUnit\Framework\Exception',
+        'PHPUnit_Framework_ExceptionWrapper' => 'PHPUnit\Framework\ExceptionWrapper',
+        'PHPUnit_Framework_ExpectationFailedException' => 'PHPUnit\Framework\ExpectationFailedException',
+        'PHPUnit_Framework_IncompleteTest' => 'PHPUnit\Framework\IncompleteTest',
+        'PHPUnit_Framework_IncompleteTestCase' => 'PHPUnit\Framework\IncompleteTestCase',
+        'PHPUnit_Framework_IncompleteTestError' => 'PHPUnit\Framework\IncompleteTestError',
+        'PHPUnit_Framework_InvalidCoversTargetException' => 'PHPUnit\Framework\InvalidCoversTargetException',
+        'PHPUnit_Framework_OutputError' => 'PHPUnit\Framework\OutputError',
+        'PHPUnit_Framework_CoveredCodeNotExecutedException' => 'PHPUnit\Framework\CoveredCodeNotExecutedException',
+        'PHPUnit_Framework_MissingCoversAnnotationException' => 'PHPUnit\Framework\MissingCoversAnnotationException',
+        'PHPUnit_Framework_RiskyTest' => 'PHPUnit\Framework\RiskyTest',
+        'PHPUnit_Framework_RiskyTestError' => 'PHPUnit\Framework\RiskyTestError',
+        'PHPUnit_Framework_SkippedTest' => 'PHPUnit\Framework\SkippedTest',
+        'PHPUnit_Framework_SkippedTestCase' => 'PHPUnit\Framework\SkippedTestCase',
+        'PHPUnit_Framework_SkippedTestError' => 'PHPUnit\Framework\SkippedTestError',
+        'PHPUnit_Framework_SkippedTestSuiteError' => 'PHPUnit\Framework\SkippedTestSuiteError',
+        'PHPUnit_Framework_SyntheticError' => 'PHPUnit\Framework\SyntheticError',
+        'PHPUnit_Framework_Test' => 'PHPUnit\Framework\Test',
+        'PHPUnit_Framework_TestCase' => 'PHPUnit\Framework\TestCase',
+        'PHPUnit_Framework_TestFailure' => 'PHPUnit\Framework\TestFailure',
+        'PHPUnit_Framework_TestListener' => 'PHPUnit\Framework\TestListener',
+        'PHPUnit_Framework_TestResult' => 'PHPUnit\Framework\TestResult',
+        'PHPUnit_Framework_TestSuite' => 'PHPUnit\Framework\TestSuite',
+        'PHPUnit_Framework_UnintentionallyCoveredCodeError' => 'PHPUnit\Framework\UnintentionallyCoveredCodeError',
+        'PHPUnit_Framework_Warning' => 'PHPUnit\Framework\Warning',
+        'PHPUnit_Framework_WarningTestCase' => 'PHPUnit\Framework\WarningTestCase',
+        'PHPUnit_Framework_Constraint_And' => 'PHPUnit\Framework\Constraint\LogicalAnd',
+        'PHPUnit_Framework_Constraint_ArrayHasKey' => 'PHPUnit\Framework\Constraint\ArrayHasKey',
+        'PHPUnit_Framework_Constraint_ArraySubset' => 'PHPUnit\Framework\Constraint\ArraySubset',
+        'PHPUnit_Framework_Constraint_Attribute' => 'PHPUnit\Framework\Constraint\Attribute',
+        'PHPUnit_Framework_Constraint_Callback' => 'PHPUnit\Framework\Constraint\Callback',
+        'PHPUnit_Framework_Constraint_ClassHasAttribute' => 'PHPUnit\Framework\Constraint\ClassHasAttribute',
+        'PHPUnit_Framework_Constraint_Composite' => 'PHPUnit\Framework\Constraint\Composite',
+        'PHPUnit_Framework_Constraint_Count' => 'PHPUnit\Framework\Constraint\Count',
+        'PHPUnit_Framework_Constraint_DirectoryExists' => 'PHPUnit\Framework\Constraint\DirectoryExists',
+        'PHPUnit_Framework_Constraint' => 'PHPUnit\Framework\Constraint\Constraint',
+        'PHPUnit_Framework_Constraint_Exception' => 'PHPUnit\Framework\Constraint\Exception',
+        'PHPUnit_Framework_Constraint_ExceptionCode' => 'PHPUnit\Framework\Constraint\ExceptionCode',
+        'PHPUnit_Framework_Constraint_ExceptionMessage' => 'PHPUnit\Framework\Constraint\ExceptionMessage',
+        'PHPUnit_Framework_Constraint_ExceptionMessageRegExp' => 'PHPUnit_Framework_Constraint_ExceptionMessageRegularExpression',
+        'PHPUnit_Framework_Constraint_FileExists' => 'PHPUnit\Framework\Constraint\FileExists',
+        'PHPUnit_Framework_Constraint_GreaterThan' => 'PHPUnit\Framework\Constraint\GreaterThan',
+        'PHPUnit_Framework_Constraint_IsAnything' => 'PHPUnit\Framework\Constraint\IsAnything',
+        'PHPUnit_Framework_Constraint_IsEmpty' => 'PHPUnit\Framework\Constraint\IsEmpty',
+        'PHPUnit_Framework_Constraint_IsIdentical' => 'PHPUnit\Framework\Constraint\IsIdentical',
+        'PHPUnit_Framework_Constraint_IsInfinite' => 'PHPUnit\Framework\Constraint\IsInfinite',
+        'PHPUnit_Framework_Constraint_IsInstanceOf' => 'PHPUnit\Framework\Constraint\IsInstanceOf',
+        'PHPUnit_Framework_Constraint_IsJson' => 'PHPUnit\Framework\Constraint\IsJson',
+        'PHPUnit_Framework_Constraint_IsNan' => 'PHPUnit\Framework\Constraint\IsNan',
+        'PHPUnit_Framework_Constraint_IsNull' => 'PHPUnit\Framework\Constraint\IsNull',
+        'PHPUnit_Framework_Constraint_IsReadable' => 'PHPUnit\Framework\Constraint\IsReadable',
+        'PHPUnit_Framework_Constraint_IsTrue' => 'PHPUnit\Framework\Constraint\IsTrue',
+        'PHPUnit_Framework_Constraint_IsType' => 'PHPUnit\Framework\Constraint\IsType',
+        'PHPUnit_Framework_Constraint_IsWritable' => 'PHPUnit\Framework\Constraint\IsWritable',
+        'PHPUnit_Framework_Constraint_JsonMatches' => 'PHPUnit\Framework\Constraint\JsonMatches',
+        'PHPUnit_Framework_Constraint_LessThan' => 'PHPUnit\Framework\Constraint\LessThan',
+        'PHPUnit_Framework_Constraint_Not' => 'PHPUnit\Framework\Constraint\LogicalNot',
+        'PHPUnit_Framework_Constraint_ObjectHasAttribute' => 'PHPUnit\Framework\Constraint\ObjectHasAttribute',
+        'PHPUnit_Framework_Constraint_Or' => 'PHPUnit\Framework\Constraint\LogicalOr',
+        'PHPUnit_Framework_Constraint_PCREMatch' => 'PHPUnit\Framework\Constraint\RegularExpression',
+        'PHPUnit_Framework_Constraint_SameSize' => 'PHPUnit\Framework\Constraint\SameSize',
+        'PHPUnit_Framework_Constraint_StringContains' => 'PHPUnit\Framework\Constraint\StringContains',
+        'PHPUnit_Framework_Constraint_StringEndsWith' => 'PHPUnit\Framework\Constraint\StringEndsWith',
+        'PHPUnit_Framework_Constraint_StringMatches' => 'PHPUnit\Framework\Constraint\StringMatchesFormatDescription',
+        'PHPUnit_Framework_Constraint_StringStartsWith' => 'PHPUnit\Framework\Constraint\StringStartsWith',
+        'PHPUnit_Framework_Constraint_TraversableContains' => 'PHPUnit\Framework\Constraint\TraversableContains',
+        'PHPUnit_Framework_Constraint_TraversableContainsOnly' => 'PHPUnit\Framework\Constraint\TraversableContainsOnly',
+        'PHPUnit_Framework_Constraint_Xor' => 'PHPUnit\Framework\Constraint\LogicalXor',
+        'PHPUnit_Framework_Constraint_JsonMatches_ErrorMessageProvider' => 'PHPUnit\Framework\Constraint\JsonMatchesErrorMessageProvider',
+        'PHPUnit_Framework_Error_Deprecated' => 'PHPUnit\Framework\Error\Deprecated',
+        'PHPUnit_Framework_Error_Notice' => 'PHPUnit\Framework\Error\Notice',
+        'PHPUnit_Framework_Error_Warning' => 'PHPUnit\Framework\Error\Warning',
+        'PHPUnit_Framework_TestSuite_DataProvider' => 'PHPUnit\Framework\DataProviderTestSuite',
+        'PHPUnit_Framework_Error' => 'PHPUnit\Framework\Error\Error',
+        'PHPUnit_Runner_BaseTestRunner' => 'PHPUnit\Runner\BaseTestRunner',
+        'PHPUnit_Runner_Exception' => 'PHPUnit\Runner\Exception',
+        'PHPUnit_Runner_PhptTestCase' => 'PHPUnit\Runner\PhptTestCase',
+        'PHPUnit_Runner_StandardTestSuiteLoader' => 'PHPUnit\Runner\StandardTestSuiteLoader',
+        'PHPUnit_Runner_TestSuiteLoader' => 'PHPUnit\Runner\TestSuiteLoader',
+        'PHPUnit_Runner_Version' => 'PHPUnit\Runner\Version',
+        'PHPUnit_Runner_Filter_Factory' => 'PHPUnit\Runner\Filter\Factory',
+        'PHPUnit_Runner_Filter_GroupFilterIterator' => 'PHPUnit\Runner\Filter\GroupFilterIterator',
+        'PHPUnit_Runner_Filter_Test' => 'PHPUnit\Runner\Filter\NameFilterIterator',
+        'PHPUnit_Runner_Filter_Group_Exclude' => 'PHPUnit\Runner\Filter\ExcludeGroupFilterIterator',
+        'PHPUnit_Runner_Filter_Group_Include' => 'PHPUnit\Runner\Filter\IncludeGroupFilterIterator',
+        'PHPUnit_TextUI_Command' => 'PHPUnit\TextUI\Command',
+        'PHPUnit_TextUI_ResultPrinter' => 'PHPUnit\TextUI\ResultPrinter',
+        'PHPUnit_TextUI_TestRunner' => 'PHPUnit\TextUI\TestRunner',
+        'PHPUnit_Util_Blacklist' => 'PHPUnit\Util\Blacklist',
+        'PHPUnit_Util_Configuration' => 'PHPUnit\Util\Configuration',
+        'PHPUnit_Util_ConfigurationGenerator' => 'PHPUnit\Util\ConfigurationGenerator',
+        'PHPUnit_Util_ErrorHandler' => 'PHPUnit\Util\ErrorHandler',
+        'PHPUnit_Util_Fileloader' => 'PHPUnit\Util\Fileloader',
+        'PHPUnit_Util_Filesystem' => 'PHPUnit\Util\Filesystem',
+        'PHPUnit_Util_Filter' => 'PHPUnit\Util\Filter',
+        'PHPUnit_Util_Getopt' => 'PHPUnit\Util\Getopt',
+        'PHPUnit_Util_GlobalState' => 'PHPUnit\Util\GlobalState',
+        'PHPUnit_Util_InvalidArgumentHelper' => 'PHPUnit\Util\InvalidArgumentHelper',
+        'PHPUnit_Util_PHP' => 'PHPUnit\Util\PHP\AbstractPhpProcess',
+        'PHPUnit_Util_PHP_Default' => 'PHPUnit\Util\PHP\DefaultPhpProcess',
+        'PHPUnit_Util_PHP_Windows' => 'PHPUnit\Util\PHP\WindowsPhpProcesPhpProcess',
+        'PHPUnit_Util_Log_JUnit' => 'PHPUnit\Util\Log\JUnit',
+        'PHPUnit_Util_Log_TeamCity' => 'PHPUnit\Util\Log\TeamCity',
+        'PHPUnit_Util_TestDox_NamePrettifier' => 'PHPUnit\Util\TestDox\NamePrettifier',
+        'PHPUnit_Util_TestDox_ResultPrinter' => 'PHPUnit\Util\TestDox\ResultPrinter',
+        'PHPUnit_Util_TestDox_ResultPrinter_HTML' => 'PHPUnit\Util\TestDox\HtmlResultPrinter',
+        'PHPUnit_Util_TestDox_ResultPrinter_Text' => 'PHPUnit\Util\TestDox\TextResultPrinter',
+        'PHPUnit_Util_TestDox_ResultPrinter_XML' => 'PHPUnit\Util\TestDox\XmlResultPrinter',
+        'PHPUnit_Util_Printer' => 'PHPUnit\Util\Printer',
+        'PHPUnit_Util_Regex' => 'PHPUnit\Util\RegularExpression',
+        'PHPUnit_Util_String' => 'PHPUnit\Util\Utf8',
+        'PHPUnit_Util_XML' => 'PHPUnit\Util\XML',
+        'PHPUnit_Util_TestSuiteIterator' => 'PHPUnit\Framework\TestSuiteIterator',
+        'PHPUnit_Util_Type' => 'PHPUnit\Util\Type',
+        'PHPUnit_Util_Test' => 'PHPUnit\Util\Test',
+    ], 'phpunit/phpunit', '>=6.0');
+
+    // the "scenario" annotation was dropped in PHPUnit 7.0
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameAnnotationRector::class, [
+        new RenameAnnotationByType('PHPUnit\Framework\TestCase', 'scenario', 'test'),
+    ], 'phpunit/phpunit', '>=7.0');
+
+    // the TestCase methods were given native types in PHPUnit 8.0
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AddParamTypeDeclarationRector::class, [
+        // @see https://github.com/rectorphp/rector/issues/1024 - no type, $dataName
+        new AddParamTypeDeclaration('PHPUnit\Framework\TestCase', MethodName::CONSTRUCT, 2, new MixedType()),
+    ], 'phpunit/phpunit', '>=8.0');
+
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'setUpBeforeClass', new VoidType()),
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'setUp', new VoidType()),
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'assertPreConditions', new VoidType()),
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'assertPostConditions', new VoidType()),
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'tearDown', new VoidType()),
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'tearDownAfterClass', new VoidType()),
+        new AddReturnTypeDeclaration('PHPUnit\Framework\TestCase', 'onNotSuccessfulTest', new VoidType()),
+    ], 'phpunit/phpunit', '>=8.0');
+
+    // the expectDeprecationMessage(), expectNoticeMessage(), expectWarningMessage() and expectErrorMessage()
+    // methods were removed in PHPUnit 10.0
+    // @see https://github.com/sebastianbergmann/phpunit/issues/5062
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectDeprecationMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectDeprecationMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectNoticeMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectNoticeMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectWarningMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectWarningMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+        new MethodCallRename('PHPUnit\Framework\TestCase', 'expectErrorMessage', 'expectExceptionMessage'),
+        new MethodCallRename(
+            'PHPUnit\Framework\TestCase',
+            'expectErrorMessageMatches',
+            'expectExceptionMessageMatches'
+        ),
+    ], 'phpunit/phpunit', '>=10.0');
+    // the attributes replacing these annotations were all added in PHPUnit 10.0
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AnnotationWithValueToAttributeRector::class, [
+        new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [
+            'enabled' => true,
+            'disabled' => false,
+        ]),
+        new AnnotationWithValueToAttribute('backupStaticAttributes', 'PHPUnit\Framework\Attributes\BackupStaticProperties', [
+            'enabled' => true,
+            'disabled' => false,
+        ]),
+        new AnnotationWithValueToAttribute('preserveGlobalState', 'PHPUnit\Framework\Attributes\PreserveGlobalState', [
+            'enabled' => true,
+            'disabled' => false,
+        ]),
+
+        new AnnotationWithValueToAttribute('depends', 'PHPUnit\Framework\Attributes\Depends'),
+        new AnnotationWithValueToAttribute('group', 'PHPUnit\Framework\Attributes\Group'),
+        new AnnotationWithValueToAttribute('uses', 'PHPUnit\Framework\Attributes\UsesClass', [], true),
+        new AnnotationWithValueToAttribute('testDox', 'PHPUnit\Framework\Attributes\TestDox'),
+        new AnnotationWithValueToAttribute('testdox', 'PHPUnit\Framework\Attributes\TestDox'),
+    ], 'phpunit/phpunit', '>=10.0');
+
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AnnotationToAttributeRector::class, [
+        // @see https://github.com/sebastianbergmann/phpunit/issues/4502
+        new AnnotationToAttribute('after', 'PHPUnit\Framework\Attributes\After'),
+        new AnnotationToAttribute('afterClass', 'PHPUnit\Framework\Attributes\AfterClass'),
+        new AnnotationToAttribute('before', 'PHPUnit\Framework\Attributes\Before'),
+        new AnnotationToAttribute('beforeClass', 'PHPUnit\Framework\Attributes\BeforeClass'),
+        // CodeCoverageIgnore attribute is deprecated.
+        // @see https://github.com/rectorphp/rector-phpunit/pull/304
+        // new AnnotationToAttribute('codeCoverageIgnore', 'PHPUnit\Framework\Attributes\CodeCoverageIgnore'),
+        new AnnotationToAttribute('coversNothing', 'PHPUnit\Framework\Attributes\CoversNothing'),
+        new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
+        new AnnotationToAttribute('large', 'PHPUnit\Framework\Attributes\Large'),
+        new AnnotationToAttribute('medium', 'PHPUnit\Framework\Attributes\Medium'),
+        new AnnotationToAttribute('preCondition', 'PHPUnit\Framework\Attributes\PreCondition'),
+        new AnnotationToAttribute('postCondition', 'PHPUnit\Framework\Attributes\PostCondition'),
+        new AnnotationToAttribute('runInSeparateProcess', 'PHPUnit\Framework\Attributes\RunInSeparateProcess'),
+        new AnnotationToAttribute(
+            'runTestsInSeparateProcesses',
+            'PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses'
+        ),
+        new AnnotationToAttribute('small', 'PHPUnit\Framework\Attributes\Small'),
+        new AnnotationToAttribute('test', 'PHPUnit\Framework\Attributes\Test'),
+    ], 'phpunit/phpunit', '>=10.0');
 };

--- a/rules-tests/PHPUnit90/Rector/Class_/TestListenerToHooksRector/TestListenerToHooksRectorTest.php
+++ b/rules-tests/PHPUnit90/Rector/Class_/TestListenerToHooksRector/TestListenerToHooksRectorTest.php
@@ -25,4 +25,12 @@ final class TestListenerToHooksRectorTest extends AbstractRectorTestCase
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    /**
+     * The rule is bound to a PHPUnit version older than the one installed here
+     */
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/PHPUnit90/Rector/Class_/TestListenerToHooksRector/config/composer.json
+++ b/rules-tests/PHPUnit90/Rector/Class_/TestListenerToHooksRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpunit/phpunit": "^9.0"
+    }
+}

--- a/rules-tests/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector/ExplicitPhpErrorApiRectorTest.php
+++ b/rules-tests/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector/ExplicitPhpErrorApiRectorTest.php
@@ -25,4 +25,12 @@ final class ExplicitPhpErrorApiRectorTest extends AbstractRectorTestCase
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    /**
+     * The rule is bound to a PHPUnit version older than the one installed here
+     */
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector/config/composer.json
+++ b/rules-tests/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpunit/phpunit": "^9.0"
+    }
+}

--- a/rules/PHPUnit100/Rector/Class_/AddProphecyTraitRector.php
+++ b/rules/PHPUnit100/Rector/Class_/AddProphecyTraitRector.php
@@ -14,6 +14,8 @@ use Rector\PHPUnit\Enum\ProphecyClassName;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,8 +26,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\AddProphecyTraitRector\AddProphecyTraitRectorTest
  */
-final class AddProphecyTraitRector extends AbstractRector
+final class AddProphecyTraitRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,

--- a/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
+++ b/rules/PHPUnit100/Rector/Class_/ParentTestClassConstructorRector.php
@@ -16,6 +16,8 @@ use PhpParser\Node\Stmt\Expression;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,8 +27,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector\ParentTestClassConstructorRectorTest
  */
-final class ParentTestClassConstructorRector extends AbstractRector
+final class ParentTestClassConstructorRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {

--- a/rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php
+++ b/rules/PHPUnit100/Rector/Class_/PublicDataProviderClassMethodRector.php
@@ -11,14 +11,24 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\PublicDataProviderClassMethodRector\PublicDataProviderClassMethodRectorTest
  */
-final class PublicDataProviderClassMethodRector extends AbstractRector
+final class PublicDataProviderClassMethodRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,

--- a/rules/PHPUnit100/Rector/Class_/StaticDataProviderClassMethodRector.php
+++ b/rules/PHPUnit100/Rector/Class_/StaticDataProviderClassMethodRector.php
@@ -13,14 +13,24 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\StaticDataProviderClassMethodRectorTest
  */
-final class StaticDataProviderClassMethodRector extends AbstractRector
+final class StaticDataProviderClassMethodRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,

--- a/rules/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
+++ b/rules/PHPUnit100/Rector/MethodCall/PropertyExistsWithoutAssertRector.php
@@ -13,6 +13,8 @@ use PhpParser\Node\Name;
 use Rector\PHPUnit\NodeAnalyzer\IdentifierManipulator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,8 +23,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\PropertyExistsWithoutAssertRector\PropertyExistsWithoutAssertRectorTest
  */
-final class PropertyExistsWithoutAssertRector extends AbstractRector
+final class PropertyExistsWithoutAssertRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     /**
      * @var array<string, string>
      */

--- a/rules/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector.php
+++ b/rules/PHPUnit100/Rector/MethodCall/RemoveSetMethodsMethodCallRector.php
@@ -12,6 +12,8 @@ use PHPStan\Type\ObjectType;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,8 +24,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\MethodCall\RemoveSetMethodsMethodCallRector\RemoveSetMethodsMethodCallRectorTest
  */
-final class RemoveSetMethodsMethodCallRector extends AbstractRector
+final class RemoveSetMethodsMethodCallRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ValueResolver $valueResolver,

--- a/rules/PHPUnit100/Rector/StmtsAwareInterface/WithConsecutiveRector.php
+++ b/rules/PHPUnit100/Rector/StmtsAwareInterface/WithConsecutiveRector.php
@@ -29,14 +29,24 @@ use Rector\PHPUnit\NodeFinder\MethodCallNodeFinder;
 use Rector\PHPUnit\PHPUnit100\NodeDecorator\WillReturnIfNodeDecorator;
 use Rector\PHPUnit\PHPUnit100\NodeFactory\WillReturnCallbackFactory;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\StmtsAwareInterface\WithConsecutiveRector\WithConsecutiveRectorTest
  */
-final class WithConsecutiveRector extends AbstractRector
+final class WithConsecutiveRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 10.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=10.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly WillReturnCallbackFactory $willReturnCallbackFactory,

--- a/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
+++ b/rules/PHPUnit110/Rector/Class_/NamedArgumentForDataProviderRector.php
@@ -16,6 +16,8 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,8 +26,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://github.com/sebastianbergmann/phpunit/pull/5225
  * @see \Rector\PHPUnit\Tests\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector\StaticDataProviderClassMethodRectorTest
  */
-final class NamedArgumentForDataProviderRector extends AbstractRector
+final class NamedArgumentForDataProviderRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 11.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=11.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
     ) {

--- a/rules/PHPUnit50/Rector/StaticCall/GetMockRector.php
+++ b/rules/PHPUnit50/Rector/StaticCall/GetMockRector.php
@@ -12,6 +12,8 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,8 +23,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit50\Rector\StaticCall\GetMockRector\GetMockRectorTest
  */
-final class GetMockRector extends AbstractRector
+final class GetMockRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * createMock() was added in PHPUnit 5.4
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=5.4');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,

--- a/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -15,6 +15,8 @@ use Rector\PHPUnit\NodeAnalyzer\AssertCallAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\MockedVariableAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,8 +26,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\AddDoesNotPerformAssertionToNonAssertingTestRectorTest
  */
-final class AddDoesNotPerformAssertionToNonAssertingTestRector extends AbstractRector
+final class AddDoesNotPerformAssertionToNonAssertingTestRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 6.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=6.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly AssertCallAnalyzer $assertCallAnalyzer,

--- a/rules/PHPUnit60/Rector/ClassMethod/ExceptionAnnotationRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/ExceptionAnnotationRector.php
@@ -13,6 +13,8 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFactory\ExpectExceptionMethodCallFactory;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,8 +24,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\ExceptionAnnotationRector\ExceptionAnnotationRectorTest
  */
-final class ExceptionAnnotationRector extends AbstractRector
+final class ExceptionAnnotationRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * expectException() was added in PHPUnit 5.2
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=5.2');
+    }
+
     /**
      * In reversed order, which they should be called in code.
      *

--- a/rules/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/PHPUnit60/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -13,14 +13,24 @@ use Rector\PhpParser\Enum\NodeGroup;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFactory\AssertCallFactory;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\DelegateExceptionArgumentsRector\DelegateExceptionArgumentsRectorTest
  */
-final class DelegateExceptionArgumentsRector extends AbstractRector
+final class DelegateExceptionArgumentsRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * expectExceptionMessage() and expectExceptionCode() were added in PHPUnit 5.2
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=5.2');
+    }
+
     /**
      * @var array<string, string>
      */

--- a/rules/PHPUnit60/Rector/MethodCall/GetMockBuilderGetMockToCreateMockRector.php
+++ b/rules/PHPUnit60/Rector/MethodCall/GetMockBuilderGetMockToCreateMockRector.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -17,8 +19,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector\GetMockBuilderGetMockToCreateMockRectorTest
  */
-final class GetMockBuilderGetMockToCreateMockRector extends AbstractRector
+final class GetMockBuilderGetMockToCreateMockRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * createMock() was added in PHPUnit 5.4
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=5.4');
+    }
+
     /**
      * @var string[]
      */

--- a/rules/PHPUnit70/Rector/Class_/RemoveDataProviderTestPrefixRector.php
+++ b/rules/PHPUnit70/Rector/Class_/RemoveDataProviderTestPrefixRector.php
@@ -12,6 +12,8 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFinder\DataProviderClassMethodFinder;
 use Rector\PHPUnit\PhpDoc\DataProviderMethodRenamer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,8 +22,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit70\Rector\Class_\RemoveDataProviderTestPrefixRector\RemoveDataProviderTestPrefixRectorTest
  */
-final class RemoveDataProviderTestPrefixRector extends AbstractRector
+final class RemoveDataProviderTestPrefixRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 7.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=7.0');
+    }
+
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly DataProviderClassMethodFinder $dataProviderClassMethodFinder,

--- a/rules/PHPUnit80/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
+++ b/rules/PHPUnit80/Rector/MethodCall/AssertEqualsParameterToSpecificMethodsTypeRector.php
@@ -11,6 +11,8 @@ use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFactory\AssertCallFactory;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,8 +23,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit80\Rector\MethodCall\AssertEqualsParameterToSpecificMethodsTypeRector\AssertEqualsParameterToSpecificMethodsTypeRectorTest
  */
-final class AssertEqualsParameterToSpecificMethodsTypeRector extends AbstractRector
+final class AssertEqualsParameterToSpecificMethodsTypeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * the assertEqualsWithDelta() family was added in PHPUnit 7.5
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=7.5');
+    }
+
     public function __construct(
         private readonly AssertCallFactory $assertCallFactory,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,

--- a/rules/PHPUnit80/Rector/MethodCall/SpecificAssertContainsRector.php
+++ b/rules/PHPUnit80/Rector/MethodCall/SpecificAssertContainsRector.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Identifier;
 use PHPStan\Type\TypeCombinator;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,8 +22,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit80\Rector\MethodCall\SpecificAssertContainsRector\SpecificAssertContainsRectorTest
  */
-final class SpecificAssertContainsRector extends AbstractRector
+final class SpecificAssertContainsRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * the assertStringContainsString() family was added in PHPUnit 7.5
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=7.5');
+    }
+
     /**
      * @var array<string, string>
      */

--- a/rules/PHPUnit80/Rector/MethodCall/SpecificAssertInternalTypeRector.php
+++ b/rules/PHPUnit80/Rector/MethodCall/SpecificAssertInternalTypeRector.php
@@ -11,6 +11,8 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,8 +22,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit80\Rector\MethodCall\SpecificAssertInternalTypeRector\SpecificAssertInternalTypeRectorTest
  */
-final class SpecificAssertInternalTypeRector extends AbstractRector
+final class SpecificAssertInternalTypeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * the assertIsArray() family was added in PHPUnit 7.5
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=7.5');
+    }
+
     /**
      * @var array<string, string[]>
      */

--- a/rules/PHPUnit90/Rector/Class_/TestListenerToHooksRector.php
+++ b/rules/PHPUnit90/Rector/Class_/TestListenerToHooksRector.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,8 +24,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://github.com/sebastianbergmann/phpunit/tree/master/src/Runner/Hook
  * @see \Rector\PHPUnit\Tests\PHPUnit90\Rector\Class_\TestListenerToHooksRector\TestListenerToHooksRectorTest
  */
-final class TestListenerToHooksRector extends AbstractRector
+final class TestListenerToHooksRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 9.0 set; the hook interfaces were removed in PHPUnit 10.0
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=9.0 <10.0');
+    }
+
     /**
      * @var array<string, array<class-string|string>>
      */

--- a/rules/PHPUnit90/Rector/MethodCall/AssertRegExpRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/AssertRegExpRector.php
@@ -20,14 +20,24 @@ use Rector\PhpParser\Enum\NodeGroup;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\PHPUnit\Tests\PHPUnit90\Rector\MethodCall\AssertRegExpRector\AssertRegExpRectorTest
  */
-final class AssertRegExpRector extends AbstractRector
+final class AssertRegExpRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * assertMatchesRegularExpression() was added in PHPUnit 9.1
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=9.1');
+    }
+
     private const string ASSERT_SAME = 'assertSame';
 
     private const string ASSERT_EQUALS = 'assertEquals';

--- a/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/ExplicitPhpErrorApiRector.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Expr\StaticCall;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\PHPUnit\NodeFactory\AssertCallFactory;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,8 +23,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\PHPUnit\Tests\PHPUnit90\Rector\MethodCall\ExplicitPhpErrorApiRector\ExplicitPhpErrorApiRectorTest
  */
-final class ExplicitPhpErrorApiRector extends AbstractRector
+final class ExplicitPhpErrorApiRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * the expectDeprecation() family was added in PHPUnit 8.4 and removed in PHPUnit 10.0
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=8.4 <10.0');
+    }
+
     /**
      * @var array<string, string>
      */

--- a/rules/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
+++ b/rules/PHPUnit90/Rector/MethodCall/SpecificAssertContainsWithoutIdentityRector.php
@@ -12,6 +12,8 @@ use PHPStan\Type\StringType;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,8 +21,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://github.com/sebastianbergmann/phpunit/issues/3426
  * @see \Rector\PHPUnit\Tests\PHPUnit90\Rector\MethodCall\SpecificAssertContainsWithoutIdentityRector\SpecificAssertContainsWithoutIdentityRectorTest
  */
-final class SpecificAssertContainsWithoutIdentityRector extends AbstractRector
+final class SpecificAssertContainsWithoutIdentityRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * inherited from the PHPUnit 9.0 set
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=9.0');
+    }
+
     /**
      * @var array<string, array<string, string>>
      */

--- a/src/Set/SetProvider/PHPUnitSetProvider.php
+++ b/src/Set/SetProvider/PHPUnitSetProvider.php
@@ -69,26 +69,6 @@ final class PHPUnitSetProvider implements SetProviderInterface
                 '11.0',
                 __DIR__ . '/../../../config/sets/phpunit110.php'
             ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '12.0',
-                __DIR__ . '/../../../config/sets/phpunit120.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '12.5',
-                __DIR__ . '/../../../config/sets/phpunit125.php'
-            ),
-
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '13.0',
-                __DIR__ . '/../../../config/sets/phpunit130.php'
-            ),
-
             // applies to any installed PHPUnit version, the rules and configuration inside are bound
             // to the exact version they are available from
             new ComposerTriggeredSet(

--- a/src/Set/SetProvider/PHPUnitSetProvider.php
+++ b/src/Set/SetProvider/PHPUnitSetProvider.php
@@ -7,7 +7,6 @@ namespace Rector\PHPUnit\Set\SetProvider;
 use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
-use Rector\Set\ValueObject\ComposerTriggeredSet;
 use Rector\Set\ValueObject\Set;
 
 /**
@@ -21,62 +20,9 @@ final class PHPUnitSetProvider implements SetProviderInterface
     public function provide(): array
     {
         return [
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '4.0',
-                __DIR__ . '/../../../config/sets/phpunit40.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '5.0',
-                __DIR__ . '/../../../config/sets/phpunit50.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '6.0',
-                __DIR__ . '/../../../config/sets/phpunit60.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '7.0',
-                __DIR__ . '/../../../config/sets/phpunit70.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '8.0',
-                __DIR__ . '/../../../config/sets/phpunit80.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '9.0',
-                __DIR__ . '/../../../config/sets/phpunit90.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '10.0',
-                __DIR__ . '/../../../config/sets/phpunit100.php'
-            ),
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '11.0',
-                __DIR__ . '/../../../config/sets/phpunit110.php'
-            ),
-            // applies to any installed PHPUnit version, the rules and configuration inside are bound
-            // to the exact version they are available from
-            new ComposerTriggeredSet(
-                SetGroup::PHPUNIT,
-                'phpunit/phpunit',
-                '>=4.0',
-                __DIR__ . '/../../../config/sets/composer-based.php'
-            ),
+            // holds every rule bound to the exact PHPUnit version it is available from,
+            // so the whole set can be run at once, no matter the PHPUnit version in the project
+            new Set(SetGroup::PHPUNIT, 'Composer Based', __DIR__ . '/../../../config/sets/composer-based.php'),
 
             new Set(SetGroup::PHPUNIT, 'Code Quality', __DIR__ . '/../../../config/sets/phpunit-code-quality.php'),
 

--- a/tests/ComposerBased/Fixture/backup_static_properties.php.inc
+++ b/tests/ComposerBased/Fixture/backup_static_properties.php.inc
@@ -9,6 +9,7 @@ class BackupStaticPropertiesTest extends TestCase
      */
     public function testSomething()
     {
+        $this->assertTrue(true);
     }
 
     /**
@@ -16,6 +17,7 @@ class BackupStaticPropertiesTest extends TestCase
      */
     public function testSomethingElse()
     {
+        $this->assertTrue(true);
     }
 }
 
@@ -30,11 +32,13 @@ class BackupStaticPropertiesTest extends TestCase
     #[\PHPUnit\Framework\Attributes\BackupStaticProperties(true)]
     public function testSomething()
     {
+        $this->assertTrue(true);
     }
 
     #[\PHPUnit\Framework\Attributes\ExcludeGlobalVariableFromBackup('someGlobalVariable')]
     public function testSomethingElse()
     {
+        $this->assertTrue(true);
     }
 }
 

--- a/tests/ComposerBased/Fixture/skip_run_class_in_separate_process.php.inc
+++ b/tests/ComposerBased/Fixture/skip_run_class_in_separate_process.php.inc
@@ -9,5 +9,6 @@ class RunClassInSeparateProcessTest extends TestCase
 {
     public function testSomething()
     {
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
Follow-up to #757, which removed the three already-covered sets. This moves the remaining eight — PHPUnit 4.0 through 11.0 — into `composer-based.php`, so **no `ComposerTriggeredSet` is left in this package**.

Each rule now declares the PHPUnit version its target API is available from:

```php
final class GetMockRector extends AbstractRector implements ComposerPackageConstraintInterface
{
    /**
     * createMock() was added in PHPUnit 5.4
     */
    public function provideComposerPackageConstraint(): ComposerPackageConstraint
    {
        return new ComposerPackageConstraint('phpunit/phpunit', '>=5.4');
    }
```

That is what makes one set enough. A project upgrading from PHPUnit 6 straight to 12 previously needed every version set in between; now a single set applies exactly the rules its installed version supports.

### Version bonds

Grounded in the API that the rule produces:

| rule | bond | why |
|---|---|---|
| `GetMockRector`, `GetMockBuilderGetMockToCreateMockRector` | `>=5.4` | `createMock()` |
| `ExceptionAnnotationRector`, `DelegateExceptionArgumentsRector` | `>=5.2` | `expectException()`, `expectExceptionMessage()` |
| `SpecificAssertInternalTypeRector`, `SpecificAssertContainsRector`, `AssertEqualsParameterToSpecificMethodsTypeRector` | `>=7.5` | `assertIsArray()`, `assertStringContainsString()`, `assertEqualsWithDelta()` |
| `AssertRegExpRector` | `>=9.1` | `assertMatchesRegularExpression()` |
| `ExplicitPhpErrorApiRector` | `>=8.4 <10.0` | the `expectDeprecation()` family, removed in 10.0 |
| `TestListenerToHooksRector` | `>=9.0 <10.0` | the hook interfaces, removed in 10.0 |

The remaining rules keep the version of the set they came from, marked as such in their docblock (`inherited from the PHPUnit 10.0 set`). That never applies a rule below where its set already claimed it worked, and the bond can be tightened to an exact minor later.

### Upper bounds and their tests

`ExplicitPhpErrorApiRector` and `TestListenerToHooksRector` target APIs PHPUnit 10 removed. Left open-ended they would rewrite code on PHPUnit 12 into methods that no longer exist, so both carry `<10.0` — which then disables them under the PHPUnit 13 installed here. Their tests read the version from a stub instead:

```php
protected function provideComposerJsonFilePath(): string
{
    return __DIR__ . '/config/composer.json';
}
```

### Two things deliberately left out

**`PropertyExistsWithoutAssertRector` is not registered in composer-based.** It matches `assertObjectHasProperty()` — the exact method the `>=10.1` rename already in this set produces — so the two rewrite each other's output. The conflict is not new (both sat in the `phpunit100` set together), but I did not want to encode its outcome as expected test output. Worth a separate look; the rule keeps its bond and its set file registration.

**Duplicate configuration was dropped rather than moved.** The `phpunit90` and `phpunit100` renames of `assertRegExp()`, `assertObjectHasAttribute()`, `setMethods()` and the file/directory asserts are already in composer-based against `PHPUnit\Framework\Assert`, which `TestCase` extends. Same for `phpunit80`'s `MockObject` class rename, already covered by the `>=6.0` map.

### Fixtures

Two composer-based fixtures gained an `assertTrue(true)`. `AddDoesNotPerformAssertionToNonAssertingTestRector` is now part of the set and was adding `#[DoesNotPerformAssertions]` to their empty test methods, which had nothing to do with what those fixtures test.

Green locally: 652 tests, PHPStan, ECS and Rector clean.
