### PR TITLE
Drop cheaper-guard ignore, rely on fixed rule (14.13.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "rector/swiss-knife": "^2.4",
         "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",
-        "symplify/phpstan-rules": "^14.12",
+        "symplify/phpstan-rules": "^14.13.1",
         "tomasvotruba/class-leak": "^2.1",
         "tomasvotruba/type-coverage": "^2.3",
         "tomasvotruba/unused-public": "^2.2",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,3 +43,8 @@ parameters:
         # see https://github.com/rectorphp/rector-src/actions/runs/11798721617/job/32865546672?pr=6422#step:5:110
         - '#Doing instanceof PHPStan\\Type\\.+ is error\-prone and deprecated#'
 
+        # $hasChanged is set by-reference inside the traversal closure that holds the expensive calls
+        -
+            identifier: rector.rectorCheaperGuardsFirst
+            path: rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,8 +43,3 @@ parameters:
         # see https://github.com/rectorphp/rector-src/actions/runs/11798721617/job/32865546672?pr=6422#step:5:110
         - '#Doing instanceof PHPStan\\Type\\.+ is error\-prone and deprecated#'
 
-        # $hasChanged is set by-reference inside the traversal closure that holds the expensive calls
-        -
-            identifier: rector.rectorCheaperGuardsFirst
-            path: rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
-

--- a/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
+++ b/rules/CodeQuality/Rector/Class_/TypeWillReturnCallableArrowFunctionRector.php
@@ -263,7 +263,6 @@ CODE_SAMPLE
             }
         });
 
-        // @phpstan-ignore rector.rectorCheaperGuardsFirst ($hasChanged is set by-reference inside the traversal above that holds the expensive calls)
         if (! $hasChanged) {
             return null;
         }


### PR DESCRIPTION
The false positive is now fixed at the source in symplify/phpstan-rules 14.13.1 (symplify/phpstan-rules#281): the rule no longer flags a guard whose variable is mutated by-reference inside the anchor's closure. The inline @phpstan-ignore added in #777 is removed entirely (no neon ignore needed), and the constraint is bumped to ^14.13.1. PHPStan green.