### PR TITLE
[PHPUnit60] Skip imported PHPUnit assert functions in AddDoesNotPerformAssertionToNonAssertingTestRector

### DIFF
--- a/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_imported_assert_function.php.inc
+++ b/rules-tests/PHPUnit60/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_imported_assert_function.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertNotNull;
+
+final class SkipImportedAssertFunction extends TestCase
+{
+    public function testSomething(): void
+    {
+        assertNotNull(true);
+    }
+
+    public function testFullyQualified(): void
+    {
+        \PHPUnit\Framework\assertTrue(true);
+    }
+}

--- a/src/NodeAnalyzer/AssertCallAnalyzer.php
+++ b/src/NodeAnalyzer/AssertCallAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PHPUnit\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
@@ -20,6 +21,11 @@ use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 final class AssertCallAnalyzer
 {
     private const int MAX_NESTED_METHOD_CALL_LEVEL = 5;
+
+    /**
+     * @see https://docs.phpunit.de/en/12.4/assertions.html
+     */
+    private const string PHPUNIT_FUNCTION_NAMESPACE = 'PHPUnit\Framework\\';
 
     /**
      * @var string[]
@@ -134,8 +140,32 @@ final class AssertCallAnalyzer
                 return $this->isAssertMethodCall($node);
             }
 
+            // standalone function assert, e.g. "use function PHPUnit\Framework\assertNotNull;"
+            if ($node instanceof FuncCall) {
+                return $this->isAssertFuncCall($node);
+            }
+
             return false;
         });
+    }
+
+    private function isAssertFuncCall(FuncCall $funcCall): bool
+    {
+        $funcCallName = $this->nodeNameResolver->getName($funcCall);
+        if (! is_string($funcCallName)) {
+            return false;
+        }
+
+        if (! str_starts_with($funcCallName, self::PHPUNIT_FUNCTION_NAMESPACE)) {
+            return false;
+        }
+
+        $shortFuncCallName = substr($funcCallName, strlen(self::PHPUNIT_FUNCTION_NAMESPACE));
+
+        return array_any(
+            self::ASSERT_METHOD_NAME_PREFIXES,
+            fn (string $assertMethodNamePrefix): bool => str_starts_with($shortFuncCallName, $assertMethodNamePrefix)
+        );
     }
 
     private function hasNestedAssertCall(ClassMethod $classMethod): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9848

`AddDoesNotPerformAssertionToNonAssertingTestRector` only looked for `$this->assert*()` method calls and `self::assert*()` static calls. Assertions called as standalone functions from the `PHPUnit\Framework` namespace were invisible to it, so tests using them were wrongly marked as non-asserting.

```diff
 use PHPUnit\Framework\TestCase;

 use function PHPUnit\Framework\assertNotNull;

 final class SomeTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testSomething(): void
     {
         assertNotNull(true);
     }
 }
```

`AssertCallAnalyzer` now also treats a `FuncCall` resolved to `PHPUnit\Framework\assert*` (and the other known assert prefixes) as an assertion, whether imported via `use function` or fully qualified.