### PR TITLE
[CI] Fire scoped-rector dispatch on merged PR, not push

### DIFF
--- a/.github/workflows/dispatch_build_scoped_rector.yaml
+++ b/.github/workflows/dispatch_build_scoped_rector.yaml
@@ -2,23 +2,25 @@
 # with the freshly merged rector-phpunit main
 name: Dispatch Build Scoped Rector
 
+# pull_request_target fires on merge even for fork PRs and, unlike "push",
+# is not suppressed when the merge commit is pushed with GITHUB_TOKEN
 on:
-    push:
-        branches:
-            - main
+    pull_request_target:
+        types:
+            - closed
     workflow_dispatch: null
 
 jobs:
     dispatch_build_scoped_rector:
-        # only for this repository, not forks
-        if: github.repository == 'rectorphp/rector-phpunit'
+        # only for this repository, not forks; and only on a merged PR (not a plain close)
+        if: github.repository == 'rectorphp/rector-phpunit' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true)
 
         runs-on: ubuntu-latest
         timeout-minutes: 10
 
         steps:
             -
-                name: "Wait 20 seconds after push"
+                name: "Wait 20 seconds after merge"
                 run: sleep 20
 
             -


### PR DESCRIPTION
## Problem

Merging a PR into `rector-phpunit` main should rebuild `rectorphp/rector` via `rector-src`'s `build_scoped_rector.yaml`. The dispatcher `dispatch_build_scoped_rector.yaml` triggered on `push: main` — but a merge commit pushed with `GITHUB_TOKEN` does **not** trigger `push` workflows (GitHub loop-prevention), so the dispatcher silently never ran.

Seen live on #770: merge commit `8a896f7` fired **zero** Actions; the scoped rebuild never happened.

## Fix

Trigger on the merged-PR event instead of `push`:

```diff
 on:
-    push:
-        branches:
-            - main
+    pull_request_target:
+        types:
+            - closed
     workflow_dispatch: null
```

- `pull_request_target` (not `pull_request`) so the job runs in **base-repo context with secrets** — fork PRs like #770 would otherwise get an empty `ACCESS_TOKEN`.
- `merged == true` guard so a plain close does not dispatch.
- No PR code is checked out in the job (only `gh workflow run`), so `pull_request_target` carries no injection risk here.

`workflow_dispatch` retained for manual runs.