### PR TITLE
[PHPUnit120] Add AnyMatcherToNewAnyInvokedCountRector for deprecated any() matcher assign

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -30,6 +30,7 @@ use Rector\PHPUnit\PHPUnit110\Rector\CallLike\AssertContainsOnlyMethodCallRector
 use Rector\PHPUnit\PHPUnit110\Rector\Class_\NamedArgumentForDataProviderRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\ExpectsParamToMockObjectRector;
 use Rector\PHPUnit\PHPUnit110\Rector\ClassMethod\MockObjectArgCreateStubToCreateMockRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubInCoalesceArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector;
@@ -105,6 +106,9 @@ return static function (RectorConfig $rectorConfig): void {
 
         // the TestCase::__construct() is final since PHPUnit 12.0.3
         RemoveOverrideFinalConstructTestCaseRector::class,
+
+        // the any() matcher was deprecated in PHPUnit 12.5
+        AnyMatcherToNewAnyInvokedCountRector::class,
 
         // the AllowMockObjectsWithoutExpectations attribute exists since PHPUnit 12.5.2
         AllowMockObjectsWhereParentClassRector::class,

--- a/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/AnyMatcherToNewAnyInvokedCountRectorTest.php
+++ b/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/AnyMatcherToNewAnyInvokedCountRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AnyMatcherToNewAnyInvokedCountRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/Fixture/fixture.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    public function test(): void
+    {
+        $matcher = $this->any();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    public function test(): void
+    {
+        $matcher = new \PHPUnit\Framework\MockObject\Rule\AnyInvokedCount();
+    }
+}
+
+?>

--- a/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/Fixture/skip_non_test_case.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/Fixture/skip_non_test_case.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector\Fixture;
+
+final class SkipNonTestCase
+{
+    public function run(): void
+    {
+        $matcher = $this->any();
+    }
+
+    public function any(): string
+    {
+        return 'any';
+    }
+}

--- a/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/config/configured_rule.php
+++ b/rules-tests/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AnyMatcherToNewAnyInvokedCountRector::class);
+};

--- a/rules/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector.php
+++ b/rules/PHPUnit120/Rector/Assign/AnyMatcherToNewAnyInvokedCountRector.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\PHPUnit120\Rector\Assign;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name\FullyQualified;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * The TestCase::any() method was deprecated in PHPUnit 12.5
+ *
+ * @see https://github.com/sebastianbergmann/phpunit/issues/6461
+ *
+ * @see \Rector\PHPUnit\Tests\PHPUnit120\Rector\Assign\AnyMatcherToNewAnyInvokedCountRector\AnyMatcherToNewAnyInvokedCountRectorTest
+ */
+final class AnyMatcherToNewAnyInvokedCountRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    private const string ANY_INVOKED_COUNT_CLASS = 'PHPUnit\Framework\MockObject\Rule\AnyInvokedCount';
+
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+    ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('phpunit/phpunit', '>=12.5');
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change deprecated `$this->any()` matcher assign to direct `new AnyInvokedCount()`',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test(): void
+    {
+        $matcher = $this->any();
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test(): void
+    {
+        $matcher = new AnyInvokedCount();
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Assign::class];
+    }
+
+    /**
+     * @param Assign $node
+     */
+    public function refactor(Node $node): ?Assign
+    {
+        if (! $node->expr instanceof MethodCall) {
+            return null;
+        }
+
+        $methodCall = $node->expr;
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isName($methodCall->name, 'any')) {
+            return null;
+        }
+
+        if ($methodCall->getArgs() !== []) {
+            return null;
+        }
+
+        if (! $this->testsNodeAnalyzer->isPHPUnitTestCaseCall($methodCall)) {
+            return null;
+        }
+
+        $node->expr = new New_(new FullyQualified(self::ANY_INVOKED_COUNT_CLASS));
+
+        return $node;
+    }
+}


### PR DESCRIPTION
`TestCase::any()` is soft-deprecated since PHPUnit 12.5, hard-deprecated in 13.0 and removed in 14.0. See https://github.com/sebastianbergmann/phpunit/issues/6461

This rule flips the standalone matcher assign to a direct instance:

```diff
 use PHPUnit\Framework\TestCase;

 final class SomeTest extends TestCase
 {
     public function test(): void
     {
-        $matcher = $this->any();
+        $matcher = new \PHPUnit\Framework\MockObject\Rule\AnyInvokedCount();
     }
 }
```

Scope is deliberately narrow — only an `Assign` whose right side is a bare `$this->any()` on a `TestCase`/`Assert`. First-class callables, calls with args and non-PHPUnit `any()` methods are skipped. The `expects($this->any())` case is already covered by `RemoveExpectAnyFromMockRector`.

Registered in the composer-based set, bonded to `phpunit/phpunit >=12.5`.

Note: `AnyInvokedCount` is marked `@internal` upstream. The upstream advice is to restructure the test towards `createStub()` or a specific matcher, which is out of reach for an automated rewrite, so the direct instance is used as the closest mechanical equivalent.
