### PR TITLE
 [CodeQuality] Skip existing imported or short @ see annotation in AddSeeTestAnnotationRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/skip_existing_imported_see.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/skip_existing_imported_see.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Fixture;
+
+use Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Source\SkipExistingImportedSeeTest;
+
+/**
+ * @see SkipExistingImportedSeeTest
+ */
+class SkipExistingImportedSee
+{
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/skip_existing_short_see.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Fixture/skip_existing_short_see.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * 2 classes here on purpose to test that the rector will not add a @see annotation to the first class, because it already has one.
+ */
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Fixture;
+
+/**
+ * @see SkipExistingShortSeeTest
+ */
+class SkipExistingShortSee
+{
+}
+
+class SkipExistingShortSeeTest extends \PHPUnit\Framework\TestCase
+{
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Source/SkipExistingImportedSeeTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector/Source/SkipExistingImportedSeeTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector\Source;
+
+final class SkipExistingImportedSeeTest
+{
+}

--- a/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocParser\ClassAnnotationMatcher;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PHPUnit\Naming\TestClassNameResolver;
 use Rector\Rector\AbstractRector;
@@ -30,6 +31,7 @@ final class AddSeeTestAnnotationRector extends AbstractRector
         private readonly TestClassNameResolver $testClassNameResolver,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly ClassAnnotationMatcher $classAnnotationMatcher,
     ) {
     }
 
@@ -139,6 +141,12 @@ CODE_SAMPLE
             $seeTagClass = ltrim($genericTagValueNode->value, '\\');
 
             if ($this->reflectionProvider->hasClass($seeTagClass)) {
+                return true;
+            }
+
+            // the @see value can be a short name, imported or in the current namespace
+            $resolvedSeeTagClass = $this->classAnnotationMatcher->resolveTagFullyQualifiedName($seeTagClass, $class);
+            if ($this->reflectionProvider->hasClass($resolvedSeeTagClass)) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9875