### PR TITLE
[CodeQuality] Skip DirectInstanceOverMockArgRector outside test classes

### DIFF
--- a/rules-tests/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector/Fixture/skip_non_test_class_spread_named_arg.php.inc
+++ b/rules-tests/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector/Fixture/skip_non_test_class_spread_named_arg.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector\Fixture;
+
+final class SkipNonTestClassSpreadNamedArg
+{
+    public function run($request)
+    {
+        return new SomeData(
+            ...$request->updateData(),
+            user: (string) $request->user()->getKey(),
+        );
+    }
+}

--- a/rules/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector.php
+++ b/rules/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector.php
@@ -13,8 +13,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\PhpParser\Node\Value\ValueResolver;
-use Rector\PHPStan\ScopeFetcher;
-use Rector\PHPUnit\Enum\PHPUnitClassName;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\SymfonyClass;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -26,7 +25,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DirectInstanceOverMockArgRector extends AbstractRector
 {
     public function __construct(
-        private readonly ValueResolver $valueResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
     ) {
     }
 
@@ -88,13 +88,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): MethodCall|StaticCall|New_|ArrayItem|null
     {
-        $scope = ScopeFetcher::fetch($node);
-        if (! $scope->isInClass()) {
-            return null;
-        }
-
-        $classReflection = $scope->getClassReflection();
-        if (! $classReflection->is(PHPUnitClassName::TEST_CASE)) {
+        // run on test classes only, non-test code may lack scope on args and crash the whole run
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes crash reported in [rectorphp/rector#9869](https://github.com/rectorphp/rector/issues/9869#issuecomment-5442908470).

## Problem

`DirectInstanceOverMockArgRector` called `ScopeFetcher::fetch($node)` as its **first** action, before any guard. PHPStan does not assign scope to args of a `new` expression that mixes an unpacked spread with a named argument, so the fetch threw `Scope not available` — crashing the entire Rector run.

Worse, this happened in **non-test application code**. The rule ships in the `phpunit-code-quality` set, so any project with this argument shape failed its whole run, even though the rule only ever touches Symfony `Request`/`RequestStack` mocks inside tests.

```php
// non-test class — crashed the run before this PR
$data = new SomeData(
    ...$request->updateData(),
    user: (string) $request->user()->getKey(),
);
```

## Fix

Gate on `TestsNodeAnalyzer::isInTestClass()` (resolves via reflection, no scope needed) and drop the eager `ScopeFetcher::fetch()` entirely. Non-test classes bail out early, before any scope is touched.

```diff
-$scope = ScopeFetcher::fetch($node);
-if (! $scope->isInClass()) {
-    return null;
-}
-
-$classReflection = $scope->getClassReflection();
-if (! $classReflection->is(PHPUnitClassName::TEST_CASE)) {
-    return null;
-}
+// run on test classes only, non-test code may lack scope on args and crash the whole run
+if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+    return null;
+}
```

Added a skip fixture reproducing the crashing shape in a non-test class.
