### PR TITLE
Run cheap guards before expensive analysis calls

### DIFF
--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -94,11 +94,11 @@ CODE_SAMPLE
 
         $possibleTestClassNames = $this->testClassNameResolver->resolve($className);
         $matchingTestClassName = $this->matchExistingClassName($possibleTestClassNames);
-
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($matchingTestClassName === null) {
             return null;
         }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         if ($this->hasAlreadySeeAnnotation($phpDocInfo, $matchingTestClassName)) {
             return null;

--- a/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
+++ b/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
@@ -263,6 +263,7 @@ CODE_SAMPLE
             }
         });
 
+        // @phpstan-ignore rector.rectorCheaperGuardsFirst ($hasChanged is set by-reference inside the traversal above that holds the expensive calls)
         if (! $hasChanged) {
             return null;
         }

--- a/rules/PHPUnit60/Rector/MethodCall/GetMockBuilderGetMockToCreateMockRector.php
+++ b/rules/PHPUnit60/Rector/MethodCall/GetMockBuilderGetMockToCreateMockRector.php
@@ -112,12 +112,12 @@ CODE_SAMPLE
             return null;
         }
 
-        // must be be test case class
-        if (! $this->isObjectType($currentMethodCall->var, new ObjectType('PHPUnit\Framework\TestCase'))) {
+        if (! $this->isName($currentMethodCall->name, 'getMockBuilder')) {
             return null;
         }
 
-        if (! $this->isName($currentMethodCall->name, 'getMockBuilder')) {
+        // must be be test case class
+        if (! $this->isObjectType($currentMethodCall->var, new ObjectType('PHPUnit\Framework\TestCase'))) {
             return null;
         }
 


### PR DESCRIPTION
New `RectorCheaperGuardsFirstRule` in symplify/phpstan-rules 14.13.0 flags cheap early-return guards that sit after an expensive analysis call inside a Rector rule method, when the guard does not depend on the expensive result.

This reorders two such guards to run before the costly analysis:

- `AddSeeTestAnnotationRector` - the `$matchingTestClassName === null` guard now runs before `createFromNodeOrEmpty()`.
- `GetMockBuilderGetMockToCreateMockRector` - the `isName(..., 'getMockBuilder')` guard now runs before `isObjectType()`.

Both moves are behavior-preserving; the guards are independent of the expensive-call result.