### PR TITLE
[CodeQuality] Narrow assertTrue(is_<type>()) to assertIs<Type>()

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/is_type_functions.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/is_type_functions.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IsTypeFunctions extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(is_array($value));
+        $this->assertTrue(is_bool($value));
+        $this->assertTrue(is_callable($value));
+        $this->assertTrue(is_float($value));
+        $this->assertTrue(is_int($value));
+        $this->assertTrue(is_iterable($value));
+        $this->assertTrue(is_numeric($value));
+        $this->assertTrue(is_object($value));
+        $this->assertTrue(is_scalar($value));
+        $this->assertTrue(is_string($value), 'the value must be a string');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IsTypeFunctions extends TestCase
+{
+    public function test()
+    {
+        $this->assertIsArray($value);
+        $this->assertIsBool($value);
+        $this->assertIsCallable($value);
+        $this->assertIsFloat($value);
+        $this->assertIsInt($value);
+        $this->assertIsIterable($value);
+        $this->assertIsNumeric($value);
+        $this->assertIsObject($value);
+        $this->assertIsScalar($value);
+        $this->assertIsString($value, 'the value must be a string');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/is_type_functions_negated.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/is_type_functions_negated.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IsTypeFunctionsNegated extends TestCase
+{
+    public function test()
+    {
+        $this->assertFalse(is_callable($value));
+        $this->assertNotTrue(is_array($value));
+        $this->assertNotFalse(is_string($value));
+        self::assertFalse(is_object($value), 'the value must not be an object');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IsTypeFunctionsNegated extends TestCase
+{
+    public function test()
+    {
+        $this->assertIsNotCallable($value);
+        $this->assertIsNotArray($value);
+        $this->assertIsString($value);
+        self::assertIsNotObject($value, 'the value must not be an object');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/skip_is_callable_with_syntax_only.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/skip_is_callable_with_syntax_only.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipIsCallableWithSyntaxOnly extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(is_callable($value, true));
+        $this->assertTrue(is_callable($value, true, $callableName));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/skip_named_and_spread_args.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/skip_named_and_spread_args.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNamedAndSpreadArgs extends TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(is_string(value: $value));
+        $this->assertTrue(is_readable(filename: $file));
+        $this->assertTrue(is_string(...$args));
+        $this->assertTrue(in_array(needle: '...', haystack: ['...'], strict: true));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/skip_named_and_spread_args.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector/Fixture/skip_named_and_spread_args.php.inc
@@ -11,6 +11,7 @@ final class SkipNamedAndSpreadArgs extends TestCase
         $this->assertTrue(is_string(value: $value));
         $this->assertTrue(is_readable(filename: $file));
         $this->assertTrue(is_string(...$args));
+        $this->assertTrue(is_string(...));
         $this->assertTrue(in_array(needle: '...', haystack: ['...'], strict: true));
     }
 }

--- a/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -171,8 +171,11 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
     }
 
     /**
-     * The assert methods use different parameter names than the functions they replace,
-     * so named args cannot be moved up. The same goes for spread args, as their count is unknown.
+     * Args are moved up by position, so a named arg only survives when the assert method happens to
+     * use the same parameter name: is_readable(filename:) fits assertIsReadable(), while
+     * is_string(value:) does not fit assertIsString(), whose parameter is $actual. Bail out instead
+     * of tracking a parameter name per mapped function. Spread args cannot be moved up either,
+     * as their count is unknown.
      */
     private function hasUnmovableArgs(FuncCall $funcCall): bool
     {

--- a/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -179,6 +179,10 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
      */
     private function hasUnmovableArgs(FuncCall $funcCall): bool
     {
+        if ($funcCall->isFirstClassCallable()) {
+            return true;
+        }
+
         foreach ($funcCall->getArgs() as $arg) {
             if ($arg->name instanceof Identifier) {
                 return true;

--- a/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertTrueFalseToSpecificMethodRector.php
@@ -42,6 +42,16 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
         'is_nan' => ['is_nan', 'assertNan', ''],
         'is_a' => ['is_a', 'assertInstanceOf', 'assertNotInstanceOf'],
         'str_contains' => ['str_contains', 'assertStringContainsString', 'assertStringNotContainsString'],
+        'is_array' => ['is_array', 'assertIsArray', 'assertIsNotArray'],
+        'is_bool' => ['is_bool', 'assertIsBool', 'assertIsNotBool'],
+        'is_callable' => ['is_callable', 'assertIsCallable', 'assertIsNotCallable'],
+        'is_float' => ['is_float', 'assertIsFloat', 'assertIsNotFloat'],
+        'is_int' => ['is_int', 'assertIsInt', 'assertIsNotInt'],
+        'is_iterable' => ['is_iterable', 'assertIsIterable', 'assertIsNotIterable'],
+        'is_numeric' => ['is_numeric', 'assertIsNumeric', 'assertIsNotNumeric'],
+        'is_object' => ['is_object', 'assertIsObject', 'assertIsNotObject'],
+        'is_scalar' => ['is_scalar', 'assertIsScalar', 'assertIsNotScalar'],
+        'is_string' => ['is_string', 'assertIsString', 'assertIsNotString'],
     ];
 
     /**
@@ -115,6 +125,10 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
             return null;
         }
 
+        if ($firstArgumentValue instanceof FuncCall && $this->hasUnmovableArgs($firstArgumentValue)) {
+            return null;
+        }
+
         if ($firstArgumentName === 'is_a') {
             /** @var FuncCall $firstArgumentValue */
             $args = $firstArgumentValue->getArgs();
@@ -126,6 +140,14 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
 
             $firstArgumentType = $this->nodeTypeResolver->getType($args[0]->value);
             if ($firstArgumentType instanceof StringType) {
+                return null;
+            }
+        }
+
+        // the is_callable() $syntax_only and $callable_name arguments have no counterpart in assertIsCallable()
+        if ($firstArgumentName === 'is_callable') {
+            /** @var FuncCall $firstArgumentValue */
+            if (count($firstArgumentValue->getArgs()) > 1) {
                 return null;
             }
         }
@@ -146,6 +168,25 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
         return $firstArgumentValue instanceof Empty_
             ? 'empty'
             : $this->getName($firstArgumentValue);
+    }
+
+    /**
+     * The assert methods use different parameter names than the functions they replace,
+     * so named args cannot be moved up. The same goes for spread args, as their count is unknown.
+     */
+    private function hasUnmovableArgs(FuncCall $funcCall): bool
+    {
+        foreach ($funcCall->getArgs() as $arg) {
+            if ($arg->name instanceof Identifier) {
+                return true;
+            }
+
+            if ($arg->unpack) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function renameMethod(


### PR DESCRIPTION
`AssertTrueFalseToSpecificMethodRector` already narrows `assertTrue(is_readable(...))`, `assertTrue(is_null(...))` and friends, but the `is_<type>()` family was missing — so `$this->assertTrue(is_callable($value))` stayed as a generic boolean assertion instead of becoming `$this->assertIsCallable($value)`.
The generic form loses the failure message: `assertTrue()` can only report "false is not true", while `assertIsCallable()` reports the actual value and the type it was expected to have.

## Added mappings
| function | assertTrue / assertNotFalse | assertFalse / assertNotTrue |
| --- | --- | --- |
| `is_array` | `assertIsArray` | `assertIsNotArray` |
| `is_bool` | `assertIsBool` | `assertIsNotBool` |
| `is_callable` | `assertIsCallable` | `assertIsNotCallable` |
| `is_float` | `assertIsFloat` | `assertIsNotFloat` |
| `is_int` | `assertIsInt` | `assertIsNotInt` |
| `is_iterable` | `assertIsIterable` | `assertIsNotIterable` |
| `is_numeric` | `assertIsNumeric` | `assertIsNotNumeric` |
| `is_object` | `assertIsObject` | `assertIsNotObject` |
| `is_scalar` | `assertIsScalar` | `assertIsNotScalar` |
| `is_string` | `assertIsString` | `assertIsNotString` |

Each of the ten was checked against `IsType::matches()` to confirm the constraint runs the very same function, so the assertions are equivalent.

`is_callable()` is skipped when it carries more than one argument — its `$syntax_only` and `$callable_name` parameters have no counterpart in `assertIsCallable()` and would otherwise be moved up into the `$message` slot.

## Also in here: named and spread args

Args are moved up by position, so a named arg only survives when the assert method happens to use the same parameter name. That holds for `is_readable(filename:)`, `is_writable(filename:)`, `file_exists(filename:)`, `array_key_exists(key:, array:)` and `str_contains(haystack:, needle:)`. It does not hold for any of the new entries, as PHP names the parameter `$value` while PHPUnit names it `$actual`:

    $this->assertTrue(is_string(value: $value));
    // became assertIsString(value: $value) -> Unknown named parameter $value

The bail-out is blanket rather than per entry, which also covers `is_dir` (`$filename` vs `$directory`), `is_null`, `is_nan`, `is_infinite` and `is_a` — those carry the same mismatch today. The cost is that the handful of pairs whose names do line up get skipped too, which seemed a better trade than tracking a parameter name per mapped function. Spread args are skipped for the same reason, as their count is unknown.

It sits in its own `hasUnmovableArgs()` method, so it is easy to pull out if you would rather keep this PR to the new mappings.