### PR TITLE
[PHPUnit60] Remove addToAssertionCount() calls in AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class RemoveAddToAssertionCount extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->someMethodCall();
+        $this->addToAssertionCount(1);
+    }
+
+    private function someMethodCall()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class RemoveAddToAssertionCount extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function test()
+    {
+        $this->someMethodCall();
+    }
+
+    private function someMethodCall()
+    {
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_in_try_catch.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_in_try_catch.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class RemoveAddToAssertionCountInTryCatch extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        try {
+            $this->someMethodCall();
+            $this->addToAssertionCount(1);
+        } catch (\Throwable $throwable) {
+        }
+    }
+
+    private function someMethodCall()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class RemoveAddToAssertionCountInTryCatch extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function test()
+    {
+        try {
+            $this->someMethodCall();
+        } catch (\Throwable $throwable) {
+        }
+    }
+
+    private function someMethodCall()
+    {
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_with_comment.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_with_comment.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class RemoveAddToAssertionCountWithComment extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->someMethodCall();
+
+        $this->addToAssertionCount(1); // Verify that no exception is thrown
+    }
+
+    private function someMethodCall()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class RemoveAddToAssertionCountWithComment extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function test()
+    {
+        $this->someMethodCall();
+    }
+
+    private function someMethodCall()
+    {
+    }
+}
+
+?>

--- a/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Rector\PHPUnit\PHPUnit60\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\NodeVisitor;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
@@ -104,6 +108,8 @@ CODE_SAMPLE
             return null;
         }
 
+        $this->removeAddToAssertionCountCalls($node);
+
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $phpDocInfo->addPhpDocTagNode(new PhpDocTagNode('@doesNotPerformAssertions', new GenericTagValueNode('')));
 
@@ -141,6 +147,49 @@ CODE_SAMPLE
         }
 
         return $this->mockedVariableAnalyzer->containsMockAsUsedVariable($classMethod);
+    }
+
+    /**
+     * The assertion count fakes an assertion, but the "@doesNotPerformAssertions" annotation makes it obsolete
+     */
+    private function removeAddToAssertionCountCalls(ClassMethod $classMethod): void
+    {
+        $hasJustRemovedCall = false;
+
+        $this->traverseNodesWithCallable($classMethod, function (Node $node) use (&$hasJustRemovedCall): ?int {
+            // a comment on the same line as the removed call is parsed as a nop statement right behind it
+            if ($hasJustRemovedCall && $node instanceof Nop) {
+                return NodeVisitor::REMOVE_NODE;
+            }
+
+            $hasJustRemovedCall = false;
+
+            if (! $this->isAddToAssertionCountExpression($node)) {
+                return null;
+            }
+
+            $hasJustRemovedCall = true;
+
+            return NodeVisitor::REMOVE_NODE;
+        });
+    }
+
+    private function isAddToAssertionCountExpression(Node $node): bool
+    {
+        if (! $node instanceof Expression) {
+            return false;
+        }
+
+        if (! $node->expr instanceof MethodCall) {
+            return false;
+        }
+
+        $methodCall = $node->expr;
+        if (! $this->isName($methodCall->var, 'this')) {
+            return false;
+        }
+
+        return $this->isName($methodCall->name, 'addToAssertionCount');
     }
 
     private function isInTwigIntegrationTestCase(ClassMethod $classMethod): bool


### PR DESCRIPTION
Once the `@doesNotPerformAssertions` annotation is added, any `$this->addToAssertionCount(1);` call in that method is dead weight - it only existed to fake an assertion so the test would not be reported as risky. The rule now removes those calls, including a trailing same-line comment.

```diff
 class SomeTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function test()
     {
         $this->someMethodCall();
-
-        $this->addToAssertionCount(1); // Verify that no exception is thrown
     }
 }
```

Nested calls are handled too, e.g. inside `try`/`catch` blocks. Methods that do contain a real assertion are skipped as before, so their `addToAssertionCount()` calls stay untouched.
