### PR TITLE
[CodeQuality] Fix AddInstanceofAssertForNullableArgumentRector duplicate assertInstanceOf inside traits

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector/Fixture/nullable_arg_in_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector/Fixture/nullable_arg_in_trait.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Source\SomeFactory;
+
+trait NullableArgInTrait
+{
+    public function assertSomething(SomeFactory $someFactory): void
+    {
+        $someObject = $someFactory->create();
+
+        $someFactory->process($someObject);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Source\SomeFactory;
+
+trait NullableArgInTrait
+{
+    public function assertSomething(SomeFactory $someFactory): void
+    {
+        $someObject = $someFactory->create();
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Source\SomeClassUsedInTests::class, $someObject);
+
+        $someFactory->process($someObject);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector/Fixture/skip_already_asserted_in_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector/Fixture/skip_already_asserted_in_trait.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Source\SomeFactory;
+
+trait SkipAlreadyAssertedInTrait
+{
+    public function assertSomething(SomeFactory $someFactory): void
+    {
+        $someObject = $someFactory->create();
+        $this->assertInstanceOf(\Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Source\SomeClassUsedInTests::class, $someObject);
+
+        $someFactory->process($someObject);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector/Source/SomeFactory.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector/Source/SomeFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector\Source;
+
+final class SomeFactory
+{
+    public function create(): ?SomeClassUsedInTests
+    {
+        return null;
+    }
+
+    public function process(SomeClassUsedInTests $someClass): void
+    {
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/AddInstanceofAssertForNullableArgumentRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
@@ -132,6 +133,20 @@ CODE_SAMPLE
 
         $next = 0;
         foreach ($node->stmts as $key => $stmt) {
+            // already asserted in a previous run? drop the variable to keep the rule idempotent
+            $assertedVariableName = $this->matchAssertInstanceOfVariableName($stmt);
+            if (is_string($assertedVariableName)) {
+                $alreadyAssertedVariableNameToType = $variableNameToTypeCollection->matchByVariableName(
+                    $assertedVariableName
+                );
+
+                if ($alreadyAssertedVariableNameToType instanceof VariableNameToType) {
+                    $variableNameToTypeCollection->remove($alreadyAssertedVariableNameToType);
+                }
+
+                continue;
+            }
+
             // has callable on nullable variable of already collected name?
             $matchedNullableVariableNameToType = $this->matchedNullableArgumentNameToType(
                 $stmt,
@@ -223,5 +238,37 @@ CODE_SAMPLE
         });
 
         return $matchedNullableVariableNameToType;
+    }
+
+    private function matchAssertInstanceOfVariableName(Stmt $stmt): ?string
+    {
+        if (! $stmt instanceof Expression) {
+            return null;
+        }
+
+        if (! $stmt->expr instanceof MethodCall) {
+            return null;
+        }
+
+        $methodCall = $stmt->expr;
+        if (! $this->isName($methodCall->name, 'assertInstanceOf')) {
+            return null;
+        }
+
+        $args = $methodCall->getArgs();
+        if (! isset($args[1])) {
+            return null;
+        }
+
+        if (! $args[1]->value instanceof Variable) {
+            return null;
+        }
+
+        $variableName = $this->getName($args[1]->value);
+        if (! is_string($variableName)) {
+            return null;
+        }
+
+        return $variableName;
     }
 }


### PR DESCRIPTION
Fixes rectorphp/rector#9863

## Problem

Inside a **test trait**, `AddInstanceofAssertForNullableArgumentRector` is not idempotent. Every `rector process` run appends one more identical `$this->assertInstanceOf(...)` line, forever.

The rule's only cross-run guard was implicit: the inserted `$this->assertInstanceOf()` narrows the variable's type, so `SimpleTypeAnalyzer::isNullableType()` stops matching on the next run. In a class extending `TestCase` that holds. In a trait `$this` is not a `PHPUnit\Framework\Assert`, so the assert never narrows, the variable stays nullable, and a fresh assert is appended each run.

```diff
 $someObject = $someFactory->create();
 $this->assertInstanceOf(SomeClass::class, $someObject);
+$this->assertInstanceOf(SomeClass::class, $someObject);   // added again every run
 $someFactory->process($someObject);
```

## Fix

Stop depending on type narrowing for idempotency. While scanning statements, detect a pre-existing `assertInstanceOf(<Type>::class, $variable)` and drop that variable from the nullable collection, so no second assert is spliced in. Works in both classes and traits, and hardens the class case when the PHPUnit type-specifying extension is unavailable.

## Tests

- `skip_already_asserted_in_trait.php.inc` — trait already carrying the assert stays unchanged (fails before the fix: a duplicate assert is added).
- `nullable_arg_in_trait.php.inc` — the rule still fires once in a trait.