### PR TITLE
[PHPUnit60] Add DoesNotPerformAssertions attribute directly and skip traits

### DIFF
--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/fixture.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/fixture.php.inc
@@ -18,9 +18,7 @@ namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAss
 
 class SomeClass extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function test()
     {
         $nothing = 5;

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count.php.inc
@@ -23,9 +23,7 @@ namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAss
 
 class RemoveAddToAssertionCount extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function test()
     {
         $this->someMethodCall();

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_in_try_catch.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_in_try_catch.php.inc
@@ -26,9 +26,7 @@ namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAss
 
 class RemoveAddToAssertionCountInTryCatch extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function test()
     {
         try {

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_with_comment.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/remove_add_to_assertion_count_with_comment.php.inc
@@ -24,9 +24,7 @@ namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAss
 
 class RemoveAddToAssertionCountWithComment extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function test()
     {
         $this->someMethodCall();

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_trait.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_trait.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+trait SomeNonAssertingTrait
+{
+    public function testSomething()
+    {
+        $nothing = 5;
+    }
+}

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/test_in_annotation.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/test_in_annotation.php.inc
@@ -23,8 +23,8 @@ class TestInAnnotation extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
-     * @doesNotPerformAssertions
      */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function thisIsTest()
     {
         $nothing = 5;

--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/test_in_annotation_with_test_attribute.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/test_in_annotation_with_test_attribute.php.inc
@@ -19,10 +19,8 @@ namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAss
 
 class TestInAnnotationWithTestAttribute extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     #[\PHPUnit\Framework\Attributes\Test]
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function thisIsTest()
     {
         $nothing = 5;

--- a/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Rector\PHPUnit\PHPUnit60\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Nop;
@@ -13,9 +16,11 @@ use PhpParser\NodeVisitor;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\PHPUnit\Enum\PHPUnitAttribute;
 use Rector\PHPUnit\Enum\PHPUnitClassName;
 use Rector\PHPUnit\NodeAnalyzer\AssertCallAnalyzer;
 use Rector\PHPUnit\NodeAnalyzer\MockedVariableAnalyzer;
@@ -51,13 +56,14 @@ final class AddDoesNotPerformAssertionToNonAssertingTestRector extends AbstractR
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly ReflectionResolver $reflectionResolver,
+        private readonly ReflectionProvider $reflectionProvider,
     ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Tests without assertion will have @doesNotPerformAssertion',
+            'Tests without assertion will have #[DoesNotPerformAssertions] attribute, or @doesNotPerformAssertions annotation on PHPUnit below 10',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
@@ -77,9 +83,7 @@ use PHPUnit\Framework\TestCase;
 
 class SomeClass extends TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function test()
     {
         $nothing = 5;
@@ -110,6 +114,15 @@ CODE_SAMPLE
 
         $this->removeAddToAssertionCountCalls($node);
 
+        // the attribute is available since PHPUnit 10, prefer it over the annotation
+        if ($this->reflectionProvider->hasClass(PHPUnitAttribute::DOES_NOT_PERFORM_ASSERTIONS)) {
+            $node->attrGroups[] = new AttributeGroup([
+                new Attribute(new FullyQualified(PHPUnitAttribute::DOES_NOT_PERFORM_ASSERTIONS)),
+            ]);
+
+            return $node;
+        }
+
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $phpDocInfo->addPhpDocTagNode(new PhpDocTagNode('@doesNotPerformAssertions', new GenericTagValueNode('')));
 
@@ -129,6 +142,11 @@ CODE_SAMPLE
         }
 
         if ($classMethod->isAbstract()) {
+            return true;
+        }
+
+        // we have no idea how the trait is used, the using class can assert on its own
+        if ($this->isInTrait($classMethod)) {
             return true;
         }
 
@@ -192,6 +210,16 @@ CODE_SAMPLE
         return $this->isName($methodCall->name, 'addToAssertionCount');
     }
 
+    private function isInTrait(ClassMethod $classMethod): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->isTrait();
+    }
+
     private function isInTwigIntegrationTestCase(ClassMethod $classMethod): bool
     {
         $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
@@ -212,7 +240,7 @@ CODE_SAMPLE
 
         return $this->phpAttributeAnalyzer->hasPhpAttribute(
             $classMethod,
-            'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'
+            PHPUnitAttribute::DOES_NOT_PERFORM_ASSERTIONS
         );
     }
 }

--- a/src/Enum/PHPUnitAttribute.php
+++ b/src/Enum/PHPUnitAttribute.php
@@ -24,6 +24,8 @@ final class PHPUnitAttribute
 
     public const string TEST = 'PHPUnit\Framework\Attributes\Test';
 
+    public const string DOES_NOT_PERFORM_ASSERTIONS = 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions';
+
     /**
      * Since PHPUnit 12.5.2
      * @see https://github.com/sebastianbergmann/phpunit/commit/24c208d6a340c3071f28a9b5cce02b9377adfd43

--- a/tests/Issues/PHPUnit10DataProvider/Fixture/some_test.php.inc
+++ b/tests/Issues/PHPUnit10DataProvider/Fixture/some_test.php.inc
@@ -27,8 +27,8 @@ namespace Rector\PHPUnit\Tests\Issues\PHPUnit10DataProvider\Fixture;
 final class SomeTest extends \PHPUnit\Framework\TestCase
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('fooProvider')]
-    #[\PHPUnit\Framework\Attributes\Test]
     #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_should_do_stuff(string $foo): void
     {
     }


### PR DESCRIPTION
Two changes to `AddDoesNotPerformAssertionToNonAssertingTestRector`:

## 1) Add the attribute directly, when it exists

If `PHPUnit\Framework\Attributes\DoesNotPerformAssertions` is available (PHPUnit 10+), the attribute is added instead of the annotation. Projects on older PHPUnit keep getting the docblock annotation.

```diff
 final class SomeTest extends TestCase
 {
-    public function test()
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test()
     {
         $nothing = 5;
     }
 }
```

Previously this always produced:

```php
    /**
     * @doesNotPerformAssertions
     */
```

## 2) Skip traits

A trait method has no owning class, so there is no way to tell whether the class using it asserts elsewhere. Adding the attribute there can silence a real assertion check.

```php
trait SomeNonAssertingTrait
{
    // left as is
    public function testSomething()
    {
        $nothing = 5;
    }
}
```
