### PR TITLE
[CodeQuality] Skip dynamic method call in AllowMockObjectsForDataProviderRector

### DIFF
--- a/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsForDataProviderRector/Fixture/skip_dynamic_method_call.php.inc
+++ b/rules-tests/PHPUnit120/Rector/Class_/AllowMockObjectsForDataProviderRector/Fixture/skip_dynamic_method_call.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SkipDynamicMethodCall extends TestCase
+{
+    #[DataProvider('methodNameProvider')]
+    public function testUnusableMethods(string $method): void
+    {
+        $sut = new \stdClass();
+
+        $this->expectException(\RuntimeException::class);
+
+        $sut->$method();
+    }
+
+    public static function methodNameProvider(): iterable
+    {
+        yield ['realMethodName'];
+    }
+}

--- a/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
+++ b/rules/CodeQuality/NodeAnalyser/MockObjectExprDetector.php
@@ -36,6 +36,11 @@ final readonly class MockObjectExprDetector
         $methodCalls = $this->betterNodeFinder->findInstancesOfScoped((array) $classMethod->stmts, [MethodCall::class]);
 
         foreach ($methodCalls as $methodCall) {
+            // dynamic method call, e.g. $sut->$method(), is not a literal ->method() call
+            if (! $methodCall->name instanceof Identifier) {
+                continue;
+            }
+
             if (! $this->nodeNameResolver->isName($methodCall->name, 'method')) {
                 continue;
             }


### PR DESCRIPTION
Fixes rectorphp/rector#9877

`$sut->$method()` was treated as a literal `->method()` call, because the dynamic method name variable resolved to `"method"`. The rule then wrongly added `#[AllowMockObjectsWithoutExpectations]`.

Fix: skip when the method call name is not an `Identifier` (i.e. a dynamic call).

https://claude.ai/code/session_01JHq62QomBxARKhP7RxQ6gJ