### PR TITLE
[CI] Shorten scoped-rector dispatch settle wait to 10s

### DIFF
--- a/.github/workflows/dispatch_build_scoped_rector.yaml
+++ b/.github/workflows/dispatch_build_scoped_rector.yaml
@@ -20,8 +20,8 @@ jobs:
 
         steps:
             -
-                name: "Wait 20 seconds after merge"
-                run: sleep 20
+                name: "Wait 10 seconds after merge"
+                run: sleep 10
 
             -
                 name: "Check whether rector-src main is a release tag commit"


### PR DESCRIPTION
Follow-up to #774. Halve the pre-dispatch settle wait from 20s to 10s — enough for the merge to land, half the idle time.

```diff
-                name: "Wait 20 seconds after merge"
-                run: sleep 20
+                name: "Wait 10 seconds after merge"
+                run: sleep 10
```

Same change is in the still-open sibling PRs (rector-doctrine#517, rector-symfony#1059, rector-downgrade-php#390).