### PR TITLE
[PHPUnit60] Skip Twig IntegrationTestCase children in AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_twig_integration_test_case.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_twig_integration_test_case.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+use Twig\Test\IntegrationTestCase;
+
+final class SkipTwigIntegrationTestCase extends IntegrationTestCase
+{
+    public function testIntegration($file, $message, $condition, $templates, $exception, $outputs)
+    {
+        $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs);
+    }
+}

--- a/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -8,13 +8,16 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\AssertCallAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\MockedVariableAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -43,6 +46,7 @@ final class AddDoesNotPerformAssertionToNonAssertingTestRector extends AbstractR
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly ReflectionResolver $reflectionResolver,
     ) {
     }
 
@@ -122,6 +126,11 @@ CODE_SAMPLE
             return true;
         }
 
+        // the parent test case asserts in its own integration methods
+        if ($this->isInTwigIntegrationTestCase($classMethod)) {
+            return true;
+        }
+
         if ($this->hasAssertingAnnotationOrAttribute($classMethod)) {
             return true;
         }
@@ -132,6 +141,16 @@ CODE_SAMPLE
         }
 
         return $this->mockedVariableAnalyzer->containsMockAsUsedVariable($classMethod);
+    }
+
+    private function isInTwigIntegrationTestCase(ClassMethod $classMethod): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->is(PHPUnitClassName::TWIG_INTEGRATION_TEST_CASE);
     }
 
     private function hasAssertingAnnotationOrAttribute(ClassMethod $classMethod): bool

--- a/src/Enum/PHPUnitClassName.php
+++ b/src/Enum/PHPUnitClassName.php
@@ -34,6 +34,8 @@ final class PHPUnitClassName
 
     public const string SYMFONY_TYPE_TEST_CASE = 'Symfony\Component\Form\Test\TypeTestCase';
 
+    public const string TWIG_INTEGRATION_TEST_CASE = 'Twig\Test\IntegrationTestCase';
+
     /**
      * @var string[]
      */

--- a/stubs/Twig/Test/IntegrationTestCase.php
+++ b/stubs/Twig/Test/IntegrationTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Twig\Test;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    /**
+     * @param array<string, string> $templates
+     * @param array<string> $outputs
+     */
+    protected function doIntegrationTest(
+        string $file,
+        string $message,
+        string $condition,
+        array $templates,
+        string $exception,
+        array $outputs,
+        string $deprecation = ''
+    ): void {
+    }
+}


### PR DESCRIPTION
`\Twig\Test\IntegrationTestCase` children got `@doesNotPerformAssertions` added, even though the parent class asserts inside `doIntegrationTest()`.

The assert-call walker only sees the child method calling `$this->doIntegrationTest(...)`; the assertions live deeper in the Twig parent, so the rule concluded nothing is asserted.

```diff
 use Twig\Test\IntegrationTestCase;

 final class SomeTwigExtensionTest extends IntegrationTestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs)
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs);
     }
 }
```

Now such class methods are skipped. The check uses `ClassReflection::is()`, so intermediate abstract test cases extending `IntegrationTestCase` are skipped too.
